### PR TITLE
43 listing tracked topics and subscriptions

### DIFF
--- a/hermes-api/src/main/java/pl/allegro/tech/hermes/api/endpoints/SubscriptionEndpoint.java
+++ b/hermes-api/src/main/java/pl/allegro/tech/hermes/api/endpoints/SubscriptionEndpoint.java
@@ -5,12 +5,14 @@ import pl.allegro.tech.hermes.api.SubscriptionMetrics;
 
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
+import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Response;
 import java.util.List;
 
@@ -20,7 +22,8 @@ import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 public interface SubscriptionEndpoint {
     @GET
     @Produces(APPLICATION_JSON)
-    List<String> list(@PathParam("topicName") String qualifiedTopicName);
+    List<String> list(@PathParam("topicName") String qualifiedTopicName,
+                      @DefaultValue("false") @QueryParam("tracked") boolean tracked);
 
     @POST
     @Consumes(APPLICATION_JSON)

--- a/hermes-api/src/main/java/pl/allegro/tech/hermes/api/endpoints/TopicEndpoint.java
+++ b/hermes-api/src/main/java/pl/allegro/tech/hermes/api/endpoints/TopicEndpoint.java
@@ -23,7 +23,9 @@ import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 public interface TopicEndpoint {
     @GET
     @Produces(APPLICATION_JSON)
-    List<String> list(@DefaultValue("") @QueryParam("groupName") String groupName);
+    List<String> list(
+            @DefaultValue("") @QueryParam("groupName") String groupName,
+            @DefaultValue("false") @QueryParam("tracked") boolean tracked);
 
     @POST
     @Consumes(APPLICATION_JSON)
@@ -64,4 +66,5 @@ public interface TopicEndpoint {
                    @PathParam("brokersClusterName") String brokersClusterName,
                    @PathParam("partition") Integer partition,
                    @PathParam("offset") Long offset);
+
 }

--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/domain/subscription/SubscriptionRepository.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/domain/subscription/SubscriptionRepository.java
@@ -25,5 +25,5 @@ public interface SubscriptionRepository {
 
     List<Subscription> listSubscriptions(TopicName topicName);
 
-
+    List<String> listTrackedSubscriptionNames(TopicName topicName);
 }

--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/infrastructure/zookeeper/ZookeeperSubscriptionRepository.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/infrastructure/zookeeper/ZookeeperSubscriptionRepository.java
@@ -108,4 +108,12 @@ public class ZookeeperSubscriptionRepository extends ZookeeperBasedRepository im
                 .map(subscription -> getSubscriptionDetails(topicName, subscription))
                 .collect(Collectors.toList());
     }
+
+    @Override
+    public List<String> listTrackedSubscriptionNames(TopicName topicName) {
+        return listSubscriptions(topicName).stream()
+                .filter(Subscription::isTrackingEnabled)
+                .map(Subscription::getName)
+                .collect(Collectors.toList());
+    }
 }

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/api/SubscriptionsEndpoint.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/api/SubscriptionsEndpoint.java
@@ -15,6 +15,7 @@ import pl.allegro.tech.hermes.management.infrastructure.kafka.MultiDCAwareServic
 import javax.annotation.security.RolesAllowed;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
+import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
 import javax.ws.rs.HttpMethod;
 import javax.ws.rs.POST;
@@ -22,6 +23,7 @@ import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Response;
 import java.util.List;
 import java.util.Optional;
