### PR TITLE
204 initial version of new consumer runtime model

### DIFF
--- a/hermes-api/src/main/java/pl/allegro/tech/hermes/api/Subscription.java
+++ b/hermes-api/src/main/java/pl/allegro/tech/hermes/api/Subscription.java
@@ -36,6 +36,10 @@ public class Subscription {
 
     private boolean trackingEnabled;
 
+    public SubscriptionName toSubscriptionName() {
+        return new SubscriptionName(name, topicName);
+    }
+
     public static enum State {
         PENDING, ACTIVE, SUSPENDED
     }

--- a/hermes-api/src/main/java/pl/allegro/tech/hermes/api/SubscriptionName.java
+++ b/hermes-api/src/main/java/pl/allegro/tech/hermes/api/SubscriptionName.java
@@ -1,5 +1,7 @@
 package pl.allegro.tech.hermes.api;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 public class SubscriptionName {
 
     private String name;
@@ -19,5 +21,16 @@ public class SubscriptionName {
 
     public TopicName getTopicName() {
         return topicName;
+    }
+
+    public static SubscriptionName fromString(String string) {
+        String[] tokens = string.split("\\$");
+        checkArgument(tokens.length > 1, "Incorrect string format. Expected 'topic$subscription'. Found:'%s'", string);
+        return new SubscriptionName(tokens[1], TopicName.fromQualifiedName(tokens[0]));
+    }
+
+    @Override
+    public String toString() {
+        return topicName.qualifiedName() + "$" + name;
     }
 }

--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/common/config/Configs.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/common/config/Configs.java
@@ -1,5 +1,10 @@
 package pl.allegro.tech.hermes.common.config;
 
+import pl.allegro.tech.hermes.common.util.InetAddressHostnameResolver;
+
+import static java.lang.Math.abs;
+import static java.util.UUID.randomUUID;
+
 @SuppressWarnings("PMD.AvoidUsingHardCodedIP")
 public enum Configs {
 
@@ -101,6 +106,9 @@ public enum Configs {
     CONSUMER_OFFSET_COMMIT_QUEUE_ALERT_MINIMAL_IDLE_PERIOD("consumer.offset.commit.queue.alert.minimal.idle.period", 3600),
     CONSUMER_OFFSET_COMMIT_QUEUE_ALERT_SIZE("consumer.offset.commit.queue.alert.size", 20_000),
     CONSUMER_HEALTH_CHECK_PORT("consumer.status.health.port", 8000),
+    CONSUMER_WORKLOAD_ALGORITHM("consumer.workload.algorithm", "legacy.mirror"),
+    CONSUMER_WORKLOAD_ID("consumer.workload.id",
+            new InetAddressHostnameResolver().resolve().replaceAll("\\.", "_") + "$" + abs(randomUUID().getMostSignificantBits())),
 
     GRAPHITE_HOST("graphite.host", "localhost"),
     GRAPHITE_PORT("graphite.port", 2003),

--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/domain/subscription/SubscriptionRepository.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/domain/subscription/SubscriptionRepository.java
@@ -1,6 +1,7 @@
 package pl.allegro.tech.hermes.domain.subscription;
 
 import pl.allegro.tech.hermes.api.Subscription;
+import pl.allegro.tech.hermes.api.SubscriptionName;
 import pl.allegro.tech.hermes.api.TopicName;
 
 import java.util.List;
@@ -20,6 +21,8 @@ public interface SubscriptionRepository {
     void updateSubscriptionState(TopicName topicName, String subscriptionName, Subscription.State state);
 
     Subscription getSubscriptionDetails(TopicName topicName, String subscriptionName);
+
+    Subscription getSubscriptionDetails(SubscriptionName subscriptionId);
 
     List<String> listSubscriptionNames(TopicName topicName);
 

--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/infrastructure/zookeeper/ZookeeperPaths.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/infrastructure/zookeeper/ZookeeperPaths.java
@@ -84,6 +84,10 @@ public class ZookeeperPaths {
         return Joiner.on(URL_SEPARATOR).join(basePath, CONSUMERS_PATH);
     }
 
+    public String consumersRuntimePath() {
+        return Joiner.on(URL_SEPARATOR).join(basePath, CONSUMERS_PATH, "runtime");
+    }
+
     public String inflightPath(String hostname, TopicName topicName, String subscriptionName, String metricName) {
         return Joiner.on(URL_SEPARATOR).join(
                 consumersPath(),

--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/infrastructure/zookeeper/ZookeeperSubscriptionRepository.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/infrastructure/zookeeper/ZookeeperSubscriptionRepository.java
@@ -6,6 +6,7 @@ import org.apache.zookeeper.KeeperException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import pl.allegro.tech.hermes.api.Subscription;
+import pl.allegro.tech.hermes.api.SubscriptionName;
 import pl.allegro.tech.hermes.api.TopicName;
 import pl.allegro.tech.hermes.common.exception.InternalProcessingException;
 import pl.allegro.tech.hermes.domain.subscription.SubscriptionAlreadyExistsException;
@@ -95,6 +96,11 @@ public class ZookeeperSubscriptionRepository extends ZookeeperBasedRepository im
     public Subscription getSubscriptionDetails(TopicName topicName, String subscriptionName) {
         ensureSubscriptionExists(topicName, subscriptionName);
         return readFrom(paths.subscriptionPath(topicName, subscriptionName), Subscription.class);
+    }
+
+    @Override
+    public Subscription getSubscriptionDetails(SubscriptionName name) {
+        return getSubscriptionDetails(name.getTopicName(), name.getName());
     }
 
     @Override

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/di/ConsumersBinder.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/di/ConsumersBinder.java
@@ -41,6 +41,10 @@ import pl.allegro.tech.hermes.consumers.subscription.cache.zookeeper.ZookeeperSu
 import pl.allegro.tech.hermes.consumers.supervisor.ConsumerFactory;
 import pl.allegro.tech.hermes.consumers.supervisor.ConsumersExecutorService;
 import pl.allegro.tech.hermes.consumers.supervisor.ConsumersSupervisor;
+import pl.allegro.tech.hermes.consumers.supervisor.workTracking.SupervisorController;
+import pl.allegro.tech.hermes.consumers.supervisor.workTracking.SupervisorControllerFactory;
+import pl.allegro.tech.hermes.consumers.supervisor.workTracking.WorkTracker;
+import pl.allegro.tech.hermes.consumers.supervisor.workTracking.WorkTrackerFactory;
 
 import javax.inject.Singleton;
 import java.util.List;
@@ -76,13 +80,15 @@ public class ConsumersBinder extends AbstractBinder {
         bindSingleton(AvroSchemaRepositoryMetadataAware.class);
 
         bindSingleton(BlockingChannelFactory.class);
-        bindFactory(OffsetStoragesFactory.class).in(Singleton.class).to(new TypeLiteral<List<OffsetsStorage>>() {
-        });
+        bindFactory(OffsetStoragesFactory.class).in(Singleton.class).to(new TypeLiteral<List<OffsetsStorage>>() {});
         bindFactory(FutureAsyncTimeoutFactory.class).in(Singleton.class).to(new TypeLiteral<FutureAsyncTimeout<MessageSendingResult>>(){});
         bindFactory(HttpClientFactory.class).in(Singleton.class).to(HttpClient.class);
         bindFactory(ZookeeperSubscriptionsCacheFactory.class).to(SubscriptionsCache.class).in(Singleton.class);
 
         bindFactory(UndeliveredMessageLogFactory.class).in(Singleton.class).to(UndeliveredMessageLog.class);
+        bindFactory(WorkTrackerFactory.class).in(Singleton.class).to(WorkTracker.class);
+        bindFactory(SupervisorControllerFactory.class).in(Singleton.class).to(SupervisorController.class);
+
         bindSingleton(UndeliveredMessageLogPersister.class);
     }
 

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/ConsumersSupervisor.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/ConsumersSupervisor.java
@@ -1,6 +1,5 @@
 package pl.allegro.tech.hermes.consumers.supervisor;
 
-import com.google.common.collect.ImmutableList;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import pl.allegro.tech.hermes.api.Subscription;
@@ -15,8 +14,6 @@ import pl.allegro.tech.hermes.consumers.consumer.Consumer;
 import pl.allegro.tech.hermes.consumers.consumer.offset.OffsetCommitter;
 import pl.allegro.tech.hermes.consumers.consumer.receiver.MessageCommitter;
 import pl.allegro.tech.hermes.consumers.message.undelivered.UndeliveredMessageLogPersister;
-import pl.allegro.tech.hermes.consumers.subscription.cache.SubscriptionCallback;
-import pl.allegro.tech.hermes.consumers.subscription.cache.SubscriptionsCache;
 import pl.allegro.tech.hermes.domain.subscription.SubscriptionRepository;
 import pl.allegro.tech.hermes.domain.subscription.offset.PartitionOffset;
 import pl.allegro.tech.hermes.domain.subscription.offset.PartitionOffsets;
@@ -31,7 +28,7 @@ import static pl.allegro.tech.hermes.api.Subscription.State.PENDING;
 import static pl.allegro.tech.hermes.api.Subscription.State.SUSPENDED;
 import static pl.allegro.tech.hermes.common.config.Configs.KAFKA_CLUSTER_NAME;
 
-public class ConsumersSupervisor implements SubscriptionCallback, AdminOperationsCallback {
+public class ConsumersSupervisor implements AdminOperationsCallback {
 
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ConsumersSupervisor.class);
@@ -46,7 +43,6 @@ public class ConsumersSupervisor implements SubscriptionCallback, AdminOperation
     private final HermesMetrics hermesMetrics;
     private final OffsetCommitter offsetCommitter;
     private final ConsumerHolder consumerHolder;
-    private final SubscriptionsCache subscriptionsCache;
     private final ZookeeperAdminCache adminCache;
     private final SubscriptionLocks subscriptionsLocks;
 
@@ -61,7 +57,6 @@ public class ConsumersSupervisor implements SubscriptionCallback, AdminOperation
                                ConsumerFactory consumerFactory,
                                List<MessageCommitter> messageCommitters,
                                List<OffsetsStorage> offsetsStorages,
-                               SubscriptionsCache subscriptionsCache,
                                HermesMetrics hermesMetrics,
                                ZookeeperAdminCache adminCache,
                                UndeliveredMessageLogPersister undeliveredMessageLogPersister) {
@@ -71,7 +66,6 @@ public class ConsumersSupervisor implements SubscriptionCallback, AdminOperation
         this.consumerFactory = consumerFactory;
         this.offsetsStorages = offsetsStorages;
         this.messageCommitters = messageCommitters;
-        this.subscriptionsCache = subscriptionsCache;
         this.adminCache = adminCache;
         this.hermesMetrics = hermesMetrics;
         this.undeliveredMessageLogPersister = undeliveredMessageLogPersister;
@@ -84,8 +78,7 @@ public class ConsumersSupervisor implements SubscriptionCallback, AdminOperation
         brokersClusterName = configFactory.getStringProperty(KAFKA_CLUSTER_NAME);
     }
 
-    @Override
-    public void onSubscriptionCreated(Subscription subscription) {
+    public void assignConsumerForSubscription(Subscription subscription) {
         synchronized (subscriptionsLocks.getLock(subscription)) {
             try {
                 if (subscription.getState() == PENDING) {
@@ -102,8 +95,7 @@ public class ConsumersSupervisor implements SubscriptionCallback, AdminOperation
         }
     }
 
-    @Override
-    public void onSubscriptionRemoved(Subscription subscription) {
+    public void deleteConsumerForSubscription(Subscription subscription) {
         synchronized (subscriptionsLocks.getLock(subscription)) {
             try {
                 deleteConsumerIfExists(subscription, true);
@@ -114,8 +106,8 @@ public class ConsumersSupervisor implements SubscriptionCallback, AdminOperation
         }
     }
 
-    @Override
-    public void onSubscriptionChanged(Subscription modifiedSubscription) {
+    @Deprecated
+    public void notifyConsumerOnSubscriptionUpdate(Subscription modifiedSubscription) {
         synchronized (subscriptionsLocks.getLock(modifiedSubscription)) {
             try {
                 Optional<Consumer> consumerOptional = consumerHolder.get(modifiedSubscription.getTopicName(), modifiedSubscription.getName());
@@ -133,15 +125,24 @@ public class ConsumersSupervisor implements SubscriptionCallback, AdminOperation
         }
     }
 
+    public void updateSubscription(Subscription modifiedSubscription) {
+        synchronized (subscriptionsLocks.getLock(modifiedSubscription)) {
+            consumerHolder.get(modifiedSubscription.getTopicName(), modifiedSubscription.getName()).
+                    ifPresent((consumer) -> consumer.updateSubscription(modifiedSubscription));
+        }
+    }
+
     private void activateSubscription(Subscription subscription) {
         subscription.setState(Subscription.State.ACTIVE);
         subscriptionRepository.updateSubscription(subscription);
     }
 
+    @Deprecated
     private boolean subscriptionStateChanged(Subscription modifiedSubscription, Subscription.State oldState) {
         return oldState != modifiedSubscription.getState() && oldState != PENDING;
     }
 
+    @Deprecated
     private void handleSubscriptionStateChange(Subscription.State oldState,
                                                Subscription.State newState,
                                                Subscription modifiedSubscription) throws Exception {
@@ -169,7 +170,6 @@ public class ConsumersSupervisor implements SubscriptionCallback, AdminOperation
     }
 
     public void start() throws Exception {
-        subscriptionsCache.start(ImmutableList.of(this));
         adminCache.start();
         adminCache.addCallback(this);
         offsetCommitter.start();

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/workTracking/LegacyMirroringSupervisorController.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/workTracking/LegacyMirroringSupervisorController.java
@@ -1,0 +1,44 @@
+package pl.allegro.tech.hermes.consumers.supervisor.workTracking;
+
+import com.google.common.collect.ImmutableList;
+import pl.allegro.tech.hermes.api.Subscription;
+import pl.allegro.tech.hermes.consumers.subscription.cache.SubscriptionsCache;
+import pl.allegro.tech.hermes.consumers.supervisor.ConsumersSupervisor;
+
+public class LegacyMirroringSupervisorController implements SupervisorController {
+    private final ConsumersSupervisor supervisor;
+    private final SubscriptionsCache subscriptionsCache;
+
+    public LegacyMirroringSupervisorController(ConsumersSupervisor supervisor,
+                                               SubscriptionsCache subscriptionsCache) {
+        this.supervisor = supervisor;
+        this.subscriptionsCache = subscriptionsCache;
+    }
+
+    @Override
+    public void onSubscriptionCreated(Subscription subscription) {
+        supervisor.assignConsumerForSubscription(subscription);
+    }
+
+    @Override
+    public void onSubscriptionRemoved(Subscription subscription) {
+        supervisor.deleteConsumerForSubscription(subscription);
+    }
+
+    @Override
+    public void onSubscriptionChanged(Subscription subscription) {
+        supervisor.notifyConsumerOnSubscriptionUpdate(subscription);
+    }
+
+
+    @Override
+    public void start() throws Exception {
+        subscriptionsCache.start(ImmutableList.of(this));
+        supervisor.start();
+    }
+
+    @Override
+    public void shutdown() throws InterruptedException {
+        supervisor.shutdown();
+    }
+}

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/workTracking/MirroringSupervisorController.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/workTracking/MirroringSupervisorController.java
@@ -1,0 +1,68 @@
+package pl.allegro.tech.hermes.consumers.supervisor.workTracking;
+
+import com.google.common.collect.ImmutableList;
+import pl.allegro.tech.hermes.api.Subscription;
+import pl.allegro.tech.hermes.consumers.subscription.cache.SubscriptionsCache;
+import pl.allegro.tech.hermes.consumers.supervisor.ConsumersSupervisor;
+
+public class MirroringSupervisorController implements SupervisorController {
+    private ConsumersSupervisor supervisor;
+    private SubscriptionsCache subscriptionsCache;
+    private WorkTracker workTracker;
+
+    public MirroringSupervisorController(ConsumersSupervisor supervisor,
+                                         SubscriptionsCache subscriptionsCache,
+                                         WorkTracker workTracker) {
+        this.supervisor = supervisor;
+        this.subscriptionsCache = subscriptionsCache;
+        this.workTracker = workTracker;
+    }
+
+    @Override
+    public void onSubscriptionCreated(Subscription subscription) {
+        workTracker.forceAssignment(subscription);
+    }
+
+    @Override
+    public void onSubscriptionRemoved(Subscription subscription) {
+        workTracker.dropAssignment(subscription);
+    }
+
+    @Override
+    public void onSubscriptionChanged(Subscription subscription) {
+        switch (subscription.getState()) {
+            case PENDING:
+            case ACTIVE:
+                workTracker.forceAssignment(subscription);
+                break;
+            case SUSPENDED:
+                workTracker.dropAssignment(subscription);
+                break;
+            default:
+                break;
+        }
+        supervisor.updateSubscription(subscription);
+    }
+
+    @Override
+    public void onSubscriptionAssigned(Subscription subscription) {
+        supervisor.assignConsumerForSubscription(subscription);
+    }
+
+    @Override
+    public void onAssignmentRemoved(Subscription subscription) {
+        supervisor.deleteConsumerForSubscription(subscription);
+    }
+
+    @Override
+    public void start() throws Exception {
+        subscriptionsCache.start(ImmutableList.of(this));
+        workTracker.start(ImmutableList.of(this));
+        supervisor.start();
+    }
+
+    @Override
+    public void shutdown() throws InterruptedException {
+        supervisor.shutdown();
+    }
+}

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/workTracking/SubscriptionAssignment.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/workTracking/SubscriptionAssignment.java
@@ -1,0 +1,21 @@
+package pl.allegro.tech.hermes.consumers.supervisor.workTracking;
+
+import pl.allegro.tech.hermes.api.SubscriptionName;
+
+public class SubscriptionAssignment {
+    private final String supervisorId;
+    private final SubscriptionName subscriptionName;
+
+    public SubscriptionAssignment(String supervisorId, SubscriptionName subscriptionName) {
+        this.supervisorId = supervisorId;
+        this.subscriptionName = subscriptionName;
+    }
+
+    public String getSupervisorId() {
+        return supervisorId;
+    }
+
+    public SubscriptionName getSubscriptionName() {
+        return subscriptionName;
+    }
+}

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/workTracking/SubscriptionAssignmentAware.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/workTracking/SubscriptionAssignmentAware.java
@@ -1,0 +1,8 @@
+package pl.allegro.tech.hermes.consumers.supervisor.workTracking;
+
+import pl.allegro.tech.hermes.api.Subscription;
+
+public interface SubscriptionAssignmentAware {
+    default void onSubscriptionAssigned(Subscription subscription) {}
+    default void onAssignmentRemoved(Subscription subscription) {}
+}

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/workTracking/SubscriptionAssignmentPathSerializer.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/workTracking/SubscriptionAssignmentPathSerializer.java
@@ -1,0 +1,27 @@
+package pl.allegro.tech.hermes.consumers.supervisor.workTracking;
+
+import com.google.common.base.Joiner;
+import pl.allegro.tech.hermes.api.Subscription;
+import pl.allegro.tech.hermes.api.SubscriptionName;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+public class SubscriptionAssignmentPathSerializer {
+    private final String prefix;
+    private final String supervisorId;
+
+    public SubscriptionAssignmentPathSerializer(String prefix, String supervisorId) {
+        this.prefix = prefix;
+        this.supervisorId = supervisorId;
+    }
+
+    public String serialize(Subscription subscription) {
+        return Joiner.on("/").join(prefix, subscription.toSubscriptionName(), supervisorId);
+    }
+
+    public SubscriptionAssignment deserialize(String path) {
+        String[] paths = path.split("/");
+        checkArgument(paths.length > 1, "Incorrect path format. Expected:'/base/subscription/supervisorId'. Found:'%s'", path);
+        return new SubscriptionAssignment(paths[paths.length - 1], SubscriptionName.fromString(paths[paths.length - 2]));
+    }
+}

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/workTracking/SubscriptionAssignmentRegistry.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/workTracking/SubscriptionAssignmentRegistry.java
@@ -1,0 +1,51 @@
+package pl.allegro.tech.hermes.consumers.supervisor.workTracking;
+
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.recipes.cache.PathChildrenCacheEvent;
+import org.apache.curator.framework.recipes.cache.PathChildrenCacheListener;
+import pl.allegro.tech.hermes.api.Subscription;
+import pl.allegro.tech.hermes.common.cache.zookeeper.StartableCache;
+import pl.allegro.tech.hermes.domain.subscription.SubscriptionRepository;
+
+import java.util.concurrent.ExecutorService;
+
+public class SubscriptionAssignmentRegistry extends StartableCache<SubscriptionAssignmentAware> implements PathChildrenCacheListener {
+    private final SubscriptionRepository subscriptionRepository;
+    private final String supervisorId;
+    private final SubscriptionAssignmentPathSerializer pathSerializer;
+
+    public SubscriptionAssignmentRegistry(CuratorFramework curatorClient,
+                                          String path,
+                                          ExecutorService executorService,
+                                          SubscriptionRepository subscriptionRepository,
+                                          String supervisorId,
+                                          SubscriptionAssignmentPathSerializer pathSerializer) {
+        super(curatorClient, path, executorService);
+        this.subscriptionRepository = subscriptionRepository;
+        this.supervisorId = supervisorId;
+        this.pathSerializer = pathSerializer;
+        getListenable().addListener(this);
+    }
+
+    @Override
+    public void childEvent(CuratorFramework client, PathChildrenCacheEvent event) throws Exception {
+        SubscriptionAssignment path = pathSerializer.deserialize(event.getData().getPath());
+        if (this.supervisorId.equals(path.getSupervisorId())) {
+            Subscription subscription = subscriptionRepository.getSubscriptionDetails(path.getSubscriptionName());
+            switch (event.getType()) {
+                case CHILD_ADDED:
+                    for (SubscriptionAssignmentAware callback : callbacks) {
+                        callback.onSubscriptionAssigned(subscription);
+                    }
+                    break;
+                case CHILD_REMOVED:
+                    for (SubscriptionAssignmentAware callback : callbacks) {
+                        callback.onAssignmentRemoved(subscription);
+                    }
+                    break;
+                default:
+                    break;
+            }
+        }
+    }
+}

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/workTracking/SupervisorController.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/workTracking/SupervisorController.java
@@ -1,0 +1,8 @@
+package pl.allegro.tech.hermes.consumers.supervisor.workTracking;
+
+import pl.allegro.tech.hermes.consumers.subscription.cache.SubscriptionCallback;
+
+public interface SupervisorController extends SubscriptionCallback, SubscriptionAssignmentAware {
+    void start() throws Exception;
+    void shutdown() throws InterruptedException;
+}

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/workTracking/SupervisorControllerFactory.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/workTracking/SupervisorControllerFactory.java
@@ -1,0 +1,38 @@
+package pl.allegro.tech.hermes.consumers.supervisor.workTracking;
+
+import com.google.common.collect.ImmutableMap;
+import org.glassfish.hk2.api.Factory;
+import pl.allegro.tech.hermes.common.config.ConfigFactory;
+import pl.allegro.tech.hermes.consumers.subscription.cache.SubscriptionsCache;
+import pl.allegro.tech.hermes.consumers.supervisor.ConsumersSupervisor;
+
+import javax.inject.Inject;
+import javax.inject.Provider;
+import java.util.Map;
+
+import static pl.allegro.tech.hermes.common.config.Configs.CONSUMER_WORKLOAD_ALGORITHM;
+
+public class SupervisorControllerFactory implements Factory<SupervisorController> {
+    private final ConfigFactory configs;
+    private final Map<String, Provider<SupervisorController>> availableImplementations;
+
+    @Inject
+    public SupervisorControllerFactory(SubscriptionsCache subscriptionsCache,
+                                       WorkTracker workTracker,
+                                       ConsumersSupervisor supervisor, ConfigFactory configs) {
+        this.configs = configs;
+        this.availableImplementations = ImmutableMap.of(
+                "legacy.mirror", () -> new LegacyMirroringSupervisorController(supervisor, subscriptionsCache),
+                "mirror", () -> new MirroringSupervisorController(supervisor, subscriptionsCache, workTracker));
+    }
+
+    @Override
+    public SupervisorController provide() {
+        return availableImplementations.get(configs.getStringProperty(CONSUMER_WORKLOAD_ALGORITHM)).get();
+    }
+
+    @Override
+    public void dispose(SupervisorController instance) {
+
+    }
+}

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/workTracking/WorkTracker.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/workTracking/WorkTracker.java
@@ -1,0 +1,67 @@
+package pl.allegro.tech.hermes.consumers.supervisor.workTracking;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.zookeeper.KeeperException;
+import pl.allegro.tech.hermes.api.Subscription;
+import pl.allegro.tech.hermes.common.cache.zookeeper.NodeCache;
+import pl.allegro.tech.hermes.common.exception.InternalProcessingException;
+import pl.allegro.tech.hermes.domain.subscription.SubscriptionRepository;
+
+import java.util.concurrent.ExecutorService;
+
+import static org.apache.zookeeper.CreateMode.EPHEMERAL;
+
+public class WorkTracker extends NodeCache<SubscriptionAssignmentAware, SubscriptionAssignmentRegistry> {
+    private final SubscriptionRepository subscriptionRepository;
+    private final String supervisorId;
+    private final SubscriptionAssignmentPathSerializer pathSerializer;
+
+
+    public WorkTracker(CuratorFramework curatorClient,
+                       ObjectMapper objectMapper,
+                       String path,
+                       String supervisorId,
+                       ExecutorService executorService,
+                       SubscriptionRepository subscriptionRepository) {
+        super(curatorClient, objectMapper, path, executorService);
+        this.subscriptionRepository = subscriptionRepository;
+        this.supervisorId = supervisorId;
+        this.pathSerializer = new SubscriptionAssignmentPathSerializer(path, supervisorId);
+    }
+
+    public void forceAssignment(Subscription subscription) {
+        askCuratorPolitely(() ->
+                curatorClient.create().creatingParentsIfNeeded().withMode(EPHEMERAL).forPath(pathSerializer.serialize(subscription)));
+    }
+
+    public void dropAssignment(Subscription subscription) {
+        askCuratorPolitely(() ->
+                curatorClient.delete().guaranteed().forPath(pathSerializer.serialize(subscription)));
+    }
+
+    private void askCuratorPolitely(CuratorTask task) {
+        try {
+            task.run();
+        } catch (KeeperException.NodeExistsException | KeeperException.NoNodeException ex) {
+            // ignore
+        } catch (Exception ex) {
+            throw new InternalProcessingException(ex);
+        }
+    }
+
+    interface CuratorTask {
+        void run() throws Exception;
+    }
+
+    @Override
+    protected SubscriptionAssignmentRegistry createSubcache(String path) {
+        return new SubscriptionAssignmentRegistry(
+                curatorClient,
+                path,
+                executorService,
+                subscriptionRepository,
+                supervisorId,
+                pathSerializer);
+    }
+}

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/workTracking/WorkTrackerFactory.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/workTracking/WorkTrackerFactory.java
@@ -1,0 +1,54 @@
+package pl.allegro.tech.hermes.consumers.supervisor.workTracking;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.curator.framework.CuratorFramework;
+import org.glassfish.hk2.api.Factory;
+import pl.allegro.tech.hermes.common.config.ConfigFactory;
+import pl.allegro.tech.hermes.common.config.Configs;
+import pl.allegro.tech.hermes.common.di.CuratorType;
+import pl.allegro.tech.hermes.common.exception.InternalProcessingException;
+import pl.allegro.tech.hermes.domain.subscription.SubscriptionRepository;
+import pl.allegro.tech.hermes.infrastructure.zookeeper.ZookeeperPaths;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import java.io.IOException;
+import java.util.concurrent.ExecutorService;
+
+import static java.util.concurrent.Executors.newFixedThreadPool;
+import static pl.allegro.tech.hermes.common.config.Configs.CONSUMER_WORKLOAD_ID;
+
+public class WorkTrackerFactory implements Factory<WorkTracker> {
+    private final CuratorFramework curatorClient;
+    private final ConfigFactory configFactory;
+    private final ObjectMapper objectMapper;
+    private final SubscriptionRepository subscriptionRepository;
+
+    @Inject
+    public WorkTrackerFactory(@Named(CuratorType.HERMES) CuratorFramework curatorClient,
+                              ConfigFactory configFactory,
+                              ObjectMapper objectMapper,
+                              SubscriptionRepository subscriptionRepository) {
+        this.curatorClient = curatorClient;
+        this.configFactory = configFactory;
+        this.objectMapper = objectMapper;
+        this.subscriptionRepository = subscriptionRepository;
+    }
+
+    @Override
+    public WorkTracker provide() {
+        ZookeeperPaths paths = new ZookeeperPaths(configFactory.getStringProperty(Configs.ZOOKEEPER_ROOT));
+        ExecutorService executorService = newFixedThreadPool(configFactory.getIntProperty(Configs.ZOOKEEPER_CACHE_THREAD_POOL_SIZE));
+        String supervisorId = configFactory.getStringProperty(CONSUMER_WORKLOAD_ID);
+        return new WorkTracker(curatorClient, objectMapper, paths.consumersRuntimePath(), supervisorId, executorService, subscriptionRepository);
+    }
+
+    @Override
+    public void dispose(WorkTracker instance) {
+        try {
+            instance.stop();
+        } catch (IOException e) {
+            throw new InternalProcessingException(e);
+        }
+    }
+}

--- a/hermes-test-helper/src/main/java/pl/allegro/tech/hermes/test/helper/endpoint/Waiter.java
+++ b/hermes-test-helper/src/main/java/pl/allegro/tech/hermes/test/helper/endpoint/Waiter.java
@@ -20,7 +20,7 @@ public class Waiter {
     }
 
     public void untilSubscriptionCreated(String group, String topic, String subscription, boolean isTracked) {
-        waitAtMost(adjust(Duration.ONE_MINUTE)).until(() ->
+        waitAtMost(adjust(Duration.TWO_MINUTES)).until(() ->
             endpoints.subscription().list(group + "." + topic, isTracked).contains(subscription)
         );
     }

--- a/integration/src/integration/java/pl/allegro/tech/hermes/integration/helper/Waiter.java
+++ b/integration/src/integration/java/pl/allegro/tech/hermes/integration/helper/Waiter.java
@@ -81,7 +81,7 @@ public class Waiter extends pl.allegro.tech.hermes.test.helper.endpoint.Waiter {
     }
 
     private void untilSubscriptionHasState(String group, String topic, String subscription, Subscription.State state) {
-        waitAtMost(adjust(Duration.ONE_MINUTE)).until(() ->
+        waitAtMost(adjust(Duration.TWO_MINUTES)).until(() ->
                         endpoints.subscription().get(group + "." + topic, subscription).getState().equals(state)
         );
     }

--- a/integration/src/integration/java/pl/allegro/tech/hermes/integration/management/GroupManagementTest.java
+++ b/integration/src/integration/java/pl/allegro/tech/hermes/integration/management/GroupManagementTest.java
@@ -8,6 +8,8 @@ import pl.allegro.tech.hermes.integration.IntegrationTest;
 
 import javax.ws.rs.core.Response;
 
+import java.util.stream.Stream;
+
 import static pl.allegro.tech.hermes.api.ErrorCode.VALIDATION_ERROR;
 import static pl.allegro.tech.hermes.api.Group.Builder.group;
 import static pl.allegro.tech.hermes.api.Topic.Builder.topic;
@@ -99,5 +101,16 @@ public class GroupManagementTest extends IntegrationTest {
 
         // then
         assertThat(response).hasStatus(Response.Status.FORBIDDEN).hasErrorCode(ErrorCode.GROUP_NOT_EMPTY);
+    }
+
+    @Test
+    public void shouldNotAllowDollarSigns() {
+        Stream.of("$name", "na$me", "name$").forEach(name -> {
+            // when
+            Response response = management.group().create(Group.from(name));
+
+            // then
+            assertThat(response).hasStatus(Response.Status.BAD_REQUEST);
+        });
     }
 }

--- a/integration/src/integration/java/pl/allegro/tech/hermes/integration/management/TopicManagementTest.java
+++ b/integration/src/integration/java/pl/allegro/tech/hermes/integration/management/TopicManagementTest.java
@@ -9,6 +9,7 @@ import pl.allegro.tech.hermes.integration.IntegrationTest;
 
 import javax.ws.rs.core.Response;
 import java.util.List;
+import java.util.stream.Stream;
 
 import static pl.allegro.tech.hermes.api.Subscription.Builder.subscription;
 import static pl.allegro.tech.hermes.api.Topic.Builder.topic;
@@ -127,5 +128,20 @@ public class TopicManagementTest extends IntegrationTest {
         // then
         assertThat(tracked).contains("mixedTrackedGroup.trackedTopic")
                            .doesNotContain("mixedTrackedGroup.untrackedTopic");
+    }
+
+    @Test
+    public void shouldNotAllowDollarSign() {
+        // given
+        operations.createGroup("dollar");
+
+        Stream.of("$name", "na$me", "name$").forEach(topic -> {
+            // when
+            Response response = management.topic().create(
+                    topic().withName("dollar", topic).applyDefaults().build());
+
+            // then
+            assertThat(response).hasStatus(Response.Status.BAD_REQUEST);
+        });
     }
 }


### PR DESCRIPTION
Initial version of new consumer runtime model. Designed to be extended by introducing more advanced workload spread algorithms.

Two basic implementations are provided:
- **legacy.mirror** - consumers are mirroring each other without using new runtime model (legacy behaviour)
- **mirror** - consumers are mirroring each other using new runtime model, the difference between *legacy.mirror* is another level of indirection between change in *SubscriptionCache* and spawning new consumers

New runtime model is based on a structure in zk reflecting which consumer supervisor is assigned to which subscription. Structure looks as follows:

/hermes/consumers/**runtime**/*qualified_topic_name$subscription_name*/*(supervisor_id)+*
