### PR TITLE
276 moved hostname to reporter prefix

### DIFF
--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/common/metric/Counters.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/common/metric/Counters.java
@@ -1,7 +1,6 @@
 package pl.allegro.tech.hermes.common.metric;
 
 import static pl.allegro.tech.hermes.metrics.PathsCompiler.GROUP;
-import static pl.allegro.tech.hermes.metrics.PathsCompiler.HOSTNAME;
 import static pl.allegro.tech.hermes.metrics.PathsCompiler.EXECUTOR_NAME;
 import static pl.allegro.tech.hermes.metrics.PathsCompiler.PARTITION;
 import static pl.allegro.tech.hermes.metrics.PathsCompiler.SUBSCRIPTION;
@@ -9,13 +8,12 @@ import static pl.allegro.tech.hermes.metrics.PathsCompiler.TOPIC;
 
 public class Counters {
 
-    public static final String PRODUCER_PUBLISHED = "producer." + HOSTNAME + ".published." + GROUP + "." + TOPIC,
-            PRODUCER_UNPUBLISHED = "producer." + HOSTNAME + ".unpublished." + GROUP + "." + TOPIC,
-            CONSUMER_DELIVERED = "consumer." + HOSTNAME + ".delivered." + GROUP + "." + TOPIC + "." + SUBSCRIPTION,
-            CONSUMER_DISCARDED = "consumer." + HOSTNAME + ".discarded." + GROUP + "." + TOPIC + "." + SUBSCRIPTION,
-            CONSUMER_INFLIGHT = "consumer." + HOSTNAME + ".inflight." + GROUP + "." + TOPIC + "." + SUBSCRIPTION,
-            CONSUMER_OFFSET_COMMIT_IDLE = "consumer." + HOSTNAME + ".offset-commit-idle." + GROUP + "." + TOPIC + "." + SUBSCRIPTION
-                    + "." + PARTITION,
-            CONSUMER_EXECUTOR_RUNNING = "consumer." + HOSTNAME + ".executors." + EXECUTOR_NAME + ".running",
-            CONSUMER_SCHEDULED_EXECUTOR_OVERRUN = "consumer." + HOSTNAME + ".executors." + EXECUTOR_NAME + ".overrun";
+    public static final String PUBLISHED = "published." + GROUP + "." + TOPIC,
+            UNPUBLISHED = "unpublished." + GROUP + "." + TOPIC,
+            DELIVERED = "delivered." + GROUP + "." + TOPIC + "." + SUBSCRIPTION,
+            DISCARDED = "discarded." + GROUP + "." + TOPIC + "." + SUBSCRIPTION,
+            INFLIGHT = "inflight." + GROUP + "." + TOPIC + "." + SUBSCRIPTION,
+            OFFSET_COMMIT_IDLE = "offset-commit-idle." + GROUP + "." + TOPIC + "." + SUBSCRIPTION + "." + PARTITION,
+            EXECUTOR_RUNNING = "executors." + EXECUTOR_NAME + ".running",
+            SCHEDULED_EXECUTOR_OVERRUN = "executors." + EXECUTOR_NAME + ".overrun";
 }

--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/common/metric/Gauges.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/common/metric/Gauges.java
@@ -1,20 +1,19 @@
 package pl.allegro.tech.hermes.common.metric;
 
 import static pl.allegro.tech.hermes.metrics.PathsCompiler.GROUP;
-import static pl.allegro.tech.hermes.metrics.PathsCompiler.HOSTNAME;
 import static pl.allegro.tech.hermes.metrics.PathsCompiler.SUBSCRIPTION;
 import static pl.allegro.tech.hermes.metrics.PathsCompiler.TOPIC;
 
 public class Gauges {
 
-    public static final String PRODUCER_EVERYONE_CONFIRMS_BUFFER_TOTAL_BYTES = "producer." + HOSTNAME + ".everyone-confirms-buffer-total-bytes",
-            PRODUCER_EVERYONE_CONFIRMS_BUFFER_AVAILABLE_BYTES = "producer." + HOSTNAME + ".everyone-confirms-buffer-available-bytes",
-            PRODUCER_EVERYONE_CONFIRMS_COMPRESSION_RATE = "producer." + HOSTNAME + ".everyone-confirms-compression-rate-avg",
-            PRODUCER_LEADER_CONFIRMS_BUFFER_TOTAL_BYTES = "producer." + HOSTNAME + ".leader-confirms-buffer-total-bytes",
-            PRODUCER_LEADER_CONFIRMS_BUFFER_AVAILABLE_BYTES = "producer." + HOSTNAME + ".leader-confirms-buffer-available-bytes",
-            PRODUCER_LEADER_CONFIRMS_COMPRESSION_RATE = "producer." + HOSTNAME + ".leader-confirms-compression-rate-avg",
-            PRODUCER_JMX_PREFIX = "producer." + HOSTNAME + ".jmx",
+    public static final String EVERYONE_CONFIRMS_BUFFER_TOTAL_BYTES = "everyone-confirms-buffer-total-bytes",
+            EVERYONE_CONFIRMS_BUFFER_AVAILABLE_BYTES = "everyone-confirms-buffer-available-bytes",
+            EVERYONE_CONFIRMS_COMPRESSION_RATE = "everyone-confirms-compression-rate-avg",
+            LEADER_CONFIRMS_BUFFER_TOTAL_BYTES = "leader-confirms-buffer-total-bytes",
+            LEADER_CONFIRMS_BUFFER_AVAILABLE_BYTES = "leader-confirms-buffer-available-bytes",
+            LEADER_CONFIRMS_COMPRESSION_RATE = "leader-confirms-compression-rate-avg",
+            JMX_PREFIX = "jmx",
 
-            CONSUMER_THREADS = "consumer." + HOSTNAME + ".threads",
-            CONSUMER_OUTPUT_RATE = "consumer." + HOSTNAME + ".output-rate." + GROUP + "." + TOPIC + "." + SUBSCRIPTION;
+            THREADS = "threads",
+            OUTPUT_RATE = "output-rate." + GROUP + "." + TOPIC + "." + SUBSCRIPTION;
 }

