### PR TITLE
consumer 4xx output rate fix

### DIFF
--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/ConsumerMessageSender.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/ConsumerMessageSender.java
@@ -99,6 +99,8 @@ public class ConsumerMessageSender {
     private void handleFailedSending(Message message, MessageSendingResult result) {
         if (shouldReduceSendingRate(result)) {
             rateLimiter.registerFailedSending();
+        } else {
+            rateLimiter.registerSuccessfulSending();
         }
         errorHandler.handleFailed(message, subscription, result);
     }

--- a/hermes-consumers/src/test/java/pl/allegro/tech/hermes/consumers/consumer/ConsumerMessageSenderTest.java
+++ b/hermes-consumers/src/test/java/pl/allegro/tech/hermes/consumers/consumer/ConsumerMessageSenderTest.java
@@ -190,7 +190,7 @@ public class ConsumerMessageSenderTest {
     }
 
     @Test
-    public void shouldNotReduceSendingRateLimitOn4xxResponseForSubscriptionWithNo4xxRetry() {
+    public void shouldTreat4xxResponseForSubscriptionWithNo4xxRetryAsSuccess() {
         // given
         Message message = message();
         doReturn(failure(403)).doReturn(success()).when(messageSender).send(message);
@@ -200,6 +200,7 @@ public class ConsumerMessageSenderTest {
 
         // then
         verifyRateLimiterFailedSendingCountedTimes(0);
+        verifyRateLimiterSuccessfulSendingCountedTimes(1);
         verifyErrorHandlerHandleFailed(message, subscription, 1);
     }
 


### PR DESCRIPTION
Fix for: consumers should treat 4xx response from "subscriptions without 4xx retry" as success