### PR TITLE
320 nonblocking subscription assignment processing for selective consumer workload

### DIFF
--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/common/config/Configs.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/common/config/Configs.java
@@ -121,6 +121,7 @@ public enum Configs {
     CONSUMER_WORKLOAD_REBALANCE_INTERVAL("consumer.workload.rebalance.interval.seconds", 30),
     CONSUMER_WORKLOAD_CONSUMERS_PER_SUBSCRIPTION("consumer.workload.consumers.per.subscription", 2),
     CONSUMER_WORKLOAD_MAX_SUBSCRIPTIONS_PER_CONSUMER("consumer.workload.max.subscriptions.per.consumer", 200),
+    CONSUMER_WORKLOAD_ASSIGNMENT_PROCESSING_THREAD_POOL_SIZE("consumer.workload.assignment.processing.thread.pool.size", 5),
     CONSUMER_WORKLOAD_NODE_ID("consumer.workload.node.id",
             new InetAddressHostnameResolver().resolve().replaceAll("\\.", "_") + "$" + abs(randomUUID().getMostSignificantBits())),
     CONSUMER_BATCH_POOLABLE_SIZE("consumer.batch.poolable.size", 1024),

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/workload/SupervisorControllerFactory.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/workload/SupervisorControllerFactory.java
@@ -23,8 +23,10 @@ import javax.inject.Provider;
 import java.util.Map;
 
 import static java.util.Optional.ofNullable;
+import static java.util.concurrent.Executors.newFixedThreadPool;
 import static java.util.concurrent.Executors.newSingleThreadExecutor;
 import static pl.allegro.tech.hermes.common.config.Configs.CONSUMER_WORKLOAD_ALGORITHM;
+import static pl.allegro.tech.hermes.common.config.Configs.CONSUMER_WORKLOAD_ASSIGNMENT_PROCESSING_THREAD_POOL_SIZE;
 import static pl.allegro.tech.hermes.consumers.supervisor.workload.ConsumerWorkloadAlgorithm.LEGACY_MIRROR;
 import static pl.allegro.tech.hermes.consumers.supervisor.workload.ConsumerWorkloadAlgorithm.MIRROR;
 import static pl.allegro.tech.hermes.consumers.supervisor.workload.ConsumerWorkloadAlgorithm.SELECTIVE;
@@ -46,7 +48,9 @@ public class SupervisorControllerFactory implements Factory<SupervisorController
                 LEGACY_MIRROR, () -> new LegacyMirroringSupervisorController(supervisor, subscriptionsCache, adminCache, configs),
                 MIRROR, () -> new MirroringSupervisorController(supervisor, subscriptionsCache, workTracker, adminCache, configs),
                 SELECTIVE, () -> new SelectiveSupervisorController(supervisor, subscriptionsCache, workTracker,
-                                                                  createConsumersRegistry(configs, curator), adminCache, configs, metrics));
+                                                                  createConsumersRegistry(configs, curator), adminCache,
+                                                                  newFixedThreadPool(configs.getIntProperty(CONSUMER_WORKLOAD_ASSIGNMENT_PROCESSING_THREAD_POOL_SIZE)),
+                                                                  configs, metrics));
     }
 
     private static ConsumerNodesRegistry createConsumersRegistry(ConfigFactory configs, CuratorFramework curator) {

--- a/hermes-consumers/src/test/java/pl/allegro/tech/hermes/consumers/supervisor/workload/ConsumerTestRuntimeEnvironment.java
+++ b/hermes-consumers/src/test/java/pl/allegro/tech/hermes/consumers/supervisor/workload/ConsumerTestRuntimeEnvironment.java
@@ -101,7 +101,7 @@ public class ConsumerTestRuntimeEnvironment {
         WorkTracker workTracker = new WorkTracker(curator, objectMapper, paths.consumersRuntimePath(CLUSTER_NAME), id, executorService, subscriptionRepository);
         ConsumerNodesRegistry registry = new ConsumerNodesRegistry(curator, executorService, paths.consumersRegistryPath(CLUSTER_NAME), id);
         SubscriptionsCache subscriptionsCache = new ZookeeperSubscriptionsCacheFactory(curator, configFactory, objectMapper).provide();
-        return new SelectiveSupervisorController(supervisor, subscriptionsCache, workTracker, registry, mock(ZookeeperAdminCache.class), configFactory, metrics);
+        return new SelectiveSupervisorController(supervisor, subscriptionsCache, workTracker, registry, mock(ZookeeperAdminCache.class), executorService, configFactory, metrics);
     }
 
     public SelectiveSupervisorController node(String id) {


### PR DESCRIPTION
This PR addresses the issue #320 by separating handling zk events from actual assignment processing. For instance handling onAssignmentRemoved will no longer block until actual consumer is killed.