### PR TITLE
299 closing LoggerContext on shutdown for async appenders

### DIFF
--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/common/hook/HooksHandler.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/common/hook/HooksHandler.java
@@ -1,6 +1,8 @@
 package pl.allegro.tech.hermes.common.hook;
 
+import ch.qos.logback.classic.LoggerContext;
 import org.glassfish.hk2.api.ServiceLocator;
+import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -19,7 +21,11 @@ public class HooksHandler {
     }
 
     public void shutdown(ServiceLocator serviceLocator) {
-        shutdownHooks.forEach(c -> c.accept(serviceLocator));
+        try {
+            shutdownHooks.forEach(c -> c.accept(serviceLocator));
+        } finally {
+            ((LoggerContext) LoggerFactory.getILoggerFactory()).stop();
+        }
     }
 
     public void startup(ServiceLocator serviceLocator) {


### PR DESCRIPTION
Added closing LoggerContext on shutdown to support proper flush of AsyncAppender (http://logback.qos.ch/manual/appenders.html#AsyncAppender). It doesn't hurt other appenders.