### PR TITLE
#25 added check if subscription exists when asked for metrics

### DIFF
--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/domain/subscription/SubscriptionService.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/domain/subscription/SubscriptionService.java
@@ -85,6 +85,7 @@ public class SubscriptionService {
     }
 
     public SubscriptionMetrics getSubscriptionMetrics(TopicName topicName, String subscriptionName) {
+        subscriptionRepository.ensureSubscriptionExists(topicName, subscriptionName);
         return metricsRepository.loadMetrics(topicName, subscriptionName);
     }
 

--- a/integration/src/integration/java/pl/allegro/tech/hermes/integration/MetricsTest.java
+++ b/integration/src/integration/java/pl/allegro/tech/hermes/integration/MetricsTest.java
@@ -1,5 +1,6 @@
 package pl.allegro.tech.hermes.integration;
 
+import com.googlecode.catchexception.CatchException;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 import pl.allegro.tech.hermes.api.SubscriptionMetrics;
@@ -16,6 +17,7 @@ import pl.allegro.tech.hermes.integration.shame.Unreliable;
 import javax.ws.rs.BadRequestException;
 import java.util.UUID;
 
+import static com.googlecode.catchexception.CatchException.catchException;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class MetricsTest extends IntegrationTest {
@@ -88,13 +90,13 @@ public class MetricsTest extends IntegrationTest {
         String randomSubscription = UUID.randomUUID().toString();
 
         //when
-        try {
-            management.subscription()
-                    .getMetrics(topic.qualifiedName(), randomSubscription);
-        } catch (BadRequestException ex) {}
+        catchException(management.subscription())
+                .getMetrics(topic.qualifiedName(), randomSubscription);
 
         //then
         assertThat(management.subscription().list(topic.qualifiedName())).doesNotContain(randomSubscription);
+        assertThat(CatchException.<BadRequestException>caughtException())
+                .isInstanceOf(BadRequestException.class);
     }
 
     @Test

--- a/integration/src/integration/java/pl/allegro/tech/hermes/integration/MetricsTest.java
+++ b/integration/src/integration/java/pl/allegro/tech/hermes/integration/MetricsTest.java
@@ -13,6 +13,9 @@ import pl.allegro.tech.hermes.test.helper.message.TestMessage;
 import pl.allegro.tech.hermes.integration.helper.graphite.GraphiteMockServer;
 import pl.allegro.tech.hermes.integration.shame.Unreliable;
 
+import javax.ws.rs.BadRequestException;
+import java.util.UUID;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class MetricsTest extends IntegrationTest {
@@ -75,6 +78,23 @@ public class MetricsTest extends IntegrationTest {
         assertThat(metrics.getDelivered()).isEqualTo(2); //we have same instance of metric registry in frontend and consumer, so metrics reporting is duplicated
         assertThat(metrics.getDiscarded()).isEqualTo(0);
         assertThat(metrics.getInflight()).isEqualTo(0);
+    }
+
+    @Test
+    public void shouldNotCreateNewSubscriptionWhenAskedForNonExistingMetrics() {
+        //given
+        TopicName topic = new TopicName("pl.group.sub.bug", "topic");
+        operations.buildTopic(topic.getGroupName(), topic.getName());
+        String randomSubscription = UUID.randomUUID().toString();
+
+        //when
+        try {
+            management.subscription()
+                    .getMetrics(topic.qualifiedName(), randomSubscription);
+        } catch (BadRequestException ex) {}
+
+        //then
+        assertThat(management.subscription().list(topic.qualifiedName())).doesNotContain(randomSubscription);
     }
 
     @Test


### PR DESCRIPTION
This is bugfix for issue with accidental zk node creation when asked for metrics of non-existing subscription.