### PR TITLE
269 extended customization via startup hooks

### DIFF
--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/common/hook/Hook.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/common/hook/Hook.java
@@ -1,5 +1,14 @@
 package pl.allegro.tech.hermes.common.hook;
 
+import org.glassfish.hk2.api.ServiceLocator;
+
 public interface Hook {
-    void apply();
+    interface Startup {
+        void apply(ServiceLocator serviceLocator);
+    }
+
+    interface Shutdown {
+        void apply();
+    }
+
 }

--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/common/hook/HooksHandler.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/common/hook/HooksHandler.java
@@ -1,27 +1,29 @@
 package pl.allegro.tech.hermes.common.hook;
 
+import org.glassfish.hk2.api.ServiceLocator;
+
 import java.util.ArrayList;
 import java.util.List;
 
 public class HooksHandler {
-    private final List<Hook> startupHooks = new ArrayList<>();
-    private final List<Hook> shutdownHooks = new ArrayList<>();
+    private final List<Hook.Startup> startupHooks = new ArrayList<>();
+    private final List<Hook.Shutdown> shutdownHooks = new ArrayList<>();
 
-    public void addStartupHook(Hook hook) {
+    public void addStartupHook(Hook.Startup hook) {
         startupHooks.add(hook);
     }
 
-    public void addShutdownHook(Hook hook) {
+    public void addShutdownHook(Hook.Shutdown hook) {
         shutdownHooks.add(hook);
     }
 
     public void shutdown() {
-        shutdownHooks.forEach(Hook::apply);
+        shutdownHooks.forEach(Hook.Shutdown::apply);
     }
 
-    public void startup() {
+    public void startup(ServiceLocator serviceLocator) {
         registerGlobalShutdownHook();
-        startupHooks.forEach(Hook::apply);
+        startupHooks.forEach(hook -> hook.apply(serviceLocator));
     }
 
     private void registerGlobalShutdownHook() {

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/HermesConsumers.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/HermesConsumers.java
@@ -78,7 +78,7 @@ public class HermesConsumers {
 
             supervisorController.start();
             healthCheckServer.start();
-            hooksHandler.startup();
+            hooksHandler.startup(serviceLocator);
         } catch (Exception e) {
             logger.error("Exception while starting Hermes Consumers", e);
         }

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/HermesConsumersBuilder.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/HermesConsumersBuilder.java
@@ -31,12 +31,12 @@ public final class HermesConsumersBuilder {
             new ConsumersBinder(),
             new ProtocolMessageSenderProvidersBinder());
 
-    public HermesConsumersBuilder withShutdownHook(Hook hook) {
+    public HermesConsumersBuilder withShutdownHook(Hook.Shutdown hook) {
         hooksHandler.addShutdownHook(hook);
         return this;
     }
 
-    public HermesConsumersBuilder withStartupHook(Hook hook) {
+    public HermesConsumersBuilder withStartupHook(Hook.Startup hook) {
         hooksHandler.addStartupHook(hook);
         return this;
     }

--- a/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/HermesFrontend.java
+++ b/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/HermesFrontend.java
@@ -44,7 +44,6 @@ public final class HermesFrontend {
     private HermesFrontend(HooksHandler hooksHandler, List<Binder> binders, List<Function<ServiceLocator, LogRepository>> logRepositories) {
         this.hooksHandler = hooksHandler;
         this.logRepositories = logRepositories;
-
         serviceLocator = createDIContainer(binders);
 
         hermesServer = serviceLocator.getService(HermesServer.class);
@@ -54,7 +53,7 @@ public final class HermesFrontend {
             hooksHandler.addShutdownHook(gracefulShutdownHook());
         }
 
-        hooksHandler.addStartupHook(() -> serviceLocator.getService(HealthCheckService.class).startup());
+        hooksHandler.addStartupHook((serviceLocator) -> serviceLocator.getService(HealthCheckService.class).startup());
         hooksHandler.addShutdownHook(defaultShutdownHook());
     }
 
@@ -82,7 +81,7 @@ public final class HermesFrontend {
                 trackers.add(serviceLocatorLogRepositoryFunction.apply(serviceLocator)));
 
         hermesServer.start();
-        hooksHandler.startup();
+        hooksHandler.startup(serviceLocator);
     }
 
     public void stop() {
@@ -122,12 +121,12 @@ public final class HermesFrontend {
             return new HermesFrontend(hooksHandler, binders, logRepositories);
         }
 
-        public Builder withShutdownHook(Hook hook) {
+        public Builder withShutdownHook(Hook.Shutdown hook) {
             hooksHandler.addShutdownHook(hook);
             return this;
         }
 
-        public Builder withStartupHook(Hook hook) {
+        public Builder withStartupHook(Hook.Startup hook) {
             hooksHandler.addStartupHook(hook);
             return this;
         }

--- a/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/server/AbstractShutdownHook.java
+++ b/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/server/AbstractShutdownHook.java
@@ -4,7 +4,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import pl.allegro.tech.hermes.common.hook.Hook;
 
-public abstract class AbstractShutdownHook implements Hook {
+public abstract class AbstractShutdownHook implements Hook.Shutdown {
 
     private static final Logger logger = LoggerFactory.getLogger(AbstractShutdownHook.class);
 


### PR DESCRIPTION
This PR makes ServiceLocator available for startup hooks. This is especially useful for adding support for custom metrics reporter (e.g. Kairos).