### PR TITLE
fixing #40 jersey client connection closing

### DIFF
--- a/hermes-client/src/main/java/pl/allegro/tech/hermes/client/jersey/JerseyHermesResponse.java
+++ b/hermes-client/src/main/java/pl/allegro/tech/hermes/client/jersey/JerseyHermesResponse.java
@@ -6,9 +6,11 @@ import javax.ws.rs.core.Response;
 
 class JerseyHermesResponse implements HermesResponse {
     private final Response response;
+    private final String body;
 
     public JerseyHermesResponse(Response response) {
         this.response = response;
+        this.body = response.readEntity(String.class);
     }
 
     @Override
@@ -18,7 +20,7 @@ class JerseyHermesResponse implements HermesResponse {
 
     @Override
     public String getBody() {
-        return response.readEntity(String.class);
+        return body;
     }
 
     @Override


### PR DESCRIPTION
This change fixes #40 where connections are not being closed if readEntity is not called on the response object.