@@ -52,8 +54,14 @@ public class SubscriptionsEndpoint {
     @GET
     @Produces(APPLICATION_JSON)
     @ApiOperation(value = "List subscriptions", response = List.class, httpMethod = HttpMethod.GET)
-    public List<String> list(@PathParam("topicName") String qualifiedTopicName) {
-        return subscriptionService.listSubscriptionNames(fromQualifiedName(qualifiedTopicName));
+    public List<String> list(
+            @PathParam("topicName") String qualifiedTopicName,
+            @DefaultValue("false") @QueryParam("tracked") boolean tracked) {
+
+
+        return tracked?
+                subscriptionService.listTrackedSubscriptionNames(fromQualifiedName(qualifiedTopicName)) :
+                subscriptionService.listSubscriptionNames(fromQualifiedName(qualifiedTopicName));
     }
 
     @POST

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/api/TopicsEndpoint.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/api/TopicsEndpoint.java
@@ -53,7 +53,18 @@ public class TopicsEndpoint {
     @GET
     @Produces(APPLICATION_JSON)
     @ApiOperation(value = "List topics from group", response = List.class, httpMethod = HttpMethod.GET)
-    public List<String> list(@DefaultValue("") @QueryParam("groupName") String groupName) {
+    public List<String> list(
+            @DefaultValue("") @QueryParam("groupName") String groupName,
+            @DefaultValue("false") @QueryParam("tracked") boolean tracked) {
+
+        return tracked? listTracked(groupName) : listNames(groupName);
+    }
+
+    public List<String> listTracked(String groupName) {
+        return isNullOrEmpty(groupName) ? topicService.listTrackedTopicNames() : topicService.listTrackedTopicNames(groupName);
+    }
+
+    public List<String> listNames(String groupName) {
         return isNullOrEmpty(groupName) ? topicService.listQualifiedTopicNames() : topicService.listQualifiedTopicNames(groupName);
     }
 

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/domain/subscription/SubscriptionService.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/domain/subscription/SubscriptionService.java
@@ -47,6 +47,10 @@ public class SubscriptionService {
         return subscriptionRepository.listSubscriptionNames(topicName);
     }
 
+    public List<String> listTrackedSubscriptionNames(TopicName topicName) {
+        return subscriptionRepository.listTrackedSubscriptionNames(topicName);
+    }
+
     public List<Subscription> listSubscriptions(TopicName topicName) {
         return subscriptionRepository.listSubscriptions(topicName);
     }

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/domain/topic/TopicService.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/domain/topic/TopicService.java
@@ -122,4 +122,20 @@ public class TopicService {
     public String fetchSingleMessage(String brokersClusterName, TopicName topicName, Integer partition, Long offset) {
         return multiDCAwareService.readMessage(brokersClusterName, topicName, partition, offset);
     }
+
+    public List<String> listTrackedTopicNames() {
+        return groupService.listGroups().stream()
+                .map(topicRepository::listTopics)
+                .flatMap(List::stream)
+                .filter(Topic::isTrackingEnabled)
+                .map(Topic::getQualifiedName)
+                .collect(Collectors.toList());
+    }
+
+    public List<String> listTrackedTopicNames(String groupName) {
+        return listTopics(groupName).stream()
+                .filter(Topic::isTrackingEnabled)
+                .map(Topic::getQualifiedName)
+                .collect(Collectors.toList());
+    }
 }

--- a/hermes-test-helper/src/main/java/pl/allegro/tech/hermes/test/helper/endpoint/HermesAPIOperations.java
+++ b/hermes-test-helper/src/main/java/pl/allegro/tech/hermes/test/helper/endpoint/HermesAPIOperations.java
@@ -72,6 +72,11 @@ public class HermesAPIOperations {
         createSubscription(group, topic, subscription, endpoint);
     }
 
+    public void buildSubscription(TopicName topic, Subscription subscription) {
+        buildTopic(topic.getGroupName(), topic.getName());
+        createSubscription(topic.getGroupName(), topic.getName(), subscription);
+    }
+
     public Response suspendSubscription(String group, String topic, String subscription) {
         return endpoints.subscription().updateState(group + "." + topic, subscription, Subscription.State.SUSPENDED);
     }

--- a/integration/src/integration/java/pl/allegro/tech/hermes/integration/MetricsTest.java
+++ b/integration/src/integration/java/pl/allegro/tech/hermes/integration/MetricsTest.java
@@ -172,7 +172,7 @@ public class MetricsTest extends IntegrationTest {
         management.topic().getMetrics(newTopic.qualifiedName());
 
         //then
-        assertThat(management.topic().list(newTopic.getGroupName())).doesNotContain(newTopic.qualifiedName());
+        assertThat(management.topic().list(newTopic.getGroupName(), false)).doesNotContain(newTopic.qualifiedName());
     }
 
     @Test

--- a/integration/src/integration/java/pl/allegro/tech/hermes/integration/MetricsTest.java
+++ b/integration/src/integration/java/pl/allegro/tech/hermes/integration/MetricsTest.java
@@ -94,7 +94,7 @@ public class MetricsTest extends IntegrationTest {
                 .getMetrics(topic.qualifiedName(), randomSubscription);
 
         //then
-        assertThat(management.subscription().list(topic.qualifiedName())).doesNotContain(randomSubscription);
+        assertThat(management.subscription().list(topic.qualifiedName(), false)).doesNotContain(randomSubscription);
         assertThat(CatchException.<BadRequestException>caughtException())
                 .isInstanceOf(BadRequestException.class);
     }

--- a/integration/src/integration/java/pl/allegro/tech/hermes/integration/management/SubscriptionManagementTest.java
+++ b/integration/src/integration/java/pl/allegro/tech/hermes/integration/management/SubscriptionManagementTest.java
@@ -56,7 +56,8 @@ public class SubscriptionManagementTest extends IntegrationTest {
 
         // then
         assertThat(response).hasStatus(Response.Status.CREATED);
-        Assertions.assertThat(management.subscription().list("subscribeGroup.topic", false)).containsExactly("subscription");
+        Assertions.assertThat(management.subscription().list("subscribeGroup.topic", false)).containsExactly(
+                "subscription");
         Assertions.assertThat(management.subscription().get("subscribeGroup.topic", "subscription").getState())
                 .isEqualTo(Subscription.State.PENDING);
     }
@@ -88,14 +89,16 @@ public class SubscriptionManagementTest extends IntegrationTest {
         // given
         operations.createGroup("removeSubscriptionGroup");
         operations.createTopic("removeSubscriptionGroup", "topic");
-        operations.createSubscription("removeSubscriptionGroup", "topic", "subscription", HTTP_ENDPOINT_URL);
+        operations.createSubscription("removeSubscriptionGroup", "topic", "subscription",
+                HTTP_ENDPOINT_URL);
 
         // when
         Response response = management.subscription().remove("removeSubscriptionGroup.topic", "subscription");
         
         // then
         assertThat(response).hasStatus(Response.Status.OK);
-        assertThat(management.subscription().list("removeSubscriptionGroup.topic", false)).doesNotContain("subscription");
+        assertThat(management.subscription().list("removeSubscriptionGroup.topic", false)).doesNotContain(
+                "subscription");
     }
 
     @Test
@@ -132,7 +135,12 @@ public class SubscriptionManagementTest extends IntegrationTest {
     public void shouldReturnSubscriptionsThatAreCurrentlyTrackedForGivenTopic() {
         // given
         TopicName topic = new TopicName("tracked", "topic");
-        SubscriptionName subscription = createTrackedSubscription(topic);
+        Subscription subscription = subscription()
+                .withName("sub")
+                .withTopicName(topic)
+                .withEndpoint(new EndpointAddress(HTTP_ENDPOINT_URL))
+                .withTrackingEnabled(true).build();
+        operations.buildSubscription(topic, subscription);
         operations.createSubscription(topic.getGroupName(), topic.getName(), "sub2", HTTP_ENDPOINT_URL);
 
         // when
@@ -140,17 +148,6 @@ public class SubscriptionManagementTest extends IntegrationTest {
 
         // then
         assertThat(tracked).containsExactly(subscription.getName());
-    }
-
-    private SubscriptionName createTrackedSubscription(TopicName topic) {
-        SubscriptionName subscription = new SubscriptionName("sub", topic);
-        operations.createGroup(topic.getGroupName());
-        operations.createTopic(topic.getGroupName(), topic.getName());
-        operations.createSubscription(topic.getGroupName(), topic.getName(),
-                subscription().withName(subscription.getName()).withTopicName(topic)
-                        .withEndpoint(new EndpointAddress(HTTP_ENDPOINT_URL))
-                        .withTrackingEnabled(true).build());
-        return subscription;
     }
 
     private List<Map<String, String>> getMessageTrace(String topic, String subscription, String messageId) {

--- a/integration/src/integration/java/pl/allegro/tech/hermes/integration/management/SubscriptionManagementTest.java
+++ b/integration/src/integration/java/pl/allegro/tech/hermes/integration/management/SubscriptionManagementTest.java
@@ -5,6 +5,8 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 import pl.allegro.tech.hermes.api.EndpointAddress;
 import pl.allegro.tech.hermes.api.Subscription;
+import pl.allegro.tech.hermes.api.SubscriptionName;
+import pl.allegro.tech.hermes.api.TopicName;
 import pl.allegro.tech.hermes.client.HermesClient;
 import pl.allegro.tech.hermes.client.jersey.JerseyHermesSender;
 import pl.allegro.tech.hermes.common.config.Configs;
@@ -54,7 +56,7 @@ public class SubscriptionManagementTest extends IntegrationTest {
 
         // then
         assertThat(response).hasStatus(Response.Status.CREATED);
-        Assertions.assertThat(management.subscription().list("subscribeGroup.topic")).containsExactly("subscription");
+        Assertions.assertThat(management.subscription().list("subscribeGroup.topic", false)).containsExactly("subscription");
         Assertions.assertThat(management.subscription().get("subscribeGroup.topic", "subscription").getState())
                 .isEqualTo(Subscription.State.PENDING);
     }
@@ -93,7 +95,7 @@ public class SubscriptionManagementTest extends IntegrationTest {
         
         // then
         assertThat(response).hasStatus(Response.Status.OK);
-        assertThat(management.subscription().list("removeSubscriptionGroup.topic")).doesNotContain("subscription");
+        assertThat(management.subscription().list("removeSubscriptionGroup.topic", false)).doesNotContain("subscription");
     }
 
     @Test
@@ -124,6 +126,31 @@ public class SubscriptionManagementTest extends IntegrationTest {
         assertThat(traces.get(1)).containsEntry("status", "INFLIGHT").containsKey("cluster");
         assertThat(traces.get(2)).containsEntry("status", "SUCCESS").containsKey("cluster");
         traces.forEach(trace -> assertThat(trace).containsEntry("cluster", Configs.KAFKA_CLUSTER_NAME.getDefaultValue()));
+    }
+
+    @Test
+    public void shouldReturnSubscriptionsThatAreCurrentlyTrackedForGivenTopic() {
+        // given
+        TopicName topic = new TopicName("tracked", "topic");
+        SubscriptionName subscription = createTrackedSubscription(topic);
+        operations.createSubscription(topic.getGroupName(), topic.getName(), "sub2", HTTP_ENDPOINT_URL);
+
+        // when
+        List<String> tracked = management.subscription().list(topic.qualifiedName(), true);
+
+        // then
+        assertThat(tracked).containsExactly(subscription.getName());
+    }
+
+    private SubscriptionName createTrackedSubscription(TopicName topic) {
+        SubscriptionName subscription = new SubscriptionName("sub", topic);
+        operations.createGroup(topic.getGroupName());
+        operations.createTopic(topic.getGroupName(), topic.getName());
+        operations.createSubscription(topic.getGroupName(), topic.getName(),
+                subscription().withName(subscription.getName()).withTopicName(topic)
+                        .withEndpoint(new EndpointAddress(HTTP_ENDPOINT_URL))
+                        .withTrackingEnabled(true).build());
+        return subscription;
     }
 
     private List<Map<String, String>> getMessageTrace(String topic, String subscription, String messageId) {

--- a/integration/src/integration/java/pl/allegro/tech/hermes/integration/management/TopicManagementTest.java
+++ b/integration/src/integration/java/pl/allegro/tech/hermes/integration/management/TopicManagementTest.java
@@ -138,10 +138,7 @@ public class TopicManagementTest extends IntegrationTest {
     private TopicName createTrackedTopic(String group, String name) {
         TopicName topic = new TopicName(group, name);
         operations.createGroup(topic.getGroupName());
-        operations.createTopic(topic.getGroupName(), topic.getName());
-        operations.updateTopic(topic, Topic.Builder.topic()
-                .withName(topic)
-                .withTrackingEnabled(true).build());
+        operations.createTopic(topic().withName(topic).withTrackingEnabled(true).build());
         return topic;
     }
 }

--- a/integration/src/integration/java/pl/allegro/tech/hermes/integration/management/TopicManagementTest.java
+++ b/integration/src/integration/java/pl/allegro/tech/hermes/integration/management/TopicManagementTest.java
@@ -4,9 +4,13 @@ import org.assertj.core.api.Assertions;
 import org.testng.annotations.Test;
 import pl.allegro.tech.hermes.api.EndpointAddress;
 import pl.allegro.tech.hermes.api.ErrorCode;
+import pl.allegro.tech.hermes.api.Topic;
+import pl.allegro.tech.hermes.api.TopicName;
 import pl.allegro.tech.hermes.integration.IntegrationTest;
 
 import javax.ws.rs.core.Response;
+
+import java.util.List;
 
 import static pl.allegro.tech.hermes.api.Subscription.Builder.subscription;
 import static pl.allegro.tech.hermes.api.Topic.Builder.topic;
@@ -41,7 +45,8 @@ public class TopicManagementTest extends IntegrationTest {
         wait.untilTopicIsCreated("listTopicsGroup", "topic2");
 
         // when then
-        Assertions.assertThat(management.topic().list("listTopicsGroup")).containsOnlyOnce("listTopicsGroup.topic1", "listTopicsGroup.topic2");
+        Assertions.assertThat(management.topic().list("listTopicsGroup", false)).containsOnlyOnce(
+                "listTopicsGroup.topic1", "listTopicsGroup.topic2");
     }
 
     @Test
@@ -55,7 +60,7 @@ public class TopicManagementTest extends IntegrationTest {
 
         // then
         assertThat(response).hasStatus(Response.Status.OK);
-        Assertions.assertThat(management.topic().list("removeTopicGroup")).isEmpty();
+        Assertions.assertThat(management.topic().list("removeTopicGroup", false)).isEmpty();
     }
 
     @Test
@@ -102,5 +107,41 @@ public class TopicManagementTest extends IntegrationTest {
 
         // then
         assertThat(response).hasStatus(Response.Status.BAD_REQUEST).hasErrorCode(ErrorCode.TOPIC_ALREADY_EXISTS);
+    }
+
+    @Test
+    public void shouldReturnTopicsThatAreCurrentlyTracked() {
+        // given
+        TopicName topic = createTrackedTopic("tracked", "topic");
+
+        // when
+        List<String> tracked = management.topic().list("", true);
+
+        // then
+        assertThat(tracked).containsOnly(topic.qualifiedName());
+    }
+
+    @Test
+    public void shouldReturnTopicsThatAreCurrentlyTrackedForGivenGroup() {
+        // given
+        TopicName topic1 = createTrackedTopic("tracked1", "topic1");
+        TopicName topic2 = createTrackedTopic("tracked2", "topic2");
+
+        // when
+        List<String> tracked = management.topic().list(topic1.getGroupName(), true);
+
+        // then
+        assertThat(tracked).contains(topic1.qualifiedName())
+                           .doesNotContain(topic2.qualifiedName());
+    }
+
+    private TopicName createTrackedTopic(String group, String name) {
+        TopicName topic = new TopicName(group, name);
+        operations.createGroup(topic.getGroupName());
+        operations.createTopic(topic.getGroupName(), topic.getName());
+        operations.updateTopic(topic, Topic.Builder.topic()
+                .withName(topic)
+                .withTrackingEnabled(true).build());
+        return topic;
     }
 }


### PR DESCRIPTION
Added listing of tracked topics and subscriptions. First iteration is without using any local caching. For performance reasons users can narrow scope via groupName query parameter.