### PR TITLE
providing reason when schema-repo returns 403 forbidden

### DIFF
--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/infrastructure/schema/repo/JerseySchemaRepoClient.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/infrastructure/schema/repo/JerseySchemaRepoClient.java
@@ -43,20 +43,20 @@ public class JerseySchemaRepoClient implements SchemaRepoClient {
     @Override
     public void registerSchema(String subject, String schema) {
         Response response = target.path(subject).path("register").request().put(Entity.entity(schema, MediaType.TEXT_PLAIN));
-        checkResponse(response.getStatusInfo(), subject, response.readEntity(String.class));
+        checkSchemaRegistration(response.getStatusInfo(), subject, response.readEntity(String.class));
     }
 
-    private void checkResponse(Response.StatusType statusType, String subject, String response) {
+    private void checkSchemaRegistration(Response.StatusType statusType, String subject, String response) {
         switch (statusType.getFamily()) {
             case SUCCESSFUL:
                 logger.info("Successful write to schema repo for subject {}", subject);
                 break;
             case CLIENT_ERROR:
                 logger.warn("Invalid schema for subject {}. Details: {}", subject, response);
-                throw new InvalidSchemaException("Invalid schema. For more details see schema-repo logs.");
+                throw new InvalidSchemaException(String.format("Invalid schema. Reason: %s", response));
             case SERVER_ERROR:
                 logger.error("Failure write to schema repo for subject {}. Reason: {}", subject, response);
-                throw new SchemaRepoException("Failure write to schema-repo.");
+                throw new SchemaRepoException("Failure writing to schema-repo.");
             default:
                 logger.error("Unknown response from schema-repo. Subject {}, http status {}, Details: {}",
                         subject, statusType.getStatusCode(), response);

--- a/hermes-common/src/test/java/pl/allegro/tech/hermes/infrastructure/schema/repo/JerseySchemaRepoClientTest.java
+++ b/hermes-common/src/test/java/pl/allegro/tech/hermes/infrastructure/schema/repo/JerseySchemaRepoClientTest.java
@@ -112,13 +112,15 @@ public class JerseySchemaRepoClientTest {
     @Test
     public void shouldThrowExceptionForInvalidSchemaRegistration() {
         // given
-        wireMockRule.stubFor(put(registerSchemaUrl()).willReturn(badRequestResponse()));
+        wireMockRule.stubFor(put(registerSchemaUrl()).willReturn(forbiddenResponse("something's wrong")));
 
         // when
         catchException(client).registerSchema(SUBJECT, "{}");
 
         // then
-        assertThat((Throwable) caughtException()).isInstanceOf(InvalidSchemaException.class);
+        assertThat((Throwable) caughtException())
+                .isInstanceOf(InvalidSchemaException.class)
+                .hasMessageContaining("something's wrong");
     }
 
     @Test
@@ -157,7 +159,7 @@ public class JerseySchemaRepoClientTest {
         return aResponse().withStatus(404);
     }
 
-    private ResponseDefinitionBuilder badRequestResponse() {
-        return aResponse().withStatus(400);
+    private ResponseDefinitionBuilder forbiddenResponse(String body) {
+        return aResponse().withStatus(403).withBody(body);
     }
 }


### PR DESCRIPTION
Once https://github.com/schema-repo/schema-repo/pull/44 is merged, the reason for schema validation failure from schema-repo will be visible in the console.