### PR TITLE
HTTPS support in message senders

### DIFF
--- a/docs/docs/configuration/secure-transport.md
+++ b/docs/docs/configuration/secure-transport.md
@@ -1,0 +1,22 @@
+# Secure transport
+
+All Hermes modules support secure transport in their own way:
+
+* Frontend can accept SSL (or Http/2) traffic
+* Consumers can send messages via SSL
+* Management operations can be secured using SSL
+
+>
+> Currently we will describe only Consumers SSL configuration.
+>
+
+## Consumers SSL
+
+Consumers by default support sending traffic to `https` endpoints. They use JRE trust store to verify the certificates.
+It is possible to change it using standard `javax.net.ssl.*` options:
+
+Option                           | Description
+-------------------------------- | --------------------------
+javax.net.ssl.trustStore         | path to custom trust store
+javax.net.ssl.trustStoreType     | trust store format
+javax.net.ssl.trustStorePassword | password to trust store

--- a/hermes-api/src/main/java/pl/allegro/tech/hermes/api/constraints/EndpointAddressValidator.java
+++ b/hermes-api/src/main/java/pl/allegro/tech/hermes/api/constraints/EndpointAddressValidator.java
@@ -22,6 +22,7 @@ public class EndpointAddressValidator implements ConstraintValidator<ValidAddres
 
     static {
         AVAILABLE_PROTOCOLS.add("http");
+        AVAILABLE_PROTOCOLS.add("https");
         AVAILABLE_PROTOCOLS.add("jms");
     }
 

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/sender/MessageSenderFactory.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/sender/MessageSenderFactory.java
@@ -20,6 +20,7 @@ public class MessageSenderFactory {
 
         this.messageSenderProviders = messageSenderProviders;
         this.messageSenderProviders.putIfProtocolAbsent("http", defaultHttpMessageSenderProvider);
+        this.messageSenderProviders.putIfProtocolAbsent("https", defaultHttpMessageSenderProvider);
         this.messageSenderProviders.putIfProtocolAbsent("jms", defaultJmsMessageSenderProvider);
 
         this.messageSenderProviders.startAll();

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/sender/http/HttpClientFactory.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/sender/http/HttpClientFactory.java
@@ -2,29 +2,39 @@ package pl.allegro.tech.hermes.consumers.consumer.sender.http;
 
 import org.eclipse.jetty.client.HttpClient;
 import org.eclipse.jetty.util.HttpCookieStore;
+import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.glassfish.hk2.api.Factory;
 import pl.allegro.tech.hermes.common.config.ConfigFactory;
 import pl.allegro.tech.hermes.common.metric.executor.InstrumentedExecutorServiceFactory;
 
 import javax.inject.Inject;
+import java.io.File;
+import java.security.KeyStore;
+import java.util.Arrays;
 import java.util.concurrent.ExecutorService;
 
-import static pl.allegro.tech.hermes.common.config.Configs.*;
+import static java.util.stream.Collectors.joining;
+import static pl.allegro.tech.hermes.common.config.Configs.CONSUMER_HTTP_CLIENT_MAX_CONNECTIONS_PER_DESTINATION;
+import static pl.allegro.tech.hermes.common.config.Configs.CONSUMER_HTTP_CLIENT_THREAD_POOL_MONITORING;
+import static pl.allegro.tech.hermes.common.config.Configs.CONSUMER_HTTP_CLIENT_THREAD_POOL_SIZE;
+import static pl.allegro.tech.hermes.common.config.Configs.CONSUMER_INFLIGHT_SIZE;
 
 public class HttpClientFactory implements Factory<HttpClient> {
 
     private final ConfigFactory configFactory;
     private final InstrumentedExecutorServiceFactory executorFactory;
+    private final SslContextFactory sslContextFactory;
 
     @Inject
     public HttpClientFactory(ConfigFactory configFactory, InstrumentedExecutorServiceFactory executorFactory) {
         this.configFactory = configFactory;
         this.executorFactory = executorFactory;
+        this.sslContextFactory = sslContextFactory();
     }
 
     @Override
     public HttpClient provide() {
-        HttpClient client = new HttpClient();
+        HttpClient client = new HttpClient(sslContextFactory);
         client.setMaxConnectionsPerDestination(configFactory.getIntProperty(CONSUMER_HTTP_CLIENT_MAX_CONNECTIONS_PER_DESTINATION));
         client.setMaxRequestsQueuedPerDestination(configFactory.getIntProperty(CONSUMER_INFLIGHT_SIZE));
         client.setExecutor(getExecutor());
@@ -40,5 +50,27 @@ public class HttpClientFactory implements Factory<HttpClient> {
 
     @Override
     public void dispose(HttpClient instance) {
+    }
+
+    private SslContextFactory sslContextFactory() {
+        SslContextFactory sslContextFactory = new SslContextFactory();
+
+        sslContextFactory.setValidateCerts(true);
+        sslContextFactory.setValidatePeerCerts(true);
+        sslContextFactory.setEnableOCSP(true);
+        sslContextFactory.setEnableCRLDP(true);
+        sslContextFactory.setEndpointIdentificationAlgorithm("HTTPS");
+
+        sslContextFactory.setTrustStorePath(System.getProperty("javax.net.ssl.trustStore", defaultTrustStorePath()));
+        sslContextFactory.setTrustStoreType(System.getProperty("javax.net.ssl.trustStoreType", KeyStore.getDefaultType()));
+        String password = System.getProperty("javax.net.ssl.trustStorePassword");
+        if (password != null) {
+            sslContextFactory.setTrustStorePassword(password);
+        }
+        return sslContextFactory;
+    }
+
+    private String defaultTrustStorePath() {
+        return Arrays.asList(System.getProperty("java.home"), "lib", "security", "cacerts").stream().collect(joining(File.separator));
     }
 }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -47,4 +47,5 @@ pages:
     - 'Schema repository': 'configuration/schema-repository.md'
     - 'Tuning Frontend': 'configuration/frontend-tuning.md'
     - 'Tuning Consumers': 'configuration/consumers-tuning.md'
+    - 'Secure transport': 'configuration/secure-transport.md'
     - 'Console': 'configuration/console.md'


### PR DESCRIPTION
Tested on MacOS X and Ubuntu 15 VM with [Mockbin](https://mockbin.org) used as a valid HTTPS subscriber endpoint.