### PR TITLE
subscription lag source

### DIFF
--- a/hermes-api/src/main/java/pl/allegro/tech/hermes/api/SubscriptionMetrics.java
+++ b/hermes-api/src/main/java/pl/allegro/tech/hermes/api/SubscriptionMetrics.java
@@ -6,6 +6,7 @@ public class SubscriptionMetrics {
     private long delivered;
     private long discarded;
     private long inflight;
+    private long lag;
     private String rate = "0.0";
     private Subscription.State state;
 
@@ -31,6 +32,14 @@ public class SubscriptionMetrics {
 
     public void setInflight(long inflight) {
         this.inflight = inflight;
+    }
+
+    public long getLag() {
+        return lag;
+    }
+
+    public void setLag(long lag) {
+        this.lag = lag;
     }
 
     public String getRate() {
@@ -99,6 +108,11 @@ public class SubscriptionMetrics {
 
         public Builder withState(Subscription.State state) {
             subscriptionMetrics.state = state;
+            return this;
+        }
+
+        public Builder withLag(long lag) {
+            subscriptionMetrics.lag = lag;
             return this;
         }
 

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/config/ManagementConfiguration.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/config/ManagementConfiguration.java
@@ -7,10 +7,13 @@ import com.fasterxml.jackson.databind.SerializationFeature;
 import org.glassfish.jersey.client.ClientConfig;
 import org.glassfish.jersey.client.ClientProperties;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import pl.allegro.tech.hermes.management.domain.subscription.SubscriptionLagSource;
 import pl.allegro.tech.hermes.management.infrastructure.graphite.GraphiteClient;
+import pl.allegro.tech.hermes.management.infrastructure.metrics.NoOpSubscriptionLagSource;
 import pl.allegro.tech.hermes.management.stub.MetricsPaths;
 
 import javax.ws.rs.client.Client;
@@ -39,7 +42,7 @@ public class ManagementConfiguration {
     public Client jerseyClient() {
         ClientConfig config = new ClientConfig();
         config.property(ClientProperties.CONNECT_TIMEOUT, httpClientProperties.getConnectTimeout());
-        config.property(ClientProperties.READ_TIMEOUT,    httpClientProperties.getReadTimeout());
+        config.property(ClientProperties.READ_TIMEOUT, httpClientProperties.getReadTimeout());
 
         return ClientBuilder.newClient(config);
     }
@@ -52,5 +55,11 @@ public class ManagementConfiguration {
     @Bean
     public GraphiteClient graphiteClient() {
         return new GraphiteClient(jerseyClient().target(metricsProperties.getGraphiteHttpUri()));
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public SubscriptionLagSource consumerLagSource() {
+        return new NoOpSubscriptionLagSource();
     }
 }

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/domain/subscription/SubscriptionLagSource.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/domain/subscription/SubscriptionLagSource.java
@@ -1,0 +1,7 @@
+package pl.allegro.tech.hermes.management.domain.subscription;
+
+import pl.allegro.tech.hermes.api.TopicName;
+
+public interface SubscriptionLagSource {
+    long getLag(TopicName topicName, String subscriptionName);
+}

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/infrastructure/metrics/HybridSubscriptionMetricsRepository.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/infrastructure/metrics/HybridSubscriptionMetricsRepository.java
@@ -7,6 +7,7 @@ import pl.allegro.tech.hermes.api.TopicName;
 import pl.allegro.tech.hermes.infrastructure.zookeeper.ZookeeperPaths;
 import pl.allegro.tech.hermes.infrastructure.zookeeper.counter.DistributedEphemeralCounter;
 import pl.allegro.tech.hermes.infrastructure.zookeeper.counter.SharedCounter;
+import pl.allegro.tech.hermes.management.domain.subscription.SubscriptionLagSource;
 import pl.allegro.tech.hermes.management.domain.subscription.SubscriptionMetricsRepository;
 import pl.allegro.tech.hermes.management.infrastructure.graphite.GraphiteClient;
 import pl.allegro.tech.hermes.management.infrastructure.graphite.GraphiteMetrics;
@@ -29,15 +30,18 @@ public class HybridSubscriptionMetricsRepository implements SubscriptionMetricsR
 
     private final ZookeeperPaths zookeeperPaths;
 
+    private final SubscriptionLagSource lagSource;
+
     @Autowired
     public HybridSubscriptionMetricsRepository(GraphiteClient graphiteClient, MetricsPaths metricsPaths,
                                                SharedCounter sharedCounter, DistributedEphemeralCounter distributedCounter,
-                                               ZookeeperPaths zookeeperPaths) {
+                                               ZookeeperPaths zookeeperPaths, SubscriptionLagSource lagSource) {
         this.graphiteClient = graphiteClient;
         this.metricsPaths = metricsPaths;
         this.sharedCounter = sharedCounter;
         this.distributedCounter = distributedCounter;
         this.zookeeperPaths = zookeeperPaths;
+        this.lagSource = lagSource;
     }
 
     @Override
@@ -54,6 +58,7 @@ public class HybridSubscriptionMetricsRepository implements SubscriptionMetricsR
                         zookeeperPaths.consumersPath(),
                         zookeeperPaths.subscriptionMetricPathWithoutBasePath(topicName, subscriptionName, "inflight")
                 ))
+                .withLag(lagSource.getLag(topicName, subscriptionName))
                 .build();
     }
 

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/infrastructure/metrics/NoOpSubscriptionLagSource.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/infrastructure/metrics/NoOpSubscriptionLagSource.java
@@ -1,0 +1,11 @@
+package pl.allegro.tech.hermes.management.infrastructure.metrics;
+
+import pl.allegro.tech.hermes.api.TopicName;
+import pl.allegro.tech.hermes.management.domain.subscription.SubscriptionLagSource;
+
+public class NoOpSubscriptionLagSource implements SubscriptionLagSource {
+    @Override
+    public long getLag(TopicName topicName, String subscriptionName) {
+        return -1;
+    }
+}

--- a/hermes-management/src/test/groovy/pl/allegro/tech/hermes/management/infrastructure/metrics/HybridSubscriptionMetricsRepositoryTest.groovy
+++ b/hermes-management/src/test/groovy/pl/allegro/tech/hermes/management/infrastructure/metrics/HybridSubscriptionMetricsRepositoryTest.groovy
@@ -5,6 +5,7 @@ import pl.allegro.tech.hermes.api.TopicName
 import pl.allegro.tech.hermes.infrastructure.zookeeper.ZookeeperPaths
 import pl.allegro.tech.hermes.infrastructure.zookeeper.counter.DistributedEphemeralCounter
 import pl.allegro.tech.hermes.infrastructure.zookeeper.counter.SharedCounter
+import pl.allegro.tech.hermes.management.domain.subscription.SubscriptionLagSource
 import pl.allegro.tech.hermes.management.infrastructure.graphite.GraphiteClient
 import pl.allegro.tech.hermes.management.infrastructure.graphite.GraphiteMetrics
 import pl.allegro.tech.hermes.management.stub.MetricsPaths
@@ -22,8 +23,10 @@ class HybridSubscriptionMetricsRepositoryTest extends Specification {
 
     private ZookeeperPaths zookeeperPaths = new ZookeeperPaths("/hermes")
 
+    private SubscriptionLagSource lagSource = new NoOpSubscriptionLagSource()
+
     private HybridSubscriptionMetricsRepository repository = new HybridSubscriptionMetricsRepository(client, paths,
-            sharedCounter, distributedCounter, zookeeperPaths)
+            sharedCounter, distributedCounter, zookeeperPaths, lagSource)
 
     def "should read subscription metrics from multiple places"() {
         given:
@@ -42,5 +45,6 @@ class HybridSubscriptionMetricsRepositoryTest extends Specification {
         metrics.delivered == 100
         metrics.discarded == 1
         metrics.inflight == 5
+        metrics.lag == -1
     }
 }


### PR DESCRIPTION
adds subscription lag property to object returned by management's `topics/{topicName}/subscriptions/{subscriptionName}/metrics` endpoint. with no custom implementation of the lag provider `-1` is returned.