### PR TITLE
docker images on alpine-linux

### DIFF
--- a/docker/Dockerfile-consumers
+++ b/docker/Dockerfile-consumers
@@ -1,9 +1,8 @@
-FROM java:8
+FROM jeanblanchard/java:8
 
 MAINTAINER Allegro
 
-RUN apt-get update && apt-get install -y unzip \
-  && apt-get clean && rm -rf /var/lib/apt/lists/*
+RUN apk update && apk add unzip bash
 
 ENV HERMES_CONSUMERS_OPTS="-Darchaius.configurationSource.additionalUrls=file:///etc/hermes/consumers.properties"
 ADD latest/consumers/consumers.properties /etc/hermes/consumers.properties

--- a/docker/Dockerfile-frontend
+++ b/docker/Dockerfile-frontend
@@ -1,9 +1,8 @@
-FROM java:8
+FROM jeanblanchard/java:8
 
 MAINTAINER Allegro
 
-RUN apt-get update && apt-get install -y unzip \
-  && apt-get clean && rm -rf /var/lib/apt/lists/*
+RUN apk update && apk add unzip bash
 
 ENV HERMES_FRONTEND_OPTS="-Darchaius.configurationSource.additionalUrls=file:///etc/hermes/frontend.properties"
 ADD latest/frontend/frontend.properties /etc/hermes/frontend.properties

--- a/docker/Dockerfile-management
+++ b/docker/Dockerfile-management
@@ -1,9 +1,8 @@
-FROM java:8
+FROM jeanblanchard/java:8
 
 MAINTAINER Allegro
 
-RUN apt-get update && apt-get install -y unzip \
-  && apt-get clean && rm -rf /var/lib/apt/lists/*
+RUN apk update && apk add unzip bash
 
 ENV SPRING_CONFIG_LOCATION="file:///etc/hermes/management.yaml"
 ADD latest/management/management.yaml /etc/hermes/management.yaml

--- a/docker/latest/consumers/Dockerfile
+++ b/docker/latest/consumers/Dockerfile
@@ -1,9 +1,8 @@
-FROM java:8
+FROM jeanblanchard/java:8
 
 MAINTAINER Allegro
 
-RUN apt-get update && apt-get install -y unzip wget \
-  && apt-get clean && rm -rf /var/lib/apt/lists/*
+RUN apk update && apk add unzip wget bash
 
 ENV ARCHIVE_NAME="hermes-consumers-latest.zip"
 ENV URL="http://box.allegrotech.io/hermes/${ARCHIVE_NAME}"

--- a/docker/latest/frontend/Dockerfile
+++ b/docker/latest/frontend/Dockerfile
@@ -1,9 +1,8 @@
-FROM java:8
+FROM jeanblanchard/java:8
 
 MAINTAINER Allegro
 
-RUN apt-get update && apt-get install -y unzip wget \
-  && apt-get clean && rm -rf /var/lib/apt/lists/*
+RUN apk update && apk add unzip wget bash
 
 ENV ARCHIVE_NAME="hermes-frontend-latest.zip"
 ENV URL="http://box.allegrotech.io/hermes/${ARCHIVE_NAME}"

--- a/docker/latest/management/Dockerfile
+++ b/docker/latest/management/Dockerfile
@@ -1,9 +1,8 @@
-FROM java:8
+FROM jeanblanchard/java:8
 
 MAINTAINER Allegro
 
-RUN apt-get update && apt-get install -y unzip wget \
-  && apt-get clean && rm -rf /var/lib/apt/lists/*
+RUN apk update && apk add unzip wget bash
 
 ENV ARCHIVE_NAME="hermes-management-latest.zip"
 ENV URL="http://box.allegrotech.io/hermes/${ARCHIVE_NAME}"


### PR DESCRIPTION
Moving with docker images to `alpine-linux` (minimal linux distribution), same functionality, much smaller image size when compared to previous `java:8` base image:

```
REPOSITORY                        TAG     VIRTUAL SIZE
allegro/hermes-management         alpine  246 MB
allegro/hermes-consumers          alpine  213.7 MB
allegro/hermes-frontend           alpine  213.8 MB
allegro/hermes-frontend           latest  852.2 MB
allegro/hermes-management         latest  884.5 MB
allegro/hermes-consumers          latest  852.1 MB
```