--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/common/metric/Histograms.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/common/metric/Histograms.java
@@ -3,9 +3,9 @@ package pl.allegro.tech.hermes.common.metric;
 import static pl.allegro.tech.hermes.metrics.PathsCompiler.*;
 
 public class Histograms {
-    public static final String PRODUCER_MESSAGE_SIZE = "producer." + HOSTNAME + ".message-size." + GROUP + "." + TOPIC,
-            PRODUCER_GLOBAL_MESSAGE_SIZE = "producer." + HOSTNAME + ".message-size",
-            CONSUMER_INFLIGHT_TIME = "consumer." + HOSTNAME + ".inflight." + GROUP + "." + TOPIC + "." + SUBSCRIPTION + ".time",
+    public static final String MESSAGE_SIZE = "message-size." + GROUP + "." + TOPIC,
+            GLOBAL_MESSAGE_SIZE = "message-size",
+            INFLIGHT_TIME = "inflight." + GROUP + "." + TOPIC + "." + SUBSCRIPTION + ".time",
             CONSUMERS_WORKLOAD_SELECTIVE_MISSING_RESOURCES = "consumers-workload." + KAFKA_CLUSTER + ".selective.missing-resources",
             CONSUMERS_WORKLOAD_SELECTIVE_DELETED_ASSIGNMENTS = "consumers-workload." + KAFKA_CLUSTER + ".selective.deleted-assignments",
             CONSUMERS_WORKLOAD_SELECTIVE_CREATED_ASSIGNMENTS = "consumers-workload." + KAFKA_CLUSTER + ".selective.created-assignments";

--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/common/metric/Meters.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/common/metric/Meters.java
@@ -4,34 +4,29 @@ import static pl.allegro.tech.hermes.metrics.PathsCompiler.*;
 
 public class Meters {
 
-    public static final String PRODUCER_METER = "producer." + HOSTNAME + ".meter",
-            PRODUCER_TOPIC_METER = PRODUCER_METER + "." + GROUP + "." + TOPIC,
+    public static final String
+        METER = "meter",
+        TOPIC_METER = METER + "." + GROUP + "." + TOPIC,
+        SUBSCRIPTION_METER = TOPIC_METER + "." + SUBSCRIPTION,
 
-    PRODUCER_FAILED_METER = "producer." + HOSTNAME + ".failed-meter",
-            PRODUCER_FAILED_TOPIC_METER = PRODUCER_FAILED_METER + "." + GROUP + "." + TOPIC,
+        FAILED_METER = "failed-meter",
+        FAILED_TOPIC_METER = FAILED_METER + "." + GROUP + "." + TOPIC,
 
-    PRODUCER_STATUS_CODES = "producer." + HOSTNAME + ".http-status-codes.code" + HTTP_CODE,
-            PRODUCER_TOPIC_STATUS_CODES = "producer." + HOSTNAME + ".http-status-codes." + GROUP + "." + TOPIC + ".code" + HTTP_CODE,
+        STATUS_CODES = "http-status-codes.code" + HTTP_CODE,
+        TOPIC_STATUS_CODES = "http-status-codes." + GROUP + "." + TOPIC + ".code" + HTTP_CODE,
 
-    CONSUMER_METER = "consumer." + HOSTNAME + ".meter",
-            CONSUMER_TOPIC_METER = CONSUMER_METER + "." + GROUP + "." + TOPIC,
-            CONSUMER_SUBSCRIPTION_METER = CONSUMER_TOPIC_METER + "." + SUBSCRIPTION,
+        ERRORS_TIMEOUTS = "status." + GROUP + "." + TOPIC + "." + SUBSCRIPTION + ".errors.timeout",
+        ERRORS_OTHER = "status." + GROUP + "." + TOPIC + "." + SUBSCRIPTION + ".errors.other",
+        ERRORS_HTTP_BY_FAMILY = "status." + GROUP + "." + TOPIC + "." + SUBSCRIPTION + "." + HTTP_CODE_FAMILY,
 
-    CONSUMER_ERRORS_TIMEOUTS = "consumer." + HOSTNAME + ".status." + GROUP + "." + TOPIC + "." + SUBSCRIPTION + ".errors.timeout",
+        ERRORS_HTTP_BY_CODE = ERRORS_HTTP_BY_FAMILY + "." + HTTP_CODE,
 
-    CONSUMER_ERRORS_OTHER = "consumer." + HOSTNAME + ".status." + GROUP + "." + TOPIC + "." + SUBSCRIPTION + ".errors.other",
+        FAILED_METER_SUBSCRIPTION = FAILED_METER + "." + SUBSCRIPTION,
 
-    CONSUMER_ERRORS_HTTP_BY_FAMILY = "consumer." + HOSTNAME + ".status." + GROUP + "." + TOPIC + "." + SUBSCRIPTION +
-            "." + HTTP_CODE_FAMILY,
+        DISCARDED_METER = "discarded-meter",
+        DISCARDED_TOPIC_METER = DISCARDED_METER + "." + GROUP + "." + TOPIC,
+        DISCARDED_SUBSCRIPTION_METER = DISCARDED_TOPIC_METER + "." + SUBSCRIPTION,
 
-    CONSUMER_ERRORS_HTTP_BY_CODE = CONSUMER_ERRORS_HTTP_BY_FAMILY + "." + HTTP_CODE,
-
-    CONSUMER_FAILED_METER = "consumer." + HOSTNAME + ".failed-meter" + "." + SUBSCRIPTION,
-
-    CONSUMER_DISCARDED_METER = "consumer." + HOSTNAME + ".discarded-meter",
-            CONSUMER_DISCARDED_TOPIC_METER = CONSUMER_DISCARDED_METER + "." + GROUP + "." + TOPIC,
-            CONSUMER_DISCARDED_SUBSCRIPTION_METER = CONSUMER_DISCARDED_TOPIC_METER + "." + SUBSCRIPTION,
-
-    CONSUMER_EXECUTOR_SUBMITTED = "consumer." + HOSTNAME + ".executors." + EXECUTOR_NAME + ".submitted",
-    CONSUMER_EXECUTOR_COMPLETED = "consumer." + HOSTNAME + ".executors." + EXECUTOR_NAME + ".completed";
+        EXECUTOR_SUBMITTED = "executors." + EXECUTOR_NAME + ".submitted",
+        EXECUTOR_COMPLETED = "executors." + EXECUTOR_NAME + ".completed";
 }

--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/common/metric/Timers.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/common/metric/Timers.java
@@ -2,7 +2,6 @@ package pl.allegro.tech.hermes.common.metric;
 
 import static pl.allegro.tech.hermes.metrics.PathsCompiler.EXECUTOR_NAME;
 import static pl.allegro.tech.hermes.metrics.PathsCompiler.GROUP;
-import static pl.allegro.tech.hermes.metrics.PathsCompiler.HOSTNAME;
 import static pl.allegro.tech.hermes.metrics.PathsCompiler.KAFKA_CLUSTER;
 import static pl.allegro.tech.hermes.metrics.PathsCompiler.SUBSCRIPTION;
 import static pl.allegro.tech.hermes.metrics.PathsCompiler.TOPIC;
@@ -10,32 +9,31 @@ import static pl.allegro.tech.hermes.metrics.PathsCompiler.TOPIC;
 public class Timers {
 
     public static final String
+            ACK_ALL_BROKER_LATENCY = "ack-all.broker-latency",
+            ACK_ALL_BROKER_TOPIC_LATENCY = ACK_ALL_BROKER_LATENCY + "." + GROUP + "." + TOPIC,
 
-    PRODUCER_ACK_ALL_BROKER_LATENCY = "producer." + HOSTNAME + ".ack-all.broker-latency",
-            PRODUCER_ACK_ALL_BROKER_TOPIC_LATENCY = PRODUCER_ACK_ALL_BROKER_LATENCY + "." + GROUP + "." + TOPIC,
+            ACK_LEADER_BROKER_LATENCY = "ack-leader.broker-latency",
+            ACK_LEADER_BROKER_TOPIC_LATENCY = ACK_LEADER_BROKER_LATENCY + "." + GROUP + "." + TOPIC,
 
-    PRODUCER_ACK_LEADER_BROKER_LATENCY = "producer." + HOSTNAME + ".ack-leader.broker-latency",
-            PRODUCER_ACK_LEADER_BROKER_TOPIC_LATENCY = PRODUCER_ACK_LEADER_BROKER_LATENCY + "." + GROUP + "." + TOPIC,
+            PARSING_REQUEST = "parsing-request",
+            TOPIC_PARSING_REQUEST = PARSING_REQUEST + "." + GROUP + "." + TOPIC,
 
-    PRODUCER_PARSING_REQUEST = "producer." + HOSTNAME + ".parsing-request",
-            PRODUCER_TOPIC_PARSING_REQUEST = PRODUCER_PARSING_REQUEST + "." + GROUP + "." + TOPIC,
+            ACK_ALL_LATENCY = "ack-all.latency",
+            ACK_ALL_TOPIC_LATENCY = ACK_ALL_LATENCY + "." + GROUP + "." + TOPIC,
 
-    PRODUCER_ACK_ALL_LATENCY = "producer." + HOSTNAME + ".ack-all.latency",
-            PRODUCER_ACK_ALL_TOPIC_LATENCY = PRODUCER_ACK_ALL_LATENCY + "." + GROUP + "." + TOPIC,
+            ACK_LEADER_LATENCY = "ack-leader.latency",
+            PRODUCER_ACK_LEADER_TOPIC_LATENCY = ACK_LEADER_LATENCY + "." + GROUP + "." + TOPIC,
 
-    PRODUCER_ACK_LEADER_LATENCY = "producer." + HOSTNAME + ".ack-leader.latency",
-            PRODUCER_ACK_LEADER_TOPIC_LATENCY = PRODUCER_ACK_LEADER_LATENCY + "." + GROUP + "." + TOPIC,
+            VALIDATION_LATENCY = "validation-latency",
+            VALIDATION_TOPIC_LATENCY = VALIDATION_LATENCY + "." + TOPIC,
 
-    PRODUCER_VALIDATION_LATENCY = "producer." + HOSTNAME + ".validation-latency",
-            PRODUCER_VALIDATION_TOPIC_LATENCY = "producer." + HOSTNAME + ".validation-latency." + TOPIC,
+            LATENCY = "latency",
+            SUBSCRIPTION_LATENCY = LATENCY + "." + GROUP + "." + TOPIC + "." + SUBSCRIPTION,
 
-    CONSUMER_LATENCY = "consumer." + HOSTNAME + ".latency",
-            CONSUMER_SUBSCRIPTION_LATENCY = CONSUMER_LATENCY + "." + GROUP + "." + TOPIC + "." + SUBSCRIPTION,
+            READ_LATENCY = "read-latency",
 
-    CONSUMER_READ_LATENCY = "consumer." + HOSTNAME + ".read-latency",
+            CONSUMER_WORKLOAD_REBALANCE_DURATION = "consumers-workload." + KAFKA_CLUSTER + ".selective.rebalance-duration",
 
-    CONSUMER_WORKLOAD_REBALANCE_DURATION = "consumers-workload." + KAFKA_CLUSTER + ".selective.rebalance-duration",
-
-    CONSUMER_EXECUTOR_DURATION = "consumer." + HOSTNAME + ".executors." + EXECUTOR_NAME + ".duration",
-            CONSUMER_EXECUTOR_WAITING = "consumer." + HOSTNAME + ".executors." + EXECUTOR_NAME + ".waiting";
+            EXECUTOR_DURATION = "executors." + EXECUTOR_NAME + ".duration",
+            EXECUTOR_WAITING = "executors." + EXECUTOR_NAME + ".waiting";
 }

--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/common/metric/counter/zookeeper/CounterMatcher.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/common/metric/counter/zookeeper/CounterMatcher.java
@@ -7,12 +7,10 @@ import static pl.allegro.tech.hermes.common.metric.HermesMetrics.escapeDots;
 class CounterMatcher {
 
     private final String counterName;
-    private final String hostname;
     private String topicName;
     private Optional<String> subscription;
 
-    public CounterMatcher(String counterName, String hostname) {
-        this.hostname = escapeDots(hostname);
+    public CounterMatcher(String counterName) {
         this.counterName = counterName;
         parseCounter(counterName);
     }
@@ -29,19 +27,19 @@ class CounterMatcher {
     }
 
     public boolean isTopicPublished() {
-        return counterName.contains(hostname + ".published.");
+        return counterName.contains("published.");
     }
 
     public boolean isSubscriptionDelivered() {
-        return counterName.contains(hostname + ".delivered.");
+        return counterName.contains("delivered.");
     }
 
     public boolean isSubscriptionDiscarded() {
-        return counterName.contains(hostname + ".discarded");
+        return counterName.contains("discarded");
     }
 
     public boolean isSubscriptionInflight() {
-        return counterName.contains(hostname + ".inflight.");
+        return counterName.contains("inflight.");
     }
 
     public String getTopicName() {

--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/common/metric/counter/zookeeper/ZookeeperCounterReporter.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/common/metric/counter/zookeeper/ZookeeperCounterReporter.java
@@ -29,12 +29,11 @@ public class ZookeeperCounterReporter extends ScheduledReporter {
     private static final TimeUnit DURATION_UNIT = TimeUnit.MILLISECONDS;
 
     private final CounterStorage counterStorage;
-    private final HostnameResolver hostnameResolver;
 
     public ZookeeperCounterReporter(MetricRegistry registry,
                                     CounterStorage counterStorage,
-                                    HostnameResolver hostnameResolver,
-                                    ConfigFactory config) {
+                                    ConfigFactory config
+                                    ) {
         super(
                 registry,
                 ZOOKEEPER_REPORTER_NAME,
@@ -43,7 +42,6 @@ public class ZookeeperCounterReporter extends ScheduledReporter {
                 DURATION_UNIT
         );
         this.counterStorage = counterStorage;
-        this.hostnameResolver = hostnameResolver;
     }
 
     @Override
@@ -63,7 +61,7 @@ public class ZookeeperCounterReporter extends ScheduledReporter {
             return;
         }
 
-        CounterMatcher matcher = new CounterMatcher(counterName, hostnameResolver.resolve());
+        CounterMatcher matcher = new CounterMatcher(counterName);
         long value = counter.getCount();
 
         if (matcher.isSubscriptionInflight()) {

--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/common/metric/timer/BrokerAckAllLatencyTimer.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/common/metric/timer/BrokerAckAllLatencyTimer.java
@@ -7,7 +7,7 @@ import pl.allegro.tech.hermes.common.metric.Timers;
 public class BrokerAckAllLatencyTimer extends BrokerLatencyTimer {
 
     public BrokerAckAllLatencyTimer(HermesMetrics hermesMetrics, TopicName topicName) {
-        super(hermesMetrics.timer(Timers.PRODUCER_ACK_ALL_BROKER_LATENCY),
-                hermesMetrics.timer(Timers.PRODUCER_ACK_ALL_BROKER_TOPIC_LATENCY, topicName));
+        super(hermesMetrics.timer(Timers.ACK_ALL_BROKER_LATENCY),
+                hermesMetrics.timer(Timers.ACK_ALL_BROKER_TOPIC_LATENCY, topicName));
     }
 }

--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/common/metric/timer/BrokerAckLeaderLatencyTimer.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/common/metric/timer/BrokerAckLeaderLatencyTimer.java
@@ -7,7 +7,7 @@ import pl.allegro.tech.hermes.common.metric.Timers;
 public class BrokerAckLeaderLatencyTimer extends BrokerLatencyTimer {
 
     public BrokerAckLeaderLatencyTimer(HermesMetrics hermesMetrics, TopicName topicName) {
-        super(hermesMetrics.timer(Timers.PRODUCER_ACK_LEADER_BROKER_LATENCY),
-                hermesMetrics.timer(Timers.PRODUCER_ACK_LEADER_BROKER_TOPIC_LATENCY, topicName));
+        super(hermesMetrics.timer(Timers.ACK_LEADER_BROKER_LATENCY),
+                hermesMetrics.timer(Timers.ACK_LEADER_BROKER_TOPIC_LATENCY, topicName));
     }
 }

--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/common/metric/timer/ConsumerLatencyTimer.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/common/metric/timer/ConsumerLatencyTimer.java
@@ -11,8 +11,8 @@ public class ConsumerLatencyTimer {
     private final Timer subscriptionLatencyTimer;
 
     public ConsumerLatencyTimer(HermesMetrics hermesMetrics, TopicName topicName, String subscriptionName) {
-        latencyTimer = hermesMetrics.timer(Timers.CONSUMER_LATENCY);
-        subscriptionLatencyTimer = hermesMetrics.timer(Timers.CONSUMER_SUBSCRIPTION_LATENCY, topicName, subscriptionName);
+        latencyTimer = hermesMetrics.timer(Timers.LATENCY);
+        subscriptionLatencyTimer = hermesMetrics.timer(Timers.SUBSCRIPTION_LATENCY, topicName, subscriptionName);
     }
 
     public Context time() {

--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/common/metric/timer/ProducerAckAllLatencyTimer.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/common/metric/timer/ProducerAckAllLatencyTimer.java
@@ -7,6 +7,6 @@ import pl.allegro.tech.hermes.common.metric.Timers;
 public class ProducerAckAllLatencyTimer extends ProducerLatencyTimer {
 
     public ProducerAckAllLatencyTimer(HermesMetrics hermesMetrics, TopicName topicName) {
-        super(hermesMetrics.timer(Timers.PRODUCER_ACK_ALL_LATENCY), hermesMetrics.timer(Timers.PRODUCER_ACK_ALL_TOPIC_LATENCY, topicName));
+        super(hermesMetrics.timer(Timers.ACK_ALL_LATENCY), hermesMetrics.timer(Timers.ACK_ALL_TOPIC_LATENCY, topicName));
     }
 }

--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/common/metric/timer/ProducerAckLeaderLatencyTimer.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/common/metric/timer/ProducerAckLeaderLatencyTimer.java
@@ -7,6 +7,6 @@ import pl.allegro.tech.hermes.common.metric.Timers;
 public class ProducerAckLeaderLatencyTimer extends ProducerLatencyTimer {
 
     public ProducerAckLeaderLatencyTimer(HermesMetrics hermesMetrics, TopicName topicName) {
-        super(hermesMetrics.timer(Timers.PRODUCER_ACK_LEADER_LATENCY), hermesMetrics.timer(Timers.PRODUCER_ACK_LEADER_TOPIC_LATENCY, topicName));
+        super(hermesMetrics.timer(Timers.ACK_LEADER_LATENCY), hermesMetrics.timer(Timers.PRODUCER_ACK_LEADER_TOPIC_LATENCY, topicName));
     }
 }

--- a/hermes-common/src/test/groovy/pl/allegro/tech/hermes/common/metric/counter/zookeeper/CounterMatcherTest.groovy
+++ b/hermes-common/src/test/groovy/pl/allegro/tech/hermes/common/metric/counter/zookeeper/CounterMatcherTest.groovy
@@ -6,8 +6,8 @@ class CounterMatcherTest extends Specification {
 
     def "should match topic published"() {
         given:
-        def counterName = "producer.localhost_domain.published.lagMetricGroup.topic"
-        def counterMatcher = new CounterMatcher(counterName, "localhost.domain")
+        def counterName = "published.lagMetricGroup.topic"
+        def counterMatcher = new CounterMatcher(counterName)
 
         when:
         def isTopic = counterMatcher.isTopicPublished()
@@ -20,8 +20,8 @@ class CounterMatcherTest extends Specification {
 
     def "should match subscription delivered"() {
         given:
-        def counterName = "consumer.localhost_domain.delivered.lagMetricGroup.topic.subscription"
-        def counterMatcher = new CounterMatcher(counterName, "localhost.domain")
+        def counterName = "delivered.lagMetricGroup.topic.subscription"
+        def counterMatcher = new CounterMatcher(counterName)
 
         when:
         def isSubscription = counterMatcher.isSubscriptionDelivered()
@@ -36,8 +36,8 @@ class CounterMatcherTest extends Specification {
 
     def "should match subscription discarded"() {
         given:
-        def counterName = "consumer.localhost_domain.discarded.lagMetricGroup.topic.subscription"
-        def counterMatcher = new CounterMatcher(counterName, "localhost.domain")
+        def counterName = "discarded.lagMetricGroup.topic.subscription"
+        def counterMatcher = new CounterMatcher(counterName)
 
         when:
         def isSubscription = counterMatcher.isSubscriptionDiscarded()
@@ -52,8 +52,8 @@ class CounterMatcherTest extends Specification {
 
     def "should match inflight counter"() {
         given:
-        def counterName = "consumer.localhost_domain.inflight.group.topic.subscription"
-        def counterMatcher = new CounterMatcher(counterName, "localhost.domain")
+        def counterName = "inflight.group.topic.subscription"
+        def counterMatcher = new CounterMatcher(counterName)
 
         when:
         def isInflight = counterMatcher.isSubscriptionInflight()

--- a/hermes-common/src/test/java/pl/allegro/tech/hermes/common/metric/counter/zookeeper/ZookeeperCounterReporterTest.java
+++ b/hermes-common/src/test/java/pl/allegro/tech/hermes/common/metric/counter/zookeeper/ZookeeperCounterReporterTest.java
@@ -23,9 +23,9 @@ import java.util.TreeMap;
 
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static pl.allegro.tech.hermes.common.metric.Counters.CONSUMER_DELIVERED;
-import static pl.allegro.tech.hermes.common.metric.Counters.CONSUMER_DISCARDED;
-import static pl.allegro.tech.hermes.common.metric.Counters.PRODUCER_PUBLISHED;
+import static pl.allegro.tech.hermes.common.metric.Counters.DELIVERED;
+import static pl.allegro.tech.hermes.common.metric.Counters.DISCARDED;
+import static pl.allegro.tech.hermes.common.metric.Counters.PUBLISHED;
 import static pl.allegro.tech.hermes.metrics.PathContext.pathContext;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -46,13 +46,13 @@ public class ZookeeperCounterReporterTest {
 
     private static PathsCompiler pathsCompiler = new PathsCompiler("localhost.domain");
 
-    public static final String METRIC_NAME_FOR_PUBLISHED = pathsCompiler.compile(PRODUCER_PUBLISHED,
+    public static final String METRIC_NAME_FOR_PUBLISHED = pathsCompiler.compile(PUBLISHED,
             pathContext().withGroup(GROUP_NAME_UNDERSCORE).withTopic(TOPIC_NAME).build());
 
-    public static final String METRIC_NAME_FOR_DELIVERED = pathsCompiler.compile(CONSUMER_DELIVERED,
+    public static final String METRIC_NAME_FOR_DELIVERED = pathsCompiler.compile(DELIVERED,
             pathContext().withGroup(GROUP_NAME_UNDERSCORE).withTopic(TOPIC_NAME).withSubscription(SUBSCRIPTION_NAME_UNDERSCORE).build());
 
-    public static final String METRIC_NAME_FOR_DISCARDED = pathsCompiler.compile(CONSUMER_DISCARDED,
+    public static final String METRIC_NAME_FOR_DISCARDED = pathsCompiler.compile(DISCARDED,
             pathContext().withGroup(GROUP_NAME_UNDERSCORE).withTopic(TOPIC_NAME).withSubscription(SUBSCRIPTION_NAME_UNDERSCORE).build());
 
     @Mock
@@ -78,7 +78,7 @@ public class ZookeeperCounterReporterTest {
     public void before() {
         when(configFactory.getStringProperty(Configs.GRAPHITE_PREFIX)).thenReturn(GRAPHITE_PREFIX);
         when(hostnameResolver.resolve()).thenReturn("localhost.domain");
-        zookeeperCounterReporter = new ZookeeperCounterReporter(metricRegistry, counterStorage, hostnameResolver, configFactory);
+        zookeeperCounterReporter = new ZookeeperCounterReporter(metricRegistry, counterStorage, configFactory);
     }
 
     @Test

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/receiver/kafka/KafkaMessageReceiverFactory.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/receiver/kafka/KafkaMessageReceiverFactory.java
@@ -47,7 +47,7 @@ public class KafkaMessageReceiverFactory implements ReceiverFactory {
                 receivingTopic,
                 Consumer.createJavaConsumerConnector(consumerConfig),
                 messageContentWrapper,
-                hermesMetrics.timer(Timers.CONSUMER_READ_LATENCY),
+                hermesMetrics.timer(Timers.READ_LATENCY),
                 clock,
                 kafkaNamesMapper,
                 configFactory.getIntProperty(Configs.KAFKA_STREAM_COUNT),

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/result/DefaultErrorHandler.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/result/DefaultErrorHandler.java
@@ -44,7 +44,7 @@ public class DefaultErrorHandler extends AbstractHandler implements ErrorHandler
         offsetHelper.remove(message);
 
         updateMeters(subscription);
-        updateMetrics(Counters.CONSUMER_DISCARDED, message, subscription);
+        updateMetrics(Counters.DISCARDED, message, subscription);
 
         undeliveredMessageLog.add(createUndeliveredMessage(subscription, new String(message.getData()), result.getFailure(), clock.getTime(),
                 message.getPartition(), message.getOffset(), cluster));
@@ -53,14 +53,14 @@ public class DefaultErrorHandler extends AbstractHandler implements ErrorHandler
     }
 
     private void updateMeters(Subscription subscription) {
-        hermesMetrics.meter(Meters.CONSUMER_DISCARDED_METER).mark();
-        hermesMetrics.meter(Meters.CONSUMER_DISCARDED_TOPIC_METER, subscription.getTopicName()).mark();
-        hermesMetrics.meter(Meters.CONSUMER_DISCARDED_SUBSCRIPTION_METER, subscription.getTopicName(), subscription.getName()).mark();
+        hermesMetrics.meter(Meters.DISCARDED_METER).mark();
+        hermesMetrics.meter(Meters.DISCARDED_TOPIC_METER, subscription.getTopicName()).mark();
+        hermesMetrics.meter(Meters.DISCARDED_SUBSCRIPTION_METER, subscription.getTopicName(), subscription.getName()).mark();
     }
 
     @Override
     public void handleFailed(Message message, Subscription subscription, MessageSendingResult result) {
-        hermesMetrics.meter(Meters.CONSUMER_FAILED_METER, subscription.getTopicName(), subscription.getName()).mark();
+        hermesMetrics.meter(Meters.FAILED_METER_SUBSCRIPTION, subscription.getTopicName(), subscription.getName()).mark();
         registerFailureMetrics(subscription, result);
         trackers.get(subscription).logFailed(toMessageMetadata(message, subscription), result.getRootCause());
     }

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/result/DefaultSuccessHandler.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/result/DefaultSuccessHandler.java
@@ -24,14 +24,14 @@ public class DefaultSuccessHandler extends AbstractHandler implements SuccessHan
     public void handle(Message message, Subscription subscription, MessageSendingResult result) {
         offsetHelper.remove(message);
         updateMeters(subscription, result);
-        updateMetrics(Counters.CONSUMER_DELIVERED, message, subscription);
+        updateMetrics(Counters.DELIVERED, message, subscription);
         trackers.get(subscription).logSent(toMessageMetadata(message, subscription));
     }
 
     private void updateMeters(Subscription subscription, MessageSendingResult result) {
-        hermesMetrics.meter(Meters.CONSUMER_METER).mark();
-        hermesMetrics.meter(Meters.CONSUMER_TOPIC_METER, subscription.getTopicName()).mark();
-        hermesMetrics.meter(Meters.CONSUMER_SUBSCRIPTION_METER, subscription.getTopicName(), subscription.getName()).mark();
+        hermesMetrics.meter(Meters.METER).mark();
+        hermesMetrics.meter(Meters.TOPIC_METER, subscription.getTopicName()).mark();
+        hermesMetrics.meter(Meters.SUBSCRIPTION_METER, subscription.getTopicName(), subscription.getName()).mark();
         hermesMetrics.registerConsumerHttpAnswer(subscription, result.getStatusCode());
     }
 }

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/di/ConsumersBinder.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/di/ConsumersBinder.java
@@ -75,6 +75,8 @@ public class ConsumersBinder extends AbstractBinder {
         bind(JettyHttpMessageSenderProvider.class).to(ProtocolMessageSenderProvider.class)
                 .in(Singleton.class).named("defaultHttpMessageSenderProvider");
 
+        bind("consumer").named("moduleName").to(String.class);
+
         bindSingleton(ConsumersSupervisor.class);
         bindSingleton(MessageSenderFactory.class);
         bindSingleton(ConsumerFactory.class);

--- a/hermes-consumers/src/test/java/pl/allegro/tech/hermes/consumers/consumer/ConsumerMessageSenderTest.java
+++ b/hermes-consumers/src/test/java/pl/allegro/tech/hermes/consumers/consumer/ConsumerMessageSenderTest.java
@@ -90,7 +90,7 @@ public class ConsumerMessageSenderTest {
         when(hermesMetrics.latencyTimer(subscription)).thenReturn(consumerLatencyTimer);
         when(hermesMetrics.consumerErrorsOtherMeter(subscription)).thenReturn(errors);
         when(consumerLatencyTimer.time()).thenReturn(consumerLatencyTimerContext);
-        when(hermesMetrics.meter(Meters.CONSUMER_FAILED_METER, subscription.getTopicName(), subscription.getName())).thenReturn(failedMeter);
+        when(hermesMetrics.meter(Meters.FAILED_METER_SUBSCRIPTION, subscription.getTopicName(), subscription.getName())).thenReturn(failedMeter);
     }
 
     @Test

--- a/hermes-consumers/src/test/java/pl/allegro/tech/hermes/consumers/consumer/result/DefaultErrorHandlerTest.java
+++ b/hermes-consumers/src/test/java/pl/allegro/tech/hermes/consumers/consumer/result/DefaultErrorHandlerTest.java
@@ -101,7 +101,7 @@ public class DefaultErrorHandlerTest {
     @Test
     public void shouldAddDiscardedEventToUndeliveredMessageLogWhenPolicyExhausted() {
         //given
-        when(hermesMetrics.counter(Counters.CONSUMER_INFLIGHT, QUALIFIED_TOPIC_NAME, SUBSCRIPTION_NAME)).thenReturn(counter);
+        when(hermesMetrics.counter(Counters.INFLIGHT, QUALIFIED_TOPIC_NAME, SUBSCRIPTION_NAME)).thenReturn(counter);
         InternalProcessingException cause = new InternalProcessingException("Test cause.");
 
         //when

--- a/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/di/FrontendBinder.java
+++ b/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/di/FrontendBinder.java
@@ -39,6 +39,8 @@ public class FrontendBinder extends AbstractBinder {
         bindSingleton(PublishingServlet.class);
         bindSingleton(MessageValidators.class);
 
+        bind("producer").named("moduleName").to(String.class);
+
         bindSingleton(HealthCheckService.class);
         bind(DefaultHeadersPropagator.class).to(HeadersPropagator.class).in(Singleton.class);
 

--- a/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/producer/kafka/Producers.java
+++ b/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/producer/kafka/Producers.java
@@ -39,12 +39,12 @@ public class Producers {
     }
 
     public void registerGauges(HermesMetrics metrics) {
-        registerTotalBytesGauge(leaderConfirms, metrics, Gauges.PRODUCER_LEADER_CONFIRMS_BUFFER_TOTAL_BYTES);
-        registerAvailableBytesGauge(leaderConfirms, metrics, Gauges.PRODUCER_LEADER_CONFIRMS_BUFFER_AVAILABLE_BYTES);
-        registerTotalBytesGauge(everyoneConfirms, metrics, Gauges.PRODUCER_EVERYONE_CONFIRMS_BUFFER_TOTAL_BYTES);
-        registerAvailableBytesGauge(everyoneConfirms, metrics, Gauges.PRODUCER_EVERYONE_CONFIRMS_BUFFER_AVAILABLE_BYTES);
-        registerCompressionRateGauge(leaderConfirms, metrics, Gauges.PRODUCER_LEADER_CONFIRMS_COMPRESSION_RATE);
-        registerCompressionRateGauge(everyoneConfirms, metrics, Gauges.PRODUCER_EVERYONE_CONFIRMS_COMPRESSION_RATE);
+        registerTotalBytesGauge(leaderConfirms, metrics, Gauges.LEADER_CONFIRMS_BUFFER_TOTAL_BYTES);
+        registerAvailableBytesGauge(leaderConfirms, metrics, Gauges.LEADER_CONFIRMS_BUFFER_AVAILABLE_BYTES);
+        registerTotalBytesGauge(everyoneConfirms, metrics, Gauges.EVERYONE_CONFIRMS_BUFFER_TOTAL_BYTES);
+        registerAvailableBytesGauge(everyoneConfirms, metrics, Gauges.EVERYONE_CONFIRMS_BUFFER_AVAILABLE_BYTES);
+        registerCompressionRateGauge(leaderConfirms, metrics, Gauges.LEADER_CONFIRMS_COMPRESSION_RATE);
+        registerCompressionRateGauge(everyoneConfirms, metrics, Gauges.EVERYONE_CONFIRMS_COMPRESSION_RATE);
     }
 
     public void maybeRegisterNodeMetricsGauges(HermesMetrics metrics) {
@@ -98,7 +98,7 @@ public class Producers {
                                                String producerName,
                                                Node node) {
 
-        String gauge = Gauges.PRODUCER_JMX_PREFIX + "." + producerName + "-" + metricName + "." + escapeDots(node.host());
+        String gauge = Gauges.JMX_PREFIX + "." + producerName + "-" + metricName + "." + escapeDots(node.host());
         registerGauge(producer, metrics, gauge,
                 entry -> entry.getKey().group().equals("producer-node-metrics")
                         && entry.getKey().name().equals(metricName)

--- a/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/publishing/MessageReader.java
+++ b/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/publishing/MessageReader.java
@@ -85,8 +85,8 @@ public class MessageReader implements ReadListener {
     }
 
     private void initParsingTimers() {
-        this.parsingTimerPerTopic = hermesMetrics.timer(Timers.PRODUCER_TOPIC_PARSING_REQUEST, topicName).time();
-        this.parsingTimer = hermesMetrics.timer(Timers.PRODUCER_PARSING_REQUEST).time();
+        this.parsingTimerPerTopic = hermesMetrics.timer(Timers.TOPIC_PARSING_REQUEST, topicName).time();
+        this.parsingTimer = hermesMetrics.timer(Timers.PARSING_REQUEST).time();
     }
 
     private void closeParsingTimers() {

--- a/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/publishing/MetricsAsyncListener.java
+++ b/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/publishing/MetricsAsyncListener.java
@@ -44,9 +44,9 @@ class MetricsAsyncListener implements AsyncListener {
         hermesMetrics.httpStatusCodeMeter(responseStatus, topicName).mark();
 
         if (Family.SUCCESSFUL != Family.familyOf(responseStatus)) {
-            hermesMetrics.meter(Meters.PRODUCER_FAILED_METER).mark();
-            hermesMetrics.meter(Meters.PRODUCER_FAILED_TOPIC_METER, topicName).mark();
-            hermesMetrics.counter(Counters.PRODUCER_UNPUBLISHED, topicName).inc();
+            hermesMetrics.meter(Meters.FAILED_METER).mark();
+            hermesMetrics.meter(Meters.FAILED_TOPIC_METER, topicName).mark();
+            hermesMetrics.counter(Counters.UNPUBLISHED, topicName).inc();
         }
     }
 

--- a/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/publishing/callbacks/MetricsPublishingCallback.java
+++ b/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/publishing/callbacks/MetricsPublishingCallback.java
@@ -36,8 +36,8 @@ public class MetricsPublishingCallback implements PublishingCallback {
     @Override
     public void onPublished(Message message, Topic topic) {
         brokerLatencyTimer.close();
-        hermesMetrics.meter(Meters.PRODUCER_METER).mark();
-        hermesMetrics.meter(Meters.PRODUCER_TOPIC_METER, topic.getName()).mark();
-        hermesMetrics.counter(Counters.PRODUCER_PUBLISHED, topic.getName()).inc();
+        hermesMetrics.meter(Meters.METER).mark();
+        hermesMetrics.meter(Meters.TOPIC_METER, topic.getName()).mark();
+        hermesMetrics.counter(Counters.PUBLISHED, topic.getName()).inc();
     }
 }

--- a/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/validator/MessageValidators.java
+++ b/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/validator/MessageValidators.java
@@ -20,8 +20,8 @@ public class MessageValidators {
     }
 
     public void check(Topic topic, byte[] message) {
-        try (Timer.Context globalValidationTimerContext = hermesMetrics.timer(Timers.PRODUCER_VALIDATION_LATENCY).time();
-             Timer.Context topicValidationTimerContext = hermesMetrics.timer(Timers.PRODUCER_VALIDATION_LATENCY, topic.getName()).time()) {
+        try (Timer.Context globalValidationTimerContext = hermesMetrics.timer(Timers.VALIDATION_LATENCY).time();
+             Timer.Context topicValidationTimerContext = hermesMetrics.timer(Timers.VALIDATION_LATENCY, topic.getName()).time()) {
             messageValidators.forEach(v -> v.check(message, topic));
         }
     }


### PR DESCRIPTION
I refactored hermes metrics slightly and moved hostname to reporter prefix. This allows metric names to be free from host specific information and be queried from tag based metric repositories (like kairosDB).