### PR TITLE
refactor elasticsearch mapping

### DIFF
--- a/hermes-tracker-elasticsearch/build.gradle
+++ b/hermes-tracker-elasticsearch/build.gradle
@@ -1,7 +1,7 @@
 dependencies {
     compile project(':hermes-tracker')
     compile 'org.slf4j:slf4j-api:1.7.12'
-    compile group: 'org.elasticsearch', name: 'elasticsearch', version: '1.6.0'
+    compile group: 'org.elasticsearch', name: 'elasticsearch', version: '1.7.1'
 
     testCompile project(path: ":hermes-tracker", configuration: "testArtifacts")
     testCompile group: 'org.spockframework', name: 'spock-core', version: versions.spock

--- a/hermes-tracker-elasticsearch/src/main/java/pl/allegro/tech/hermes/tracker/elasticsearch/SchemaManager.java
+++ b/hermes-tracker-elasticsearch/src/main/java/pl/allegro/tech/hermes/tracker/elasticsearch/SchemaManager.java
@@ -5,12 +5,21 @@ import org.elasticsearch.action.admin.indices.exists.indices.IndicesExistsReques
 import org.elasticsearch.action.admin.indices.exists.indices.IndicesExistsResponse;
 import org.elasticsearch.action.admin.indices.template.put.PutIndexTemplateRequest;
 import org.elasticsearch.client.Client;
+import org.elasticsearch.common.xcontent.XContentBuilder;
 import pl.allegro.tech.hermes.tracker.elasticsearch.consumers.ConsumersDailyIndexFactory;
 import pl.allegro.tech.hermes.tracker.elasticsearch.consumers.ConsumersIndexFactory;
 import pl.allegro.tech.hermes.tracker.elasticsearch.frontend.FrontendDailyIndexFactory;
 import pl.allegro.tech.hermes.tracker.elasticsearch.frontend.FrontendIndexFactory;
 
-import java.util.concurrent.ExecutionException;
+import java.io.IOException;
+
+import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
+import static pl.allegro.tech.hermes.tracker.elasticsearch.LogSchemaAware.CLUSTER;
+import static pl.allegro.tech.hermes.tracker.elasticsearch.LogSchemaAware.MESSAGE_ID;
+import static pl.allegro.tech.hermes.tracker.elasticsearch.LogSchemaAware.REASON;
+import static pl.allegro.tech.hermes.tracker.elasticsearch.LogSchemaAware.STATUS;
+import static pl.allegro.tech.hermes.tracker.elasticsearch.LogSchemaAware.SUBSCRIPTION;
+import static pl.allegro.tech.hermes.tracker.elasticsearch.LogSchemaAware.TOPIC_NAME;
 
 public class SchemaManager {
 
@@ -41,14 +50,14 @@ public class SchemaManager {
     }
 
     public void ensureSchema() {
+        createTemplate(PUBLISHED_TEMPLATE_NAME, PUBLISHED_TYPE, PUBLISHED_INDICES_REG_EXP, PUBLISHED_ALIAS_NAME);
+        createTemplate(SENT_TEMPLATE_NAME, SENT_TYPE, SENT_INDICES_REG_EXP, SENT_ALIAS_NAME);
+
         createIndexIfNeeded(frontendIndexFactory, PUBLISHED_INDICES_REG_EXP);
         createIndexIfNeeded(consumersIndexFactory, SENT_INDICES_REG_EXP);
 
         createAlias(frontendIndexFactory, PUBLISHED_ALIAS_NAME);
         createAlias(consumersIndexFactory, SENT_ALIAS_NAME);
-
-        createTemplate(PUBLISHED_TEMPLATE_NAME, PUBLISHED_INDICES_REG_EXP, PUBLISHED_ALIAS_NAME);
-        createTemplate(SENT_TEMPLATE_NAME, SENT_INDICES_REG_EXP, SENT_ALIAS_NAME);
     }
 
     private void createIndexIfNeeded(IndexFactory indexFactory, String indexRegExp) {
@@ -63,21 +72,35 @@ public class SchemaManager {
     }
 
     private void createAlias(IndexFactory indexFactory, String alias) {
-        try {
-            client.admin().indices().prepareAliases().addAlias(indexFactory.createIndex(), alias).execute().get();
-        } catch (ExecutionException | InterruptedException ex) {
-            throw new ElasticsearchRepositoryException(ex);
-        }
+        client.admin().indices().prepareAliases()
+                .addAlias(indexFactory.createIndex(), alias)
+                .execute().actionGet();
     }
 
-    private void createTemplate(String templateName, String indicesRegExp, String aliasName) {
+    private void createTemplate(String templateName, String indexType, String indicesRegExp, String aliasName) {
+
         PutIndexTemplateRequest publishedTemplateRequest = new PutIndexTemplateRequest(templateName)
                 .template(indicesRegExp)
+                .mapping(indexType, prepareMapping(indexType))
                 .alias(new Alias(aliasName));
 
+        client.admin().indices().putTemplate(publishedTemplateRequest).actionGet();
+    }
+
+    private XContentBuilder prepareMapping(String indexType) {
         try {
-            client.admin().indices().putTemplate(publishedTemplateRequest).get();
-        } catch (ExecutionException | InterruptedException ex) {
+            return jsonBuilder()
+                    .startObject().startObject(indexType)
+                    .startObject("_all").field("enabled", false).endObject()
+                    .startObject("properties")
+                    .startObject(MESSAGE_ID).field("type", "string").field("index", "not_analyzed").endObject()
+                    .startObject(STATUS).field("type", "string").field("index", "not_analyzed").endObject()
+                    .startObject(TOPIC_NAME).field("type", "string").field("index", "not_analyzed").endObject()
+                    .startObject(SUBSCRIPTION).field("type", "string").field("index", "not_analyzed").endObject()
+                    .startObject(CLUSTER).field("type", "string").field("index", "not_analyzed").endObject()
+                    .startObject(REASON).field("type", "string").field("index", "not_analyzed").endObject()
+                    .endObject().endObject();
+        } catch (IOException ex) {
             throw new ElasticsearchRepositoryException(ex);
         }
     }

--- a/hermes-tracker-elasticsearch/src/test/java/pl/allegro/tech/hermes/tracker/elasticsearch/ElasticsearchResource.java
+++ b/hermes-tracker-elasticsearch/src/test/java/pl/allegro/tech/hermes/tracker/elasticsearch/ElasticsearchResource.java
@@ -31,17 +31,6 @@ public class ElasticsearchResource extends ExternalResource implements LogSchema
         elastic = NodeBuilder.nodeBuilder().local(true).settings(settings).build();
         elastic.start();
         client = elastic.client();
-
-        createIndices();
-    }
-
-    private void createIndices() {
-        for (IndexFactory index : indices) {
-            client.admin().indices()
-                    .prepareCreate(index.createIndex())
-                    .execute().actionGet();
-            client.admin().cluster().prepareHealth(index.createIndex()).setWaitForActiveShards(1).execute().actionGet();
-        }
     }
 
     @Override

--- a/hermes-tracker-elasticsearch/src/test/java/pl/allegro/tech/hermes/tracker/elasticsearch/frontend/FrontendElasticsearchLogRepositoryTest.java
+++ b/hermes-tracker-elasticsearch/src/test/java/pl/allegro/tech/hermes/tracker/elasticsearch/frontend/FrontendElasticsearchLogRepositoryTest.java
@@ -2,6 +2,7 @@ package pl.allegro.tech.hermes.tracker.elasticsearch.frontend;
 
 import com.codahale.metrics.MetricRegistry;
 import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.index.query.FilterBuilders;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.junit.ClassRule;
 import pl.allegro.tech.hermes.api.PublishedMessageTraceStatus;
@@ -9,6 +10,8 @@ import pl.allegro.tech.hermes.metrics.PathsCompiler;
 import pl.allegro.tech.hermes.tracker.elasticsearch.ElasticsearchResource;
 import pl.allegro.tech.hermes.tracker.elasticsearch.LogSchemaAware;
 import pl.allegro.tech.hermes.tracker.elasticsearch.SchemaManager;
+import pl.allegro.tech.hermes.tracker.elasticsearch.consumers.ConsumersDailyIndexFactory;
+import pl.allegro.tech.hermes.tracker.elasticsearch.consumers.ConsumersIndexFactory;
 import pl.allegro.tech.hermes.tracker.frontend.AbstractLogRepositoryTest;
 import pl.allegro.tech.hermes.tracker.frontend.LogRepository;
 
@@ -19,50 +22,59 @@ import java.time.ZoneOffset;
 
 import static com.jayway.awaitility.Awaitility.await;
 import static com.jayway.awaitility.Duration.ONE_MINUTE;
-import static org.elasticsearch.index.query.QueryBuilders.boolQuery;
-import static org.elasticsearch.index.query.QueryBuilders.matchQuery;
+import static org.elasticsearch.index.query.QueryBuilders.filteredQuery;
+import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
 
 public class FrontendElasticsearchLogRepositoryTest extends AbstractLogRepositoryTest implements LogSchemaAware {
 
     private static final String CLUSTER_NAME = "primary";
 
     private static final Clock clock = Clock.fixed(LocalDate.of(2000, 1, 1).atStartOfDay().toInstant(ZoneOffset.UTC), ZoneId.systemDefault());
-    private static final FrontendIndexFactory indexFactory = new FrontendDailyIndexFactory(clock);
+    private static final FrontendIndexFactory frontendIndexFactory = new FrontendDailyIndexFactory(clock);
+    private static final ConsumersIndexFactory consumersIndexFactory = new ConsumersDailyIndexFactory(clock);
 
     @ClassRule
-    public static ElasticsearchResource elasticsearch = new ElasticsearchResource(indexFactory);
+    public static ElasticsearchResource elasticsearch = new ElasticsearchResource(frontendIndexFactory);
+
+    private final SchemaManager schemaManager = new SchemaManager(elasticsearch.client(), frontendIndexFactory, consumersIndexFactory);
 
     @Override
     protected LogRepository createRepository() {
+        schemaManager.ensureSchema();
+
         return new FrontendElasticsearchLogRepository.Builder(elasticsearch.client(), new PathsCompiler("localhost"), new MetricRegistry())
-                .withIndexFactory(indexFactory)
+                .withIndexFactory(frontendIndexFactory)
                 .build();
     }
 
     @Override
     protected void awaitUntilMessageIsPersisted(String topic, String id, PublishedMessageTraceStatus status, String reason) throws Exception {
         awaitUntilMessageIsIndexed(
-                boolQuery()
-                        .should(matchQuery(TOPIC_NAME, topic))
-                        .should(matchQuery(MESSAGE_ID, id))
-                        .should(matchQuery(STATUS, status.toString()))
-                        .should(matchQuery(REASON, reason))
-                        .should(matchQuery(CLUSTER, CLUSTER_NAME)));
+                filteredQuery(matchAllQuery(),
+                        FilterBuilders.andFilter(
+                                FilterBuilders.termFilter(TOPIC_NAME, topic),
+                                FilterBuilders.termFilter(MESSAGE_ID, id),
+                                FilterBuilders.termFilter(STATUS, status.toString()),
+                                FilterBuilders.termFilter(REASON, reason),
+                                FilterBuilders.termFilter(CLUSTER, CLUSTER_NAME)
+                        )));
     }
 
     @Override
     protected void awaitUntilMessageIsPersisted(String topic, String id, PublishedMessageTraceStatus status) throws Exception {
         awaitUntilMessageIsIndexed(
-                boolQuery()
-                        .should(matchQuery(TOPIC_NAME, topic))
-                        .should(matchQuery(MESSAGE_ID, id))
-                        .should(matchQuery(STATUS, status.toString()))
-                        .should(matchQuery(CLUSTER, CLUSTER_NAME)));
+                filteredQuery(matchAllQuery(),
+                        FilterBuilders.andFilter(
+                                FilterBuilders.termFilter(TOPIC_NAME, topic),
+                                FilterBuilders.termFilter(MESSAGE_ID, id),
+                                FilterBuilders.termFilter(STATUS, status.toString()),
+                                FilterBuilders.termFilter(CLUSTER, CLUSTER_NAME)
+                        )));
     }
 
     private void awaitUntilMessageIsIndexed(QueryBuilder query) {
         await().atMost(ONE_MINUTE).until(() -> {
-            SearchResponse response = elasticsearch.client().prepareSearch(indexFactory.createIndex())
+            SearchResponse response = elasticsearch.client().prepareSearch(frontendIndexFactory.createIndex())
                     .setTypes(SchemaManager.PUBLISHED_TYPE)
                     .setQuery(query)
                     .execute().get();

--- a/hermes-tracker-elasticsearch/src/test/java/pl/allegro/tech/hermes/tracker/elasticsearch/management/ElasticsearchLogRepositoryTest.java
+++ b/hermes-tracker-elasticsearch/src/test/java/pl/allegro/tech/hermes/tracker/elasticsearch/management/ElasticsearchLogRepositoryTest.java
@@ -13,8 +13,8 @@ import pl.allegro.tech.hermes.tracker.elasticsearch.DataInitializer;
 import pl.allegro.tech.hermes.tracker.elasticsearch.ElasticsearchResource;
 import pl.allegro.tech.hermes.tracker.elasticsearch.LogSchemaAware;
 import pl.allegro.tech.hermes.tracker.elasticsearch.SchemaManager;
-import pl.allegro.tech.hermes.tracker.elasticsearch.consumers.ConsumersIndexFactory;
 import pl.allegro.tech.hermes.tracker.elasticsearch.consumers.ConsumersDailyIndexFactory;
+import pl.allegro.tech.hermes.tracker.elasticsearch.consumers.ConsumersIndexFactory;
 import pl.allegro.tech.hermes.tracker.elasticsearch.frontend.FrontendDailyIndexFactory;
 import pl.allegro.tech.hermes.tracker.elasticsearch.frontend.FrontendIndexFactory;
 import pl.allegro.tech.hermes.tracker.management.LogRepository;
@@ -35,7 +35,6 @@ public class ElasticsearchLogRepositoryTest implements LogSchemaAware {
 
     private static final String CLUSTER_NAME = "primary";
     private static final String REASON_MESSAGE = "Bad Request";
-    private static final float MIN_SCORE = 0.2f;
 
     private static final Clock clock = Clock.fixed(LocalDate.of(2000, 1, 1).atStartOfDay().toInstant(ZoneOffset.UTC), ZoneId.systemDefault());
     private static final FrontendIndexFactory frontendIndexFactory = new FrontendDailyIndexFactory(clock);
@@ -46,7 +45,7 @@ public class ElasticsearchLogRepositoryTest implements LogSchemaAware {
 
     private final DataInitializer dataInitializer = new DataInitializer(elasticsearch.client(), frontendIndexFactory, consumersIndexFactory, CLUSTER_NAME);
     private final SchemaManager schemaManager = new SchemaManager(elasticsearch.client(), frontendIndexFactory, consumersIndexFactory);
-    private final LogRepository logRepository = new ElasticsearchLogRepository(elasticsearch.client(), MIN_SCORE, schemaManager);
+    private final LogRepository logRepository = new ElasticsearchLogRepository(elasticsearch.client(), schemaManager);
 
     @Test
     public void shouldGetLastUndelivered() throws Exception {


### PR DESCRIPTION
chg string field types to not analyzed ("keyword type"), and booleanQuery to filterQuery(without scoring), for cleaner, smaller lucene index, and more efficient query.