### PR TITLE
Fix for always-passing awaitility assertions in Waiter

### DIFF
--- a/hermes-test-helper/src/main/java/pl/allegro/tech/hermes/test/helper/endpoint/Waiter.java
+++ b/hermes-test-helper/src/main/java/pl/allegro/tech/hermes/test/helper/endpoint/Waiter.java
@@ -20,21 +20,21 @@ public class Waiter {
     }
 
     public void untilSubscriptionCreated(String group, String topic, String subscription, boolean isTracked) {
-        waitAtMost(adjust(Duration.ONE_MINUTE)).until(() -> {
-            endpoints.subscription().list(group + "." + topic, isTracked).contains(subscription);
-        });
+        waitAtMost(adjust(Duration.ONE_MINUTE)).until(() ->
+            endpoints.subscription().list(group + "." + topic, isTracked).contains(subscription)
+        );
     }
 
     public void untilGroupCreated(String group) {
-        waitAtMost(adjust(Duration.ONE_MINUTE)).until(() -> {
-            return endpoints.group().list().contains(group);
-        });
+        waitAtMost(adjust(Duration.ONE_MINUTE)).until(() ->
+            endpoints.group().list().contains(group)
+        );
     }
 
     public void untilTopicCreated(Topic topic) {
-        waitAtMost(adjust(Duration.ONE_MINUTE)).until(() -> {
-            return endpoints.findTopics(topic, topic.isTrackingEnabled()).contains(topic.getQualifiedName());
-        });
+        waitAtMost(adjust(Duration.ONE_MINUTE)).until(() ->
+            endpoints.findTopics(topic, topic.isTrackingEnabled()).contains(topic.getQualifiedName())
+        );
     }
 }
 

--- a/integration/src/integration/java/pl/allegro/tech/hermes/integration/helper/Waiter.java
+++ b/integration/src/integration/java/pl/allegro/tech/hermes/integration/helper/Waiter.java
@@ -18,7 +18,6 @@ import pl.allegro.tech.hermes.test.helper.endpoint.HermesEndpoints;
 
 import java.util.List;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Supplier;
 
 import static com.jayway.awaitility.Awaitility.waitAtMost;
 import static pl.allegro.tech.hermes.test.helper.endpoint.TimeoutAdjuster.adjust;
@@ -69,20 +68,21 @@ public class Waiter extends pl.allegro.tech.hermes.test.helper.endpoint.Waiter {
     }
 
     public void untilSubscriptionIsActivated(String group, String topic, String subscription) {
-        waitAtMost(adjust(Duration.ONE_MINUTE)).until(() -> {
-            endpoints.subscription().get(group + "." + topic, subscription).getState().equals(Subscription.State.ACTIVE);
-        });
+        untilSubscriptionHasState(group, topic, subscription, Subscription.State.ACTIVE);
+    }
+
+    public void untilSubscriptionIsSuspended(String group, String topic, String subscription) {
+        untilSubscriptionHasState(group, topic, subscription, Subscription.State.SUSPENDED);
+    }
+
+    private void untilSubscriptionHasState(String group, String topic, String subscription, Subscription.State state) {
+        waitAtMost(adjust(Duration.ONE_MINUTE)).until(() ->
+            endpoints.subscription().get(group + "." + topic, subscription).getState().equals(state)
+        );
     }
 
     public void untilSubscriptionEndsReiteration(TopicName topicName, String subscription) {
-        untilSubscriptionEndsReiteration(topicName.getGroupName(), topicName.getName(), subscription);
-    }
-
-    public void untilSubscriptionEndsReiteration(final String group, final String topic, final String subscription) {
-        waitAtMost(adjust(30), TimeUnit.SECONDS).until(() -> {
-            Subscription.State state = endpoints.subscription().get(group + "." + topic, subscription).getState();
-            return state == Subscription.State.ACTIVE;
-        });
+        untilSubscriptionHasState(topicName.getGroupName(), topicName.getName(), subscription, Subscription.State.ACTIVE);
     }
 
     public void untilAllOffsetsEqual(final String group, final String topic, final String subscription, final int offset) {

--- a/integration/src/integration/java/pl/allegro/tech/hermes/integration/management/SubscriptionManagementTest.java
+++ b/integration/src/integration/java/pl/allegro/tech/hermes/integration/management/SubscriptionManagementTest.java
@@ -1,6 +1,5 @@
 package pl.allegro.tech.hermes.integration.management;
 
-import com.jayway.awaitility.Duration;
 import org.assertj.core.api.Assertions;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -12,7 +11,6 @@ import pl.allegro.tech.hermes.client.jersey.JerseyHermesSender;
 import pl.allegro.tech.hermes.common.config.Configs;
 import pl.allegro.tech.hermes.integration.IntegrationTest;
 import pl.allegro.tech.hermes.integration.env.SharedServices;
-import pl.allegro.tech.hermes.integration.shame.Unreliable;
 import pl.allegro.tech.hermes.test.helper.endpoint.RemoteServiceEndpoint;
 import pl.allegro.tech.hermes.test.helper.message.TestMessage;
 
@@ -23,7 +21,6 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import static com.jayway.awaitility.Awaitility.await;
-import static com.jayway.awaitility.Awaitility.waitAtMost;
 import static java.net.URI.create;
 import static javax.ws.rs.client.ClientBuilder.newClient;
 import static pl.allegro.tech.hermes.api.Subscription.Builder.subscription;
@@ -45,7 +42,6 @@ public class SubscriptionManagementTest extends IntegrationTest {
         client = hermesClient(new JerseyHermesSender(newClient())).withURI(create("http://localhost:" + FRONTEND_PORT)).build();
     }
 
-    @Unreliable
     @Test
     public void shouldCreateSubscriptionWithActiveStatus() {
         // given
@@ -63,7 +59,6 @@ public class SubscriptionManagementTest extends IntegrationTest {
         wait.untilSubscriptionIsActivated("subscribeGroup", "topic", "subscription");
     }
     
-    @Unreliable
     @Test
     public void shouldSuspendSubscription() {
         // given
@@ -78,9 +73,7 @@ public class SubscriptionManagementTest extends IntegrationTest {
 
         // then
         assertThat(response).hasStatus(Response.Status.OK);
-        waitAtMost(Duration.ONE_MINUTE).until(() -> {
-            management.subscription().get("suspendSubscriptionGroup.topic", "subscription").getState().equals(Subscription.State.SUSPENDED);
-        });
+        wait.untilSubscriptionIsSuspended("suspendSubscriptionGroup", "topic", "subscription");
     }
 
     @Test


### PR DESCRIPTION
Fixes such assertions:
```java
(…).until(() -> {
	x.equals(y);
});
```

Such lambdas were treated as a `Runnable`, so since no exception was thrown the assertions did always pass. I replaced such lambdas with `() -> x.equals(y)`. Also simplified lambdas of this sort: `() -> { return x.equals(y); }` for brevity.

Also, did some minor refactorings for code reuse and removed `@Unreliable` annotations, since the tests do pass on Travis right now and assertions are now reliable :)