### PR TITLE
fixing bug in frotnend counter reporting

### DIFF
--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/common/metric/counter/zookeeper/CounterMatcher.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/common/metric/counter/zookeeper/CounterMatcher.java
@@ -2,8 +2,6 @@ package pl.allegro.tech.hermes.common.metric.counter.zookeeper;
 
 import java.util.Optional;
 
-import static pl.allegro.tech.hermes.common.metric.HermesMetrics.escapeDots;
-
 class CounterMatcher {
 
     private final String counterName;
@@ -27,19 +25,19 @@ class CounterMatcher {
     }
 
     public boolean isTopicPublished() {
-        return counterName.contains("published.");
+        return counterName.startsWith("published.");
     }
 
     public boolean isSubscriptionDelivered() {
-        return counterName.contains("delivered.");
+        return counterName.startsWith("delivered.");
     }
 
     public boolean isSubscriptionDiscarded() {
-        return counterName.contains("discarded");
+        return counterName.startsWith("discarded.");
     }
 
     public boolean isSubscriptionInflight() {
-        return counterName.contains("inflight.");
+        return counterName.startsWith("inflight.");
     }
 
     public String getTopicName() {

--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/common/metric/counter/zookeeper/ZookeeperCounterReporter.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/common/metric/counter/zookeeper/ZookeeperCounterReporter.java
@@ -14,7 +14,6 @@ import pl.allegro.tech.hermes.common.config.ConfigFactory;
 import pl.allegro.tech.hermes.common.config.Configs;
 import pl.allegro.tech.hermes.common.metric.HermesMetrics;
 import pl.allegro.tech.hermes.common.metric.counter.CounterStorage;
-import pl.allegro.tech.hermes.common.util.HostnameResolver;
 
 import java.util.Map;
 import java.util.SortedMap;


### PR DESCRIPTION
both 'publish' and 'unpublish' counters have the same prefix,
since hosntame was removed, sometimes (data race) unpublished
was reported as published, which casuses us to lose topic
published messages metrics (they are no longer monotonic)