### PR TITLE
Kafka namespacing

### DIFF
--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/common/admin/zookeeper/ZookeeperAdminCache.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/common/admin/zookeeper/ZookeeperAdminCache.java
@@ -7,6 +7,7 @@ import org.apache.curator.framework.recipes.cache.PathChildrenCacheEvent;
 import org.apache.curator.framework.recipes.cache.PathChildrenCacheListener;
 import pl.allegro.tech.hermes.api.SubscriptionName;
 import pl.allegro.tech.hermes.common.admin.AdminOperationsCallback;
+import pl.allegro.tech.hermes.infrastructure.zookeeper.ZookeeperPaths;
 
 import javax.inject.Inject;
 import java.util.ArrayList;
@@ -20,8 +21,8 @@ public class ZookeeperAdminCache extends PathChildrenCache implements PathChildr
     private final List<AdminOperationsCallback> adminCallbacks = new ArrayList<>();
 
     @Inject
-    public ZookeeperAdminCache(CuratorFramework client, ObjectMapper objectMapper) {
-        super(client, ZookeeperAdminTool.ROOT, true);
+    public ZookeeperAdminCache(ZookeeperPaths zookeeperPaths, CuratorFramework client, ObjectMapper objectMapper) {
+        super(client, zookeeperPaths.adminPath(), true);
         this.objectMapper = objectMapper;
 
         getListenable().addListener(this);

--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/common/admin/zookeeper/ZookeeperAdminTool.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/common/admin/zookeeper/ZookeeperAdminTool.java
@@ -1,7 +1,6 @@
 package pl.allegro.tech.hermes.common.admin.zookeeper;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.base.Joiner;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.recipes.locks.Reaper;
 import org.apache.zookeeper.CreateMode;
@@ -9,18 +8,20 @@ import pl.allegro.tech.hermes.api.SubscriptionName;
 import pl.allegro.tech.hermes.common.admin.AdminTool;
 import pl.allegro.tech.hermes.common.admin.AdminToolStartupException;
 import pl.allegro.tech.hermes.common.exception.RetransmissionException;
+import pl.allegro.tech.hermes.infrastructure.zookeeper.ZookeeperPaths;
 
 import static pl.allegro.tech.hermes.common.admin.AdminTool.Operations.RETRANSMIT;
 
 public class ZookeeperAdminTool implements AdminTool {
 
-    public static final String ROOT = "/hermes_admin";
-
+    private final ZookeeperPaths zookeeperPaths;
     private final CuratorFramework curatorFramework;
     private final ObjectMapper objectMapper;
     private final Reaper reaper;
 
-    public ZookeeperAdminTool(CuratorFramework curatorFramework, ObjectMapper objectMapper, int reapingInterval) {
+    public ZookeeperAdminTool(ZookeeperPaths zookeeperPaths, CuratorFramework curatorFramework,
+                              ObjectMapper objectMapper, int reapingInterval) {
+        this.zookeeperPaths = zookeeperPaths;
         this.curatorFramework = curatorFramework;
         this.objectMapper = objectMapper;
         this.reaper = new Reaper(curatorFramework, reapingInterval);
@@ -37,7 +38,7 @@ public class ZookeeperAdminTool implements AdminTool {
     @Override
     public void retransmit(SubscriptionName subscriptionName) {
         try {
-            String path = Joiner.on("/").join(ROOT, RETRANSMIT.name());
+            String path = zookeeperPaths.adminOperationPath(RETRANSMIT.name());
 
             String createdPath = curatorFramework.create()
                     .withMode(CreateMode.EPHEMERAL_SEQUENTIAL)

--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/common/config/Configs.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/common/config/Configs.java
@@ -19,6 +19,7 @@ public enum Configs {
 
     KAFKA_CLUSTER_NAME("kafka.cluster.name", "primary"),
     KAFKA_BROKER_LIST("kafka.broker.list", "localhost:9092"),
+    KAFKA_NAMESPACE("kafka.namespace", ""),
     KAFKA_CONSUMER_TIMEOUT_MS("kafka.consumer.timeout.ms", 60000),
     KAFKA_CONSUMER_AUTO_OFFSET_RESET("kafka.consumer.auto.offset.reset", "largest"),
     KAFKA_CONSUMER_OFFSETS_STORAGE("kafka.consumer.offsets.storage", "kafka"),

--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/common/di/CommonBinder.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/common/di/CommonBinder.java
@@ -23,6 +23,7 @@ import pl.allegro.tech.hermes.common.di.factories.SubscriptionOffsetChangeIndica
 import pl.allegro.tech.hermes.common.di.factories.SubscriptionRepositoryFactory;
 import pl.allegro.tech.hermes.common.di.factories.TopicRepositoryFactory;
 import pl.allegro.tech.hermes.common.di.factories.ZookeeperPathsFactory;
+import pl.allegro.tech.hermes.common.kafka.KafkaNamesMapperFactory;
 import pl.allegro.tech.hermes.common.message.wrapper.AvroMessageContentWrapper;
 import pl.allegro.tech.hermes.common.message.wrapper.JsonMessageContentWrapper;
 import pl.allegro.tech.hermes.common.message.wrapper.MessageContentWrapper;
@@ -78,5 +79,6 @@ public class CommonBinder extends AbstractBinder {
         bindSingletonFactory(SimpleConsumerPoolFactory.class);
         bindSingletonFactory(SubscriptionOffsetChangeIndicatorFactory.class);
         bindSingletonFactory(PathsCompilerFactory.class);
+        bindSingletonFactory(KafkaNamesMapperFactory.class);
     }
 }

--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/common/kafka/ConsumerGroupId.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/common/kafka/ConsumerGroupId.java
@@ -1,0 +1,44 @@
+package pl.allegro.tech.hermes.common.kafka;
+
+import java.util.Objects;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+public class ConsumerGroupId {
+
+    private final String value;
+
+    private ConsumerGroupId(String value) {
+        this.value = checkNotNull(value);
+    }
+
+    public static ConsumerGroupId valueOf(String value) {
+        return new ConsumerGroupId(value);
+    }
+
+    public String asString() {
+        return value;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ConsumerGroupId that = (ConsumerGroupId) o;
+        return Objects.equals(value, that.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(value);
+    }
+
+    @Override
+    public String toString() {
+        return "ConsumerGroupId(" + value + ")";
+    }
+}

--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/common/kafka/KafkaNamesMapper.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/common/kafka/KafkaNamesMapper.java
@@ -17,7 +17,11 @@ public class KafkaNamesMapper {
     }
 
     public ConsumerGroupId toConsumerGroupId(Subscription subscription) {
-        return ConsumerGroupId.valueOf(namespaced(subscription.getId()));
+        return toConsumerGroupId(subscription.getId());
+    }
+
+    public ConsumerGroupId toConsumerGroupId(String subscriptionId) {
+        return ConsumerGroupId.valueOf(namespaced(subscriptionId));
     }
 
     public KafkaTopicName toKafkaTopicName(Topic topic) {

--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/common/kafka/KafkaNamesMapper.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/common/kafka/KafkaNamesMapper.java
@@ -1,0 +1,39 @@
+package pl.allegro.tech.hermes.common.kafka;
+
+import pl.allegro.tech.hermes.api.Subscription;
+import pl.allegro.tech.hermes.api.Topic;
+import pl.allegro.tech.hermes.api.TopicName;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+public class KafkaNamesMapper {
+
+    private static final String SEPARATOR = "_";
+
+    private final String namespace;
+
+    public KafkaNamesMapper(String namespace) {
+        this.namespace = checkNotNull(namespace);
+    }
+
+    public ConsumerGroupId toConsumerGroupId(Subscription subscription) {
+        return ConsumerGroupId.valueOf(namespaced(subscription.getId()));
+    }
+
+    public KafkaTopicName toKafkaTopicName(Topic topic) {
+        return toKafkaTopicName(topic.getName());
+    }
+
+    public KafkaTopicName toKafkaTopicName(TopicName topicName) {
+        return KafkaTopicName.valueOf(namespaced(topicName.qualifiedName()));
+    }
+
+    private String namespaced(String name) {
+        if (namespace.isEmpty()) {
+            return name;
+        }
+
+        return namespace + SEPARATOR + name;
+    }
+
+}

--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/common/kafka/KafkaNamesMapperFactory.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/common/kafka/KafkaNamesMapperFactory.java
@@ -1,0 +1,27 @@
+package pl.allegro.tech.hermes.common.kafka;
+
+import org.glassfish.hk2.api.Factory;
+import pl.allegro.tech.hermes.common.config.ConfigFactory;
+import pl.allegro.tech.hermes.common.config.Configs;
+
+import javax.inject.Inject;
+
+public class KafkaNamesMapperFactory implements Factory<KafkaNamesMapper> {
+
+    private final String namespace;
+
+    @Inject
+    public KafkaNamesMapperFactory(ConfigFactory configFactory) {
+        this.namespace = configFactory.getStringProperty(Configs.KAFKA_NAMESPACE);
+    }
+
+    @Override
+    public KafkaNamesMapper provide() {
+        return new KafkaNamesMapper(namespace);
+    }
+
+    @Override
+    public void dispose(KafkaNamesMapper instance) {
+
+    }
+}

--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/common/kafka/KafkaTopicName.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/common/kafka/KafkaTopicName.java
@@ -1,0 +1,44 @@
+package pl.allegro.tech.hermes.common.kafka;
+
+import java.util.Objects;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+public class KafkaTopicName {
+
+    private final String value;
+
+    private KafkaTopicName(String value) {
+        this.value = checkNotNull(value);
+    }
+
+    public static KafkaTopicName valueOf(String value) {
+        return new KafkaTopicName(value);
+    }
+
+    public String asString() {
+        return value;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        KafkaTopicName that = (KafkaTopicName) o;
+        return Objects.equals(value, that.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(value);
+    }
+
+    @Override
+    public String toString() {
+        return "KafkaTopicName(" + value + ")";
+    }
+}

--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/common/kafka/KafkaZookeeperPaths.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/common/kafka/KafkaZookeeperPaths.java
@@ -27,6 +27,10 @@ public final class KafkaZookeeperPaths {
         return join("/consumers", groupId.asString());
     }
 
+    public static String topicPath(KafkaTopicName topicName) {
+        return join("/brokers/topics", topicName.asString());
+    }
+
     private static String join(Object... parts) {
         return Joiner.on("/").join(parts);
     }

--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/common/kafka/KafkaZookeeperPaths.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/common/kafka/KafkaZookeeperPaths.java
@@ -1,0 +1,34 @@
+package pl.allegro.tech.hermes.common.kafka;
+
+import com.google.common.base.Joiner;
+
+public final class KafkaZookeeperPaths {
+
+    private KafkaZookeeperPaths() {
+    }
+
+    public static String offsetsPath(ConsumerGroupId groupId, KafkaTopicName topicName) {
+        return join(consumerGroupPath(groupId), "offsets", topicName.asString());
+    }
+
+    public static String ownersPath(ConsumerGroupId groupId, KafkaTopicName topicName) {
+        return join(consumerGroupPath(groupId), "owners", topicName.asString());
+    }
+
+    public static String idsPath(ConsumerGroupId groupId) {
+        return join(consumerGroupPath(groupId), "ids");
+    }
+
+    public static String partitionOffsetPath(ConsumerGroupId groupId, KafkaTopicName topic, int partition) {
+        return join(offsetsPath(groupId, topic), partition);
+    }
+
+    public static String consumerGroupPath(ConsumerGroupId groupId) {
+        return join("/consumers", groupId.asString());
+    }
+
+    private static String join(Object... parts) {
+        return Joiner.on("/").join(parts);
+    }
+
+}

--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/infrastructure/zookeeper/ZookeeperPaths.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/infrastructure/zookeeper/ZookeeperPaths.java
@@ -12,6 +12,7 @@ public class ZookeeperPaths {
     public static final String URL_SEPARATOR = "/";
     public static final String CONSUMERS_PATH = "consumers";
     public static final String METRICS_PATH = "metrics";
+    public static final String ADMIN_PATH = "admin";
 
     private final String basePath;
 
@@ -21,6 +22,14 @@ public class ZookeeperPaths {
 
     public String basePath() {
         return basePath;
+    }
+
+    public String adminPath() {
+        return Joiner.on(URL_SEPARATOR).join(basePath, ADMIN_PATH);
+    }
+
+    public String adminOperationPath(String operation) {
+        return Joiner.on(URL_SEPARATOR).join(adminPath(), operation);
     }
 
     public String groupsPath() {

--- a/hermes-common/src/test/groovy/pl/allegro/tech/hermes/common/kafka/KafkaNamesMapperTest.groovy
+++ b/hermes-common/src/test/groovy/pl/allegro/tech/hermes/common/kafka/KafkaNamesMapperTest.groovy
@@ -1,7 +1,5 @@
 package pl.allegro.tech.hermes.common.kafka
 
-import pl.allegro.tech.hermes.api.Subscription
-import pl.allegro.tech.hermes.api.SubscriptionName
 import pl.allegro.tech.hermes.api.TopicName
 import spock.lang.Specification
 import spock.lang.Unroll
@@ -26,12 +24,9 @@ class KafkaNamesMapperTest extends Specification {
     def "should map subscription id '#subscriptionId' to consumer group '#consumerGroupId' for namespace '#namespace'"() {
         given:
         def mapper = new KafkaNamesMapper(namespace)
-        def subscription = Stub(Subscription) {
-            getId() >> subscriptionId
-        }
 
         expect:
-        mapper.toConsumerGroupId(subscription) == ConsumerGroupId.valueOf(consumerGroupId)
+        mapper.toConsumerGroupId(subscriptionId) == ConsumerGroupId.valueOf(consumerGroupId)
 
         where:
         namespace | subscriptionId     | consumerGroupId

--- a/hermes-common/src/test/groovy/pl/allegro/tech/hermes/common/kafka/KafkaNamesMapperTest.groovy
+++ b/hermes-common/src/test/groovy/pl/allegro/tech/hermes/common/kafka/KafkaNamesMapperTest.groovy
@@ -1,0 +1,42 @@
+package pl.allegro.tech.hermes.common.kafka
+
+import pl.allegro.tech.hermes.api.Subscription
+import pl.allegro.tech.hermes.api.SubscriptionName
+import pl.allegro.tech.hermes.api.TopicName
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class KafkaNamesMapperTest extends Specification {
+
+    @Unroll
+    def "should map topic '#topicName' to kafka topic '#kafkaTopicName' for namespace '#namespace'"() {
+        given:
+        def mapper = new KafkaNamesMapper(namespace)
+
+        expect:
+        mapper.toKafkaTopicName(TopicName.fromQualifiedName(topicName)) == KafkaTopicName.valueOf(kafkaTopicName)
+
+        where:
+        namespace | topicName     | kafkaTopicName
+        "ns"      | "group.topic" | "ns_group.topic"
+        ""        | "group.topic" | "group.topic"
+    }
+
+    @Unroll
+    def "should map subscription id '#subscriptionId' to consumer group '#consumerGroupId' for namespace '#namespace'"() {
+        given:
+        def mapper = new KafkaNamesMapper(namespace)
+        def subscription = Stub(Subscription) {
+            getId() >> subscriptionId
+        }
+
+        expect:
+        mapper.toConsumerGroupId(subscription) == ConsumerGroupId.valueOf(consumerGroupId)
+
+        where:
+        namespace | subscriptionId     | consumerGroupId
+        "ns"      | "subscription_id" | "ns_subscription_id"
+        ""        | "subscription_id" | "subscription_id"
+    }
+
+}

--- a/hermes-common/src/test/groovy/pl/allegro/tech/hermes/infrastructure/zookeeper/ZookeeperAdminCacheTest.groovy
+++ b/hermes-common/src/test/groovy/pl/allegro/tech/hermes/infrastructure/zookeeper/ZookeeperAdminCacheTest.groovy
@@ -10,7 +10,7 @@ import pl.allegro.tech.hermes.test.IntegrationTest
 
 class ZookeeperAdminCacheTest extends IntegrationTest {
 
-    def adminCache = new ZookeeperAdminCache(zookeeper(), mapper)
+    def adminCache = new ZookeeperAdminCache(paths, zookeeper(), mapper)
     def subscriptionBytes =  mapper.writeValueAsBytes(new SubscriptionName("test", new TopicName("group", "name")));
 
     def "should cleanup RETRANSMIT marker after retransmission"() {

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/offset/kafka/broker/BlockingChannelFactory.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/offset/kafka/broker/BlockingChannelFactory.java
@@ -8,6 +8,7 @@ import kafka.javaapi.ConsumerMetadataResponse;
 import kafka.network.BlockingChannel;
 import pl.allegro.tech.hermes.common.config.ConfigFactory;
 import pl.allegro.tech.hermes.common.config.Configs;
+import pl.allegro.tech.hermes.common.kafka.ConsumerGroupId;
 
 import javax.inject.Inject;
 import java.util.Arrays;
@@ -32,7 +33,7 @@ public class BlockingChannelFactory {
         this.readTimeout = readTimeout;
     }
 
-    public BlockingChannel create(String consumerGroupId) {
+    public BlockingChannel create(ConsumerGroupId consumerGroupId) {
         ConsumerMetadataResponse metadataResponse = readConsumerMetadata(consumerGroupId);
 
         if (metadataResponse.errorCode() != ErrorMapping.NoError()) {
@@ -49,14 +50,14 @@ public class BlockingChannelFactory {
         return blockingChannel;
     }
 
-    private ConsumerMetadataResponse readConsumerMetadata(String consumerGroupId) {
+    private ConsumerMetadataResponse readConsumerMetadata(ConsumerGroupId consumerGroupId) {
         BlockingChannel channel = new BlockingChannel(broker.getHostText(), broker.getPort(),
                 BlockingChannel.UseDefaultBufferSize(),
                 BlockingChannel.UseDefaultBufferSize(),
                 readTimeout);
 
         channel.connect();
-        channel.send(new ConsumerMetadataRequest(consumerGroupId, ConsumerMetadataRequest.CurrentVersion(), 0, "0"));
+        channel.send(new ConsumerMetadataRequest(consumerGroupId.asString(), ConsumerMetadataRequest.CurrentVersion(), 0, "0"));
         ConsumerMetadataResponse metadataResponse = ConsumerMetadataResponse.readFrom(channel.receive().buffer());
         channel.disconnect();
         return metadataResponse;

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/offset/kafka/zookeeper/ZookeeperOffsetsStorage.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/offset/kafka/zookeeper/ZookeeperOffsetsStorage.java
@@ -2,12 +2,12 @@ package pl.allegro.tech.hermes.consumers.consumer.offset.kafka.zookeeper;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Charsets;
-import com.google.common.base.Joiner;
 import org.apache.curator.framework.CuratorFramework;
 import pl.allegro.tech.hermes.api.Subscription;
 import pl.allegro.tech.hermes.common.di.CuratorType;
 import pl.allegro.tech.hermes.common.exception.InternalProcessingException;
 import pl.allegro.tech.hermes.common.kafka.KafkaNamesMapper;
+import pl.allegro.tech.hermes.common.kafka.KafkaZookeeperPaths;
 import pl.allegro.tech.hermes.consumers.consumer.offset.OffsetsStorage;
 import pl.allegro.tech.hermes.domain.subscription.offset.PartitionOffset;
 
@@ -15,8 +15,6 @@ import javax.inject.Inject;
 import javax.inject.Named;
 
 public class ZookeeperOffsetsStorage implements OffsetsStorage {
-
-    private static final String OFFSET_PATTERN_PATH = "/consumers/%s/offsets/%s";
 
     private final CuratorFramework curatorFramework;
     private final KafkaNamesMapper kafkaNamesMapper;
@@ -60,10 +58,11 @@ public class ZookeeperOffsetsStorage implements OffsetsStorage {
 
     @VisibleForTesting
     protected String getPartitionOffsetPath(Subscription subscription, int partition) {
-        return Joiner.on("/").join(getOffsetPath(subscription), partition);
+        return KafkaZookeeperPaths.partitionOffsetPath(
+                kafkaNamesMapper.toConsumerGroupId(subscription),
+                kafkaNamesMapper.toKafkaTopicName(subscription.getTopicName()),
+                partition
+        );
     }
 
-    private String getOffsetPath(Subscription subscription) {
-        return String.format(OFFSET_PATTERN_PATH, subscription.getId(), kafkaNamesMapper.toKafkaTopicName(subscription.getTopicName()).asString());
-    }
 }

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/offset/kafka/zookeeper/ZookeeperOffsetsStorage.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/offset/kafka/zookeeper/ZookeeperOffsetsStorage.java
@@ -7,6 +7,7 @@ import org.apache.curator.framework.CuratorFramework;
 import pl.allegro.tech.hermes.api.Subscription;
 import pl.allegro.tech.hermes.common.di.CuratorType;
 import pl.allegro.tech.hermes.common.exception.InternalProcessingException;
+import pl.allegro.tech.hermes.common.kafka.KafkaNamesMapper;
 import pl.allegro.tech.hermes.consumers.consumer.offset.OffsetsStorage;
 import pl.allegro.tech.hermes.domain.subscription.offset.PartitionOffset;
 
@@ -18,10 +19,12 @@ public class ZookeeperOffsetsStorage implements OffsetsStorage {
     private static final String OFFSET_PATTERN_PATH = "/consumers/%s/offsets/%s";
 
     private final CuratorFramework curatorFramework;
+    private final KafkaNamesMapper kafkaNamesMapper;
 
     @Inject
-    public ZookeeperOffsetsStorage(@Named(CuratorType.KAFKA) CuratorFramework curatorFramework) {
+    public ZookeeperOffsetsStorage(@Named(CuratorType.KAFKA) CuratorFramework curatorFramework, KafkaNamesMapper kafkaNamesMapper) {
         this.curatorFramework = curatorFramework;
+        this.kafkaNamesMapper = kafkaNamesMapper;
     }
 
     @Override
@@ -60,7 +63,7 @@ public class ZookeeperOffsetsStorage implements OffsetsStorage {
         return Joiner.on("/").join(getOffsetPath(subscription), partition);
     }
 
-    private static String getOffsetPath(Subscription subscription) {
-        return String.format(OFFSET_PATTERN_PATH, subscription.getId(), subscription.getQualifiedTopicName());
+    private String getOffsetPath(Subscription subscription) {
+        return String.format(OFFSET_PATTERN_PATH, subscription.getId(), kafkaNamesMapper.toKafkaTopicName(subscription.getTopicName()).asString());
     }
 }

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/receiver/kafka/KafkaMessageReceiverFactory.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/receiver/kafka/KafkaMessageReceiverFactory.java
@@ -6,6 +6,7 @@ import pl.allegro.tech.hermes.api.Subscription;
 import pl.allegro.tech.hermes.api.Topic;
 import pl.allegro.tech.hermes.common.config.ConfigFactory;
 import pl.allegro.tech.hermes.common.config.Configs;
+import pl.allegro.tech.hermes.common.kafka.ConsumerGroupId;
 import pl.allegro.tech.hermes.common.kafka.KafkaNamesMapper;
 import pl.allegro.tech.hermes.common.message.wrapper.MessageContentWrapper;
 import pl.allegro.tech.hermes.common.metric.HermesMetrics;
@@ -37,7 +38,7 @@ public class KafkaMessageReceiverFactory implements ReceiverFactory {
 
     @Override
     public MessageReceiver createMessageReceiver(Topic receivingTopic, Subscription subscription) {
-        return create(receivingTopic, createConsumerConfig(subscription.getId()));
+        return create(receivingTopic, createConsumerConfig(kafkaNamesMapper.toConsumerGroupId(subscription)));
     }
 
     MessageReceiver create(Topic receivingTopic, ConsumerConfig consumerConfig) {
@@ -51,10 +52,10 @@ public class KafkaMessageReceiverFactory implements ReceiverFactory {
                 configFactory.getIntProperty(Configs.KAFKA_STREAM_COUNT));
     }
 
-    private ConsumerConfig createConsumerConfig(String subscriptionName) {
+    private ConsumerConfig createConsumerConfig(ConsumerGroupId groupId) {
         Properties props = new Properties();
 
-        props.put("group.id", subscriptionName);
+        props.put("group.id", groupId.asString());
         props.put("zookeeper.connect", configFactory.getStringProperty(Configs.KAFKA_ZOOKEEPER_CONNECT_STRING));
         props.put("zookeeper.connection.timeout.ms", configFactory.getIntPropertyAsString(Configs.ZOOKEEPER_CONNECTION_TIMEOUT));
         props.put("zookeeper.session.timeout.ms", configFactory.getIntPropertyAsString(Configs.ZOOKEEPER_SESSION_TIMEOUT));

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/receiver/kafka/KafkaMessageReceiverFactory.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/receiver/kafka/KafkaMessageReceiverFactory.java
@@ -6,6 +6,7 @@ import pl.allegro.tech.hermes.api.Subscription;
 import pl.allegro.tech.hermes.api.Topic;
 import pl.allegro.tech.hermes.common.config.ConfigFactory;
 import pl.allegro.tech.hermes.common.config.Configs;
+import pl.allegro.tech.hermes.common.kafka.KafkaNamesMapper;
 import pl.allegro.tech.hermes.common.message.wrapper.MessageContentWrapper;
 import pl.allegro.tech.hermes.common.metric.HermesMetrics;
 import pl.allegro.tech.hermes.common.metric.Timers;
@@ -22,14 +23,16 @@ public class KafkaMessageReceiverFactory implements ReceiverFactory {
     private final MessageContentWrapper messageContentWrapper;
     private final HermesMetrics hermesMetrics;
     private final Clock clock;
+    private final KafkaNamesMapper kafkaNamesMapper;
 
     @Inject
     public KafkaMessageReceiverFactory(ConfigFactory configFactory, MessageContentWrapper messageContentWrapper,
-                                       HermesMetrics hermesMetrics, Clock clock) {
+                                       HermesMetrics hermesMetrics, Clock clock, KafkaNamesMapper kafkaNamesMapper) {
         this.configFactory = configFactory;
         this.messageContentWrapper = messageContentWrapper;
         this.hermesMetrics = hermesMetrics;
         this.clock = clock;
+        this.kafkaNamesMapper = kafkaNamesMapper;
     }
 
     @Override
@@ -41,10 +44,11 @@ public class KafkaMessageReceiverFactory implements ReceiverFactory {
         return new KafkaMessageReceiver(
                 receivingTopic,
                 Consumer.createJavaConsumerConnector(consumerConfig),
-                configFactory,
                 messageContentWrapper,
                 hermesMetrics.timer(Timers.CONSUMER_READ_LATENCY),
-                clock);
+                clock,
+                kafkaNamesMapper,
+                configFactory.getIntProperty(Configs.KAFKA_STREAM_COUNT));
     }
 
     private ConsumerConfig createConsumerConfig(String subscriptionName) {

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/receiver/kafka/zookeeper/ZookeeperMessageCommitter.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/receiver/kafka/zookeeper/ZookeeperMessageCommitter.java
@@ -4,6 +4,7 @@ import org.apache.curator.framework.CuratorFramework;
 import org.apache.zookeeper.KeeperException;
 import pl.allegro.tech.hermes.api.Subscription;
 import pl.allegro.tech.hermes.api.TopicName;
+import pl.allegro.tech.hermes.common.kafka.KafkaNamesMapper;
 import pl.allegro.tech.hermes.consumers.consumer.receiver.MessageCommitter;
 import pl.allegro.tech.hermes.domain.subscription.offset.PartitionOffset;
 
@@ -11,10 +12,12 @@ import java.nio.charset.Charset;
 
 public class ZookeeperMessageCommitter implements MessageCommitter {
 
-    private CuratorFramework curatorFramework;
+    private final CuratorFramework curatorFramework;
+    private final KafkaNamesMapper kafkaNamesMapper;
 
-    public ZookeeperMessageCommitter(CuratorFramework curatorFramework) {
+    public ZookeeperMessageCommitter(CuratorFramework curatorFramework, KafkaNamesMapper kafkaNamesMapper) {
         this.curatorFramework = curatorFramework;
+        this.kafkaNamesMapper = kafkaNamesMapper;
     }
 
     @Override
@@ -34,7 +37,7 @@ public class ZookeeperMessageCommitter implements MessageCommitter {
     }
 
     private String subscriptionPath(TopicName topicName, String subscriptionId, int partition) {
-        return String.format("/consumers/%s/offsets/%s/%s", subscriptionId, topicName.qualifiedName(), partition);
+        return String.format("/consumers/%s/offsets/%s/%s", subscriptionId, kafkaNamesMapper.toKafkaTopicName(topicName).asString(), partition);
     }
 
     @Override

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/receiver/kafka/zookeeper/ZookeeperMessageCommitter.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/receiver/kafka/zookeeper/ZookeeperMessageCommitter.java
@@ -5,6 +5,7 @@ import org.apache.zookeeper.KeeperException;
 import pl.allegro.tech.hermes.api.Subscription;
 import pl.allegro.tech.hermes.api.TopicName;
 import pl.allegro.tech.hermes.common.kafka.KafkaNamesMapper;
+import pl.allegro.tech.hermes.common.kafka.KafkaZookeeperPaths;
 import pl.allegro.tech.hermes.consumers.consumer.receiver.MessageCommitter;
 import pl.allegro.tech.hermes.domain.subscription.offset.PartitionOffset;
 
@@ -24,9 +25,9 @@ public class ZookeeperMessageCommitter implements MessageCommitter {
     public void commitOffset(Subscription subscription, PartitionOffset partitionOffset) throws Exception {
         long firstToRead = partitionOffset.getOffset() + 1;
         byte[] data = String.valueOf(firstToRead).getBytes(Charset.forName("UTF-8"));
-        String offsetPath = subscriptionPath(
-                subscription.getTopicName(),
-                subscription.getId(),
+        String offsetPath = KafkaZookeeperPaths.partitionOffsetPath(
+                kafkaNamesMapper.toConsumerGroupId(subscription),
+                kafkaNamesMapper.toKafkaTopicName(subscription.getTopicName()),
                 partitionOffset.getPartition()
         );
         try {
@@ -36,14 +37,13 @@ public class ZookeeperMessageCommitter implements MessageCommitter {
         }
     }
 
-    private String subscriptionPath(TopicName topicName, String subscriptionId, int partition) {
-        return String.format("/consumers/%s/offsets/%s/%s", subscriptionId, kafkaNamesMapper.toKafkaTopicName(topicName).asString(), partition);
-    }
-
     @Override
     public void removeOffset(TopicName topicName, String subscriptionName, int partition) throws Exception {
-        curatorFramework.delete().forPath(
-            subscriptionPath(topicName, Subscription.getId(topicName, subscriptionName), partition)
+        String offsetPath = KafkaZookeeperPaths.partitionOffsetPath(
+                kafkaNamesMapper.toConsumerGroupId(Subscription.getId(topicName, subscriptionName)),
+                kafkaNamesMapper.toKafkaTopicName(topicName),
+                partition
         );
+        curatorFramework.delete().forPath(offsetPath);
     }
 }

--- a/hermes-consumers/src/test/java/pl/allegro/tech/hermes/consumers/consumer/offset/kafka/zookeeper/ZookeeperOffsetsStorageTest.java
+++ b/hermes-consumers/src/test/java/pl/allegro/tech/hermes/consumers/consumer/offset/kafka/zookeeper/ZookeeperOffsetsStorageTest.java
@@ -3,6 +3,7 @@ package pl.allegro.tech.hermes.consumers.consumer.offset.kafka.zookeeper;
 import org.junit.After;
 import org.junit.Test;
 import pl.allegro.tech.hermes.api.Subscription;
+import pl.allegro.tech.hermes.common.kafka.KafkaNamesMapper;
 import pl.allegro.tech.hermes.domain.subscription.offset.PartitionOffset;
 import pl.allegro.tech.hermes.test.helper.zookeeper.ZookeeperBaseTest;
 
@@ -14,7 +15,7 @@ public class ZookeeperOffsetsStorageTest extends ZookeeperBaseTest {
             .withTopicName("brokerGroup", "brokerTopic")
             .withName("brokerSubscription").build();
 
-    private final ZookeeperOffsetsStorage offsetsStorage = new ZookeeperOffsetsStorage(zookeeperClient);
+    private final ZookeeperOffsetsStorage offsetsStorage = new ZookeeperOffsetsStorage(zookeeperClient, new KafkaNamesMapper("ns"));
 
     @After
     public void after() throws Exception {

--- a/hermes-consumers/src/test/java/pl/allegro/tech/hermes/consumers/consumer/receiver/kafka/KafkaMessageReceiverTest.java
+++ b/hermes-consumers/src/test/java/pl/allegro/tech/hermes/consumers/consumer/receiver/kafka/KafkaMessageReceiverTest.java
@@ -2,7 +2,6 @@ package pl.allegro.tech.hermes.consumers.consumer.receiver.kafka;
 
 import com.codahale.metrics.Timer;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Maps;
 import kafka.consumer.ConsumerConfig;
 import kafka.consumer.ConsumerTimeoutException;
 import kafka.consumer.KafkaStream;
@@ -14,10 +13,10 @@ import org.mockito.Answers;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import pl.allegro.tech.hermes.api.Topic;
-import pl.allegro.tech.hermes.common.config.ConfigFactory;
 import pl.allegro.tech.hermes.common.exception.InternalProcessingException;
-import pl.allegro.tech.hermes.common.message.wrapper.MessageMetadata;
+import pl.allegro.tech.hermes.common.kafka.KafkaNamesMapper;
 import pl.allegro.tech.hermes.common.message.wrapper.MessageContentWrapper;
+import pl.allegro.tech.hermes.common.message.wrapper.MessageMetadata;
 import pl.allegro.tech.hermes.common.message.wrapper.UnwrappedMessageContent;
 import pl.allegro.tech.hermes.common.time.SystemClock;
 import pl.allegro.tech.hermes.consumers.consumer.Message;
@@ -29,8 +28,8 @@ import java.util.Map;
 import static com.googlecode.catchexception.CatchException.catchException;
 import static com.googlecode.catchexception.CatchException.caughtException;
 import static java.lang.String.format;
+import static java.util.Collections.singletonMap;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.when;
 import static pl.allegro.tech.hermes.api.Topic.Builder.topic;
 
@@ -38,6 +37,7 @@ import static pl.allegro.tech.hermes.api.Topic.Builder.topic;
 public class KafkaMessageReceiverTest {
 
     private static final Topic TOPIC = topic().withContentType(Topic.ContentType.JSON).withName("group.topic1").build();
+    private static final Integer KAFKA_STREAM_COUNT = 1;
     private static final String CONTENT = "{\"test\":\"a\"}";
     private static final MessageMetadata METADATA = new MessageMetadata(1L, "unique");
     private static final String WRAPPED_MESSAGE_CONTENT =
@@ -58,20 +58,25 @@ public class KafkaMessageReceiverTest {
     @Mock(answer = Answers.RETURNS_MOCKS)
     private Timer timer;
 
+    private KafkaNamesMapper kafkaNamesMapper = new KafkaNamesMapper("ns");
+
+    private KafkaMessageReceiver kafkaMsgReceiver;
+
     @Before
     @SuppressWarnings("unchecked")
     public void setUp() {
-        Map<String, List<kafka.consumer.KafkaStream<byte[], byte[]>>> consumerMap = Maps.newHashMap();
-        consumerMap.put(TOPIC.getQualifiedName(), ImmutableList.of(kafkaStream).asList());
-        when(consumerConnector.createMessageStreams(any(Map.class))).thenReturn(consumerMap);
+        Map<String, List<kafka.consumer.KafkaStream<byte[], byte[]>>> consumerMap = singletonMap("ns_group.topic1", ImmutableList.of(kafkaStream));
+        Map<String, Integer> expectedTopicCountMap = singletonMap("ns_group.topic1", KAFKA_STREAM_COUNT);
+        when(consumerConnector.createMessageStreams(expectedTopicCountMap)).thenReturn(consumerMap);
         when(messageContentWrapper.unwrap(WRAPPED_MESSAGE_CONTENT.getBytes(), TOPIC)).thenReturn(new UnwrappedMessageContent(METADATA, CONTENT.getBytes()));
+        kafkaMsgReceiver = new KafkaMessageReceiver(TOPIC, consumerConnector, messageContentWrapper,
+                timer, new SystemClock(), kafkaNamesMapper, KAFKA_STREAM_COUNT);
     }
 
     @Test
     public void shouldReadMessage() {
         // given
         when(kafkaStream.iterator().next().message()).thenReturn(WRAPPED_MESSAGE_CONTENT.getBytes());
-        KafkaMessageReceiver kafkaMsgReceiver = getKafkaMessageReceiver();
 
         // when
         Message msg = kafkaMsgReceiver.next();
@@ -84,7 +89,6 @@ public class KafkaMessageReceiverTest {
     public void shouldThrowTimeoutException() {
         // given
         when(kafkaStream.iterator().next()).thenThrow(new ConsumerTimeoutException());
-        KafkaMessageReceiver kafkaMsgReceiver = getKafkaMessageReceiver();
 
         // when
         catchException(kafkaMsgReceiver).next();
@@ -97,18 +101,12 @@ public class KafkaMessageReceiverTest {
     public void shouldRethrowIfOtherError() {
         // given
         when(kafkaStream.iterator().next()).thenThrow(new NullPointerException());
-        KafkaMessageReceiver kafkaMsgReceiver = getKafkaMessageReceiver();
 
         // when
         catchException(kafkaMsgReceiver).next();
 
         // then
         assertThat((Throwable) caughtException()).isInstanceOf(InternalProcessingException.class);
-    }
-
-    private KafkaMessageReceiver getKafkaMessageReceiver() {
-        return new KafkaMessageReceiver(TOPIC, consumerConnector, new ConfigFactory(),
-                messageContentWrapper, timer, new SystemClock());
     }
 
 }

--- a/hermes-consumers/src/test/java/pl/allegro/tech/hermes/consumers/consumer/receiver/kafka/ZookeeperMessageCommitterTest.java
+++ b/hermes-consumers/src/test/java/pl/allegro/tech/hermes/consumers/consumer/receiver/kafka/ZookeeperMessageCommitterTest.java
@@ -9,6 +9,7 @@ import org.junit.Test;
 import pl.allegro.tech.hermes.api.EndpointAddress;
 import pl.allegro.tech.hermes.api.Subscription;
 import pl.allegro.tech.hermes.api.TopicName;
+import pl.allegro.tech.hermes.common.kafka.KafkaNamesMapper;
 import pl.allegro.tech.hermes.consumers.consumer.receiver.kafka.zookeeper.ZookeeperMessageCommitter;
 import pl.allegro.tech.hermes.domain.subscription.offset.PartitionOffset;
 
@@ -25,7 +26,7 @@ public class ZookeeperMessageCommitterTest {
     private static final TopicName SOME_TOPIC_NAME = new TopicName("g", "b");
     private static CuratorFramework curatorClient;
 
-    private ZookeeperMessageCommitter zookeeperMessageCommitter = new ZookeeperMessageCommitter(curatorClient);
+    private ZookeeperMessageCommitter zookeeperMessageCommitter = new ZookeeperMessageCommitter(curatorClient, new KafkaNamesMapper("ns"));
 
     @BeforeClass
     public static void beforeClass() throws Exception {
@@ -43,7 +44,7 @@ public class ZookeeperMessageCommitterTest {
         zookeeperMessageCommitter.commitOffset(subscriptionForTopic(SOME_TOPIC_NAME), new PartitionOffset(15, 0));
 
         //then
-        assertEquals(16, getOffsetForPath("/consumers/g_b_sub1/offsets/g.b/0"));
+        assertEquals(16, getOffsetForPath("/consumers/g_b_sub1/offsets/ns_g.b/0"));
     }
 
     @Test
@@ -55,7 +56,7 @@ public class ZookeeperMessageCommitterTest {
         zookeeperMessageCommitter.commitOffset(subscriptionForTopic(SOME_TOPIC_NAME), new PartitionOffset(17, 0));
 
         //then
-        assertEquals(18, getOffsetForPath("/consumers/g_b_sub1/offsets/g.b/0"));
+        assertEquals(18, getOffsetForPath("/consumers/g_b_sub1/offsets/ns_g.b/0"));
     }
 
     @Test
@@ -67,8 +68,8 @@ public class ZookeeperMessageCommitterTest {
         zookeeperMessageCommitter.commitOffset(subscriptionForTopic(SOME_TOPIC_NAME), new PartitionOffset(17, 1));
 
         //then
-        assertEquals(16, getOffsetForPath("/consumers/g_b_sub1/offsets/g.b/0"));
-        assertEquals(18, getOffsetForPath("/consumers/g_b_sub1/offsets/g.b/1"));
+        assertEquals(16, getOffsetForPath("/consumers/g_b_sub1/offsets/ns_g.b/0"));
+        assertEquals(18, getOffsetForPath("/consumers/g_b_sub1/offsets/ns_g.b/1"));
     }
 
     @Test
@@ -80,7 +81,7 @@ public class ZookeeperMessageCommitterTest {
         zookeeperMessageCommitter.removeOffset(SOME_TOPIC_NAME, "sub1", 0);
 
         //then
-        assertNull(curatorClient.checkExists().forPath("/consumers/g_b_sub1/offsets/g.b/0"));
+        assertNull(curatorClient.checkExists().forPath("/consumers/g_b_sub1/offsets/ns_g.b/0"));
     }
 
     private Subscription subscriptionForTopic(TopicName topicName) throws MalformedURLException {

--- a/hermes-consumers/src/test/java/pl/allegro/tech/hermes/consumers/consumer/receiver/kafka/ZookeeperMessageCommitterTest.java
+++ b/hermes-consumers/src/test/java/pl/allegro/tech/hermes/consumers/consumer/receiver/kafka/ZookeeperMessageCommitterTest.java
@@ -44,7 +44,7 @@ public class ZookeeperMessageCommitterTest {
         zookeeperMessageCommitter.commitOffset(subscriptionForTopic(SOME_TOPIC_NAME), new PartitionOffset(15, 0));
 
         //then
-        assertEquals(16, getOffsetForPath("/consumers/g_b_sub1/offsets/ns_g.b/0"));
+        assertEquals(16, getOffsetForPath("/consumers/ns_g_b_sub1/offsets/ns_g.b/0"));
     }
 
     @Test
@@ -56,7 +56,7 @@ public class ZookeeperMessageCommitterTest {
         zookeeperMessageCommitter.commitOffset(subscriptionForTopic(SOME_TOPIC_NAME), new PartitionOffset(17, 0));
 
         //then
-        assertEquals(18, getOffsetForPath("/consumers/g_b_sub1/offsets/ns_g.b/0"));
+        assertEquals(18, getOffsetForPath("/consumers/ns_g_b_sub1/offsets/ns_g.b/0"));
     }
 
     @Test
@@ -68,8 +68,8 @@ public class ZookeeperMessageCommitterTest {
         zookeeperMessageCommitter.commitOffset(subscriptionForTopic(SOME_TOPIC_NAME), new PartitionOffset(17, 1));
 
         //then
-        assertEquals(16, getOffsetForPath("/consumers/g_b_sub1/offsets/ns_g.b/0"));
-        assertEquals(18, getOffsetForPath("/consumers/g_b_sub1/offsets/ns_g.b/1"));
+        assertEquals(16, getOffsetForPath("/consumers/ns_g_b_sub1/offsets/ns_g.b/0"));
+        assertEquals(18, getOffsetForPath("/consumers/ns_g_b_sub1/offsets/ns_g.b/1"));
     }
 
     @Test
@@ -81,7 +81,7 @@ public class ZookeeperMessageCommitterTest {
         zookeeperMessageCommitter.removeOffset(SOME_TOPIC_NAME, "sub1", 0);
 
         //then
-        assertNull(curatorClient.checkExists().forPath("/consumers/g_b_sub1/offsets/ns_g.b/0"));
+        assertNull(curatorClient.checkExists().forPath("/consumers/ns_g_b_sub1/offsets/ns_g.b/0"));
     }
 
     private Subscription subscriptionForTopic(TopicName topicName) throws MalformedURLException {

--- a/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/di/FrontendBinder.java
+++ b/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/di/FrontendBinder.java
@@ -6,7 +6,7 @@ import org.glassfish.hk2.utilities.binding.AbstractBinder;
 import pl.allegro.tech.hermes.frontend.cache.topic.TopicsCache;
 import pl.allegro.tech.hermes.frontend.cache.topic.zookeeper.ZookeeperTopicsCacheFactory;
 import pl.allegro.tech.hermes.frontend.producer.BrokerMessageProducer;
-import pl.allegro.tech.hermes.frontend.producer.kafka.KafkaBrokerMessageProducer;
+import pl.allegro.tech.hermes.frontend.producer.kafka.KafkaBrokerMessageProducerFactory;
 import pl.allegro.tech.hermes.frontend.producer.kafka.KafkaMessageProducerFactory;
 import pl.allegro.tech.hermes.frontend.producer.kafka.Producers;
 import pl.allegro.tech.hermes.frontend.publishing.MessageContentTypeEnforcer;
@@ -29,12 +29,12 @@ public class FrontendBinder extends AbstractBinder {
     protected void configure() {
         bind(HermesServer.class).to(HermesServer.class).in(Singleton.class);
         bind(PublishingServlet.class).to(PublishingServlet.class).in(Singleton.class);
-        bind(KafkaBrokerMessageProducer.class).to(BrokerMessageProducer.class).in(Singleton.class);
         bind(MessageValidators.class).to(MessageValidators.class).in(Singleton.class);
 
         bind(HealthCheckService.class).to(HealthCheckService.class).in(Singleton.class);
 
         bindFactory(KafkaMessageProducerFactory.class).to(Producers.class).in(Singleton.class);
+        bindFactory(KafkaBrokerMessageProducerFactory.class).to(BrokerMessageProducer.class).in(Singleton.class);
         bindFactory(ZkClientFactory.class).to(ZkClient.class).in(Singleton.class);
         bindSingleton(PublishingMessageTracker.class);
         bindSingleton(NoOperationPublishingTracker.class);

--- a/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/producer/kafka/KafkaBrokerMessageProducerFactory.java
+++ b/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/producer/kafka/KafkaBrokerMessageProducerFactory.java
@@ -1,0 +1,32 @@
+package pl.allegro.tech.hermes.frontend.producer.kafka;
+
+import org.glassfish.hk2.api.Factory;
+import pl.allegro.tech.hermes.common.kafka.KafkaNamesMapper;
+import pl.allegro.tech.hermes.common.metric.HermesMetrics;
+
+import javax.inject.Inject;
+
+public class KafkaBrokerMessageProducerFactory implements Factory<KafkaBrokerMessageProducer> {
+
+    private final Producers producers;
+    private final HermesMetrics hermesMetrics;
+    private final KafkaNamesMapper kafkaNamesMapper;
+
+    @Inject
+    public KafkaBrokerMessageProducerFactory(Producers producers, HermesMetrics hermesMetrics, KafkaNamesMapper kafkaNamesMapper) {
+        this.producers = producers;
+        this.hermesMetrics = hermesMetrics;
+        this.kafkaNamesMapper = kafkaNamesMapper;
+    }
+
+    @Override
+    public KafkaBrokerMessageProducer provide() {
+        return new KafkaBrokerMessageProducer(producers, hermesMetrics, kafkaNamesMapper);
+    }
+
+    @Override
+    public void dispose(KafkaBrokerMessageProducer instance) {
+
+    }
+
+}

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/config/StorageConfiguration.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/config/StorageConfiguration.java
@@ -105,7 +105,8 @@ public class StorageConfiguration {
 
     @Bean
     AdminTool adminTool() {
-        return new ZookeeperAdminTool(storageZookeeper(), objectMapper, Configs.ADMIN_REAPER_INTERAL_MS.getDefaultValue());
+        return new ZookeeperAdminTool(zookeeperPaths(), storageZookeeper(), objectMapper,
+                Configs.ADMIN_REAPER_INTERAL_MS.getDefaultValue());
     }
 
     @Bean

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/config/kafka/KafkaProperties.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/config/kafka/KafkaProperties.java
@@ -18,6 +18,8 @@ public class KafkaProperties {
 
     private boolean dualCommitEnabled = false;
 
+    private String namespace = "";
+
     private SimpleConsumer simpleConsumer = new SimpleConsumer();
 
     public static final class SimpleConsumer {
@@ -133,5 +135,13 @@ public class KafkaProperties {
 
     public void setDualCommitEnabled(boolean dualCommitEnabled) {
         this.dualCommitEnabled = dualCommitEnabled;
+    }
+
+    public String getNamespace() {
+        return namespace;
+    }
+
+    public void setNamespace(String namespace) {
+        this.namespace = namespace;
     }
 }

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/infrastructure/kafka/service/KafkaSingleMessageReader.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/infrastructure/kafka/service/KafkaSingleMessageReader.java
@@ -2,6 +2,7 @@ package pl.allegro.tech.hermes.management.infrastructure.kafka.service;
 
 import org.apache.avro.Schema;
 import pl.allegro.tech.hermes.api.Topic;
+import pl.allegro.tech.hermes.common.kafka.KafkaNamesMapper;
 import pl.allegro.tech.hermes.common.message.converter.AvroToJsonConverter;
 import pl.allegro.tech.hermes.domain.topic.schema.SchemaRepository;
 import pl.allegro.tech.hermes.management.domain.topic.SingleMessageReader;
@@ -11,16 +12,18 @@ import java.nio.charset.Charset;
 public class KafkaSingleMessageReader implements SingleMessageReader {
     private final KafkaRawMessageReader kafkaRawMessageReader;
     private final SchemaRepository<Schema> avroSchemaRepository;
+    private final KafkaNamesMapper kafkaNamesMapper;
 
     public KafkaSingleMessageReader(KafkaRawMessageReader kafkaRawMessageReader,
-                                    SchemaRepository<Schema> avroSchemaRepository) {
+                                    SchemaRepository<Schema> avroSchemaRepository, KafkaNamesMapper kafkaNamesMapper) {
         this.kafkaRawMessageReader = kafkaRawMessageReader;
         this.avroSchemaRepository = avroSchemaRepository;
+        this.kafkaNamesMapper = kafkaNamesMapper;
     }
 
     @Override
     public String readMessage(Topic topic, int partition, long offset) {
-        byte[] bytes = kafkaRawMessageReader.readMessage(topic.getQualifiedName(), partition, offset);
+        byte[] bytes = kafkaRawMessageReader.readMessage(kafkaNamesMapper.toKafkaTopicName(topic).asString(), partition, offset);
         if (topic.getContentType() == Topic.ContentType.AVRO) {
             bytes = convertAvroToJson(avroSchemaRepository.getSchema(topic), bytes);
         }

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/infrastructure/kafka/service/retransmit/KafkaRetransmissionService.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/infrastructure/kafka/service/retransmit/KafkaRetransmissionService.java
@@ -10,6 +10,8 @@ import kafka.javaapi.consumer.SimpleConsumer;
 import pl.allegro.tech.hermes.api.Topic;
 import pl.allegro.tech.hermes.api.TopicName;
 import pl.allegro.tech.hermes.common.broker.BrokerStorage;
+import pl.allegro.tech.hermes.common.kafka.KafkaNamesMapper;
+import pl.allegro.tech.hermes.common.kafka.KafkaTopicName;
 import pl.allegro.tech.hermes.common.kafka.SimpleConsumerPool;
 import pl.allegro.tech.hermes.common.message.wrapper.MessageContentWrapper;
 import pl.allegro.tech.hermes.domain.subscription.offset.PartitionOffset;
@@ -31,6 +33,7 @@ public class KafkaRetransmissionService implements RetransmissionService {
     private final SubscriptionOffsetChangeIndicator subscriptionOffsetChange;
     private final SimpleConsumerPool simpleConsumerPool;
     private final TopicRepository topicRepository;
+    private final KafkaNamesMapper kafkaNamesMapper;
 
     public KafkaRetransmissionService(
             BrokerStorage brokerStorage,
@@ -38,7 +41,8 @@ public class KafkaRetransmissionService implements RetransmissionService {
             MessageContentWrapper messageContentWrapper,
             SubscriptionOffsetChangeIndicator subscriptionOffsetChange,
             SimpleConsumerPool simpleConsumerPool,
-            TopicRepository topicRepository) {
+            TopicRepository topicRepository,
+            KafkaNamesMapper kafkaNamesMapper) {
 
         this.brokerStorage = brokerStorage;
         this.singleMessageReader = singleMessageReader;
@@ -46,6 +50,7 @@ public class KafkaRetransmissionService implements RetransmissionService {
         this.subscriptionOffsetChange = subscriptionOffsetChange;
         this.simpleConsumerPool = simpleConsumerPool;
         this.topicRepository = topicRepository;
+        this.kafkaNamesMapper = kafkaNamesMapper;
     }
 
     @Override
@@ -53,10 +58,11 @@ public class KafkaRetransmissionService implements RetransmissionService {
                                                             long timestamp, boolean dryRun) {
 
         List<PartitionOffset> partitionOffsetList = new ArrayList<>();
-        List<Integer> partitionsIds = brokerStorage.readPartitionsIds(topic.qualifiedName());
+        KafkaTopicName kafkaTopicName = kafkaNamesMapper.toKafkaTopicName(topic);
+        List<Integer> partitionsIds = brokerStorage.readPartitionsIds(kafkaTopicName.asString());
 
         for (Integer partitionId : partitionsIds) {
-            SimpleConsumer consumer = createSimpleConsumer(topic, partitionId);
+            SimpleConsumer consumer = createSimpleConsumer(kafkaTopicName, partitionId);
             long offset = getLastOffset(consumer, topicRepository.getTopicDetails(topic), partitionId, timestamp);
             partitionOffsetList.add(new PartitionOffset(offset, partitionId));
             if (!dryRun) {
@@ -67,8 +73,8 @@ public class KafkaRetransmissionService implements RetransmissionService {
         return partitionOffsetList;
     }
 
-    private SimpleConsumer createSimpleConsumer(TopicName topic, int partition) {
-        Integer leader = brokerStorage.readLeaderForPartition(new TopicAndPartition(topic.qualifiedName(), partition));
+    private SimpleConsumer createSimpleConsumer(KafkaTopicName kafkaTopicName, int partition) {
+        Integer leader = brokerStorage.readLeaderForPartition(new TopicAndPartition(kafkaTopicName.asString(), partition));
 
         return simpleConsumerPool.get(leader);
     }
@@ -93,7 +99,7 @@ public class KafkaRetransmissionService implements RetransmissionService {
     }
 
     private long getOffset(SimpleConsumer simpleConsumer, Topic topic, int partition, long whichTime) {
-        TopicAndPartition topicAndPartition = new TopicAndPartition(topic.getQualifiedName(), partition);
+        TopicAndPartition topicAndPartition = new TopicAndPartition(kafkaNamesMapper.toKafkaTopicName(topic).asString(), partition);
 
         Map<TopicAndPartition, PartitionOffsetRequestInfo> requestInfo = new HashMap<>();
         requestInfo.put(topicAndPartition, new PartitionOffsetRequestInfo(whichTime, 1));

--- a/hermes-management/src/main/resources/application.yaml
+++ b/hermes-management/src/main/resources/application.yaml
@@ -4,7 +4,7 @@ zookeeper:
 kafka:
   clusters:
     -
-      clusterName: kafkaPrimary
+      clusterName: primary
       connectionString: localhost:2181
       connectionTimeout: 3000
 

--- a/integration/src/integration/java/pl/allegro/tech/hermes/integration/IntegrationTest.java
+++ b/integration/src/integration/java/pl/allegro/tech/hermes/integration/IntegrationTest.java
@@ -23,7 +23,7 @@ public class IntegrationTest extends HermesIntegrationEnvironment {
     public void initializeIntegrationTest() {
         this.management = new HermesEndpoints(MANAGEMENT_ENDPOINT_URL);
         this.publisher = new HermesPublisher(FRONTEND_URL);
-        this.wait = new Waiter(management, services().zookeeper(), services().kafkaZookeeper());
+        this.wait = new Waiter(management, services().zookeeper(), services().kafkaZookeeper(), KAFKA_NAMESPACE);
         this.operations = new HermesAPIOperations(management, wait);
     }
 

--- a/integration/src/integration/java/pl/allegro/tech/hermes/integration/KafkaBrokerOffsetsRepositoryTest.java
+++ b/integration/src/integration/java/pl/allegro/tech/hermes/integration/KafkaBrokerOffsetsRepositoryTest.java
@@ -5,6 +5,7 @@ import kafka.server.KafkaConfig;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 import pl.allegro.tech.hermes.api.Subscription;
+import pl.allegro.tech.hermes.common.kafka.KafkaNamesMapper;
 import pl.allegro.tech.hermes.consumers.consumer.offset.kafka.broker.BlockingChannelFactory;
 import pl.allegro.tech.hermes.common.time.SystemClock;
 import pl.allegro.tech.hermes.common.util.HostnameResolver;
@@ -46,7 +47,7 @@ public class KafkaBrokerOffsetsRepositoryTest extends IntegrationTest {
         wait.waitUntilConsumerMetadataAvailable(subscription, kafkaHost, kafkaPort);
 
         blockingChannelFactory = new BlockingChannelFactory(HostAndPort.fromParts(kafkaHost, kafkaPort), readTimeout);
-        offsetStorage = new BrokerOffsetsRepository(blockingChannelFactory, new SystemClock(), hostnameResolver, channelExpTime);
+        offsetStorage = new BrokerOffsetsRepository(blockingChannelFactory, new SystemClock(), hostnameResolver, new KafkaNamesMapper(KAFKA_NAMESPACE), channelExpTime);
     }
 
     @Test

--- a/integration/src/integration/java/pl/allegro/tech/hermes/integration/KafkaRetransmissionServiceTest.java
+++ b/integration/src/integration/java/pl/allegro/tech/hermes/integration/KafkaRetransmissionServiceTest.java
@@ -34,7 +34,7 @@ public class KafkaRetransmissionServiceTest extends HermesIntegrationEnvironment
     public void initialize() {
         publisher = new HermesPublisher(FRONTEND_URL);
         endpoints = new HermesEndpoints(MANAGEMENT_ENDPOINT_URL);
-        wait = new Waiter(endpoints, services().zookeeper(), services().kafkaZookeeper());
+        wait = new Waiter(endpoints, services().zookeeper(), services().kafkaZookeeper(), KAFKA_NAMESPACE);
         operations = new HermesAPIOperations(endpoints, wait);
     }
 

--- a/integration/src/integration/java/pl/allegro/tech/hermes/integration/OffsetCommitTest.java
+++ b/integration/src/integration/java/pl/allegro/tech/hermes/integration/OffsetCommitTest.java
@@ -2,10 +2,11 @@ package pl.allegro.tech.hermes.integration;
 
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
+import pl.allegro.tech.hermes.common.kafka.KafkaNamesMapper;
 import pl.allegro.tech.hermes.integration.env.ConsumersStarter;
+import pl.allegro.tech.hermes.integration.shame.Unreliable;
 import pl.allegro.tech.hermes.test.helper.endpoint.RemoteServiceEndpoint;
 import pl.allegro.tech.hermes.test.helper.message.TestMessage;
-import pl.allegro.tech.hermes.integration.shame.Unreliable;
 
 import static pl.allegro.tech.hermes.integration.env.SharedServices.services;
 import static pl.allegro.tech.hermes.integration.test.HermesAssertions.assertThat;
@@ -13,6 +14,8 @@ import static pl.allegro.tech.hermes.integration.test.HermesAssertions.assertTha
 public class OffsetCommitTest extends IntegrationTest {
 
     private RemoteServiceEndpoint remoteService;
+
+    private KafkaNamesMapper kafkaNamesMapper = new KafkaNamesMapper(KAFKA_NAMESPACE);
 
     @BeforeMethod
     public void initializeAlways() {
@@ -43,7 +46,8 @@ public class OffsetCommitTest extends IntegrationTest {
         wait.untilAllOffsetsEqual("properCommitOffsetGroup", "topic", "subscription", messages);
 
         //then
-        assertThat(services().zookeeper()).offsetsAreNotRetracted("properCommitOffsetGroup", "topic", "subscription", 2, messages);
+        assertThat(services().zookeeper(), kafkaNamesMapper)
+                .offsetsAreNotRetracted("properCommitOffsetGroup", "topic", "subscription", 2, messages);
         secondConsumer.stop();
     }
 

--- a/integration/src/integration/java/pl/allegro/tech/hermes/integration/OffsetManipulationTest.java
+++ b/integration/src/integration/java/pl/allegro/tech/hermes/integration/OffsetManipulationTest.java
@@ -31,7 +31,7 @@ public class OffsetManipulationTest extends HermesIntegrationEnvironment {
     public void initialize() {
         this.publisher = new HermesPublisher(FRONTEND_URL);
         HermesEndpoints endpoints = new HermesEndpoints(MANAGEMENT_ENDPOINT_URL);
-        this.wait = new Waiter(endpoints, SharedServices.services().zookeeper(), services().kafkaZookeeper());
+        this.wait = new Waiter(endpoints, SharedServices.services().zookeeper(), services().kafkaZookeeper(), KAFKA_NAMESPACE);
         this.operations = new HermesAPIOperations(endpoints, wait);
         this.consumers = SharedServices.services().consumers();
     }

--- a/integration/src/integration/java/pl/allegro/tech/hermes/integration/env/EnvironmentAware.java
+++ b/integration/src/integration/java/pl/allegro/tech/hermes/integration/env/EnvironmentAware.java
@@ -46,4 +46,6 @@ public interface EnvironmentAware {
     String SECONDARY_KAFKA_CONNECT = "localhost:" + SECONDARY_KAFKA_PORT;
 
     String SECONDARY_ZK_KAFKA_CONNECT = "localhost:14192/secondaryKafka";
+
+    String KAFKA_NAMESPACE = CONFIG_FACTORY.getStringProperty(Configs.KAFKA_NAMESPACE);
 }

--- a/integration/src/integration/java/pl/allegro/tech/hermes/integration/helper/Waiter.java
+++ b/integration/src/integration/java/pl/allegro/tech/hermes/integration/helper/Waiter.java
@@ -90,6 +90,10 @@ public class Waiter extends pl.allegro.tech.hermes.test.helper.endpoint.Waiter {
         untilSubscriptionHasState(topicName.getGroupName(), topicName.getName(), subscription, Subscription.State.ACTIVE);
     }
 
+    public void untilTopicRemovedInKafka(TopicName topicName) {
+        untilZookeeperNodeDeletion(KafkaZookeeperPaths.topicPath(kafkaNamesMapper.toKafkaTopicName(topicName)), kafkaZookeeper);
+    }
+
     public void untilAllOffsetsEqual(final String group, final String topic, final String subscription, final int offset) {
         waitAtMost(adjust(30), TimeUnit.SECONDS).until(() -> {
             List<String> partitions = zookeeper.getChildren().forPath(subscriptionOffsetPath(group, topic, subscription));

--- a/integration/src/integration/java/pl/allegro/tech/hermes/integration/management/TopicManagementTest.java
+++ b/integration/src/integration/java/pl/allegro/tech/hermes/integration/management/TopicManagementTest.java
@@ -4,6 +4,7 @@ import org.assertj.core.api.Assertions;
 import org.testng.annotations.Test;
 import pl.allegro.tech.hermes.api.EndpointAddress;
 import pl.allegro.tech.hermes.api.ErrorCode;
+import pl.allegro.tech.hermes.api.TopicName;
 import pl.allegro.tech.hermes.integration.IntegrationTest;
 
 import javax.ws.rs.core.Response;
@@ -77,7 +78,7 @@ public class TopicManagementTest extends IntegrationTest {
         operations.createTopic("recreateTopicGroup", "topic");
         management.topic().remove("recreateTopicGroup.topic");
 
-        wait.untilKafkaZookeeperNodeDeletion("/brokers/topics/recreateTopicGroup.topic");
+        wait.untilTopicRemovedInKafka(new TopicName("recreateTopicGroup", "topic"));
 
         // when
         Response response = management.topic().create(

--- a/integration/src/integration/java/pl/allegro/tech/hermes/integration/test/HermesAssertions.java
+++ b/integration/src/integration/java/pl/allegro/tech/hermes/integration/test/HermesAssertions.java
@@ -2,6 +2,7 @@ package pl.allegro.tech.hermes.integration.test;
 
 import org.apache.curator.framework.CuratorFramework;
 import org.assertj.core.api.Assertions;
+import pl.allegro.tech.hermes.common.kafka.KafkaNamesMapper;
 
 import javax.ws.rs.core.Response;
 
@@ -13,7 +14,7 @@ public final class HermesAssertions extends Assertions {
     public static HttpResponseAssertion assertThat(Response response) {
         return new HttpResponseAssertion(response);
     }
-    public static ZookeeperAssertion assertThat(CuratorFramework zookeeper) {
-        return new ZookeeperAssertion(zookeeper, ZookeeperAssertion.class);
+    public static ZookeeperAssertion assertThat(CuratorFramework zookeeper, KafkaNamesMapper kafkaNamesMapper) {
+        return new ZookeeperAssertion(zookeeper, ZookeeperAssertion.class, kafkaNamesMapper);
     }
 }

--- a/integration/src/test/resources/application-integration.yaml
+++ b/integration/src/test/resources/application-integration.yaml
@@ -10,10 +10,12 @@ kafka:
       clusterName: primary
       connectionString: localhost:14192/kafka
       connectionTimeout: 10000
+      namespace: 'itTest'
     -
       clusterName: secondary
       connectionString: localhost:14192/secondaryKafka
       connectionTimeout: 10000
+      namespace: 'itTest'
 
 topic:
   replicationFactor: 1

--- a/integration/src/test/resources/config.properties
+++ b/integration/src/test/resources/config.properties
@@ -3,6 +3,7 @@ kafka.zookeeper.connect.string=localhost:14192/kafka
 zookeeper.connection.timeout=10000
 zookeeper.session.timeout=10000
 kafka.broker.list=localhost:9093
+kafka.namespace=itTest
 frontend.port=18080
 frontend.ssl.enabled=true
 frontend.ssl.port=18443


### PR DESCRIPTION
Adds optional namespaces for kafka topics and consumer groups allowing multiple hermes instances to operate on a single kafka instance.