### PR TITLE
374 separated handling of zk events from processing consumer commands

### DIFF
--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/common/cache/queue/LinkedHashSetBlockingQueue.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/common/cache/queue/LinkedHashSetBlockingQueue.java
@@ -1,0 +1,422 @@
+package pl.allegro.tech.hermes.common.cache.queue;
+
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import java.util.AbstractQueue;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * A blocking queue implementation backed by a linked hash set for predictable iteration order and
+ * constant time addition, removal and contains operations.
+ *
+ * Author: Sebastian Schaffert
+ * Project: apache.marmotta
+ */
+public class LinkedHashSetBlockingQueue<E> extends AbstractQueue<E> implements BlockingQueue<E> {
+
+    private int capacity = Integer.MAX_VALUE;
+
+    /** Current number of elements */
+    private final AtomicInteger count = new AtomicInteger(0);
+
+    /** Lock held by take, poll, etc */
+    private final ReentrantLock takeLock = new ReentrantLock();
+
+    /** Wait queue for waiting takes */
+    private final Condition notEmpty = takeLock.newCondition();
+
+    /** Lock held by put, offer, etc */
+    private final ReentrantLock putLock = new ReentrantLock();
+
+    /** Wait queue for waiting puts */
+    private final Condition notFull = putLock.newCondition();
+
+    private final LinkedHashSet<E> delegate;
+
+    public LinkedHashSetBlockingQueue() {
+        delegate = new LinkedHashSet<E>();
+    }
+
+    public LinkedHashSetBlockingQueue(int capacity) {
+        this.delegate = new LinkedHashSet<E>(capacity);
+        this.capacity = capacity;
+    }
+
+    @Override
+    public boolean offer(E e) {
+        if (e == null) throw new NullPointerException();
+        final AtomicInteger count = this.count;
+        if (count.get() == capacity)
+            return false;
+        int c = -1;
+        final ReentrantLock putLock = this.putLock;
+        putLock.lock();
+        try {
+            if (count.get() < capacity) {
+                final boolean wasAdded = enqueue(e);
+                c = wasAdded?count.getAndIncrement():count.get();
+                if (c + 1 < capacity)
+                    notFull.signal();
+            }
+        } finally {
+            putLock.unlock();
+        }
+        if (c == 0)
+            signalNotEmpty();
+        return c >= 0;
+    }
+
+    @Override
+    public void put(E e) throws InterruptedException {
+        if (e == null) throw new NullPointerException();
+
+        int c = -1;
+        final ReentrantLock putLock = this.putLock;
+        final AtomicInteger count = this.count;
+        putLock.lockInterruptibly();
+        try {
+            while (count.get() == capacity) {
+                notFull.await();
+            }
+            final boolean wasAdded = enqueue(e);
+            c = wasAdded?count.getAndIncrement():count.get();
+            if (c + 1 < capacity)
+                notFull.signal();
+        } finally {
+            putLock.unlock();
+        }
+        if (c == 0)
+            signalNotEmpty();
+    }
+
+    @Override
+    public boolean offer(E e, long timeout, TimeUnit unit) throws InterruptedException {
+        if (e == null) throw new NullPointerException();
+        long nanos = unit.toNanos(timeout);
+        int c = -1;
+        final ReentrantLock putLock = this.putLock;
+        final AtomicInteger count = this.count;
+        putLock.lockInterruptibly();
+        try {
+            while (count.get() == capacity) {
+
+                if (nanos <= 0)
+                    return false;
+                nanos = notFull.awaitNanos(nanos);
+            }
+            final boolean wasAdded = enqueue(e);
+            c = wasAdded?count.getAndIncrement():count.get();
+            if (c + 1 < capacity)
+                notFull.signal();
+        } finally {
+            putLock.unlock();
+        }
+        if (c == 0)
+            signalNotEmpty();
+        return true;
+    }
+
+    @Override
+    public E take() throws InterruptedException {
+        E x;
+        int c = -1;
+        final AtomicInteger count = this.count;
+        final ReentrantLock takeLock = this.takeLock;
+        takeLock.lockInterruptibly();
+        try {
+            while (count.get() == 0) {
+                notEmpty.await();
+            }
+            x = dequeue();
+            c = count.getAndDecrement();
+            if (c > 1)
+                notEmpty.signal();
+        } finally {
+            takeLock.unlock();
+        }
+        if (c == capacity)
+            signalNotFull();
+        return x;
+    }
+
+    @Override
+    public E poll(long timeout, TimeUnit unit) throws InterruptedException {
+        E x = null;
+        int c = -1;
+        long nanos = unit.toNanos(timeout);
+        final AtomicInteger count = this.count;
+        final ReentrantLock takeLock = this.takeLock;
+        takeLock.lockInterruptibly();
+        try {
+            while (count.get() == 0) {
+                if (nanos <= 0)
+                    return null;
+                nanos = notEmpty.awaitNanos(nanos);
+            }
+            x = dequeue();
+            c = count.getAndDecrement();
+            if (c > 1)
+                notEmpty.signal();
+        } finally {
+            takeLock.unlock();
+        }
+        if (c == capacity)
+            signalNotFull();
+        return x;
+    }
+
+    @Override
+    public int remainingCapacity() {
+        return Integer.MAX_VALUE - size();
+    }
+
+    @Override
+    public int drainTo(Collection<? super E> c) {
+        return drainTo(c,Integer.MAX_VALUE);
+    }
+
+    @Override
+    public int drainTo(Collection<? super E> c, int maxElements) {
+        if (c == null)
+            throw new NullPointerException();
+        if (c == this)
+            throw new IllegalArgumentException();
+        boolean signalNotFull = false;
+        final ReentrantLock takeLock = this.takeLock;
+        takeLock.lock();
+        try {
+            int n = Math.min(maxElements, count.get());
+            Iterator<E> it = delegate.iterator();
+            for(int i=0; i<n && it.hasNext(); i++) {
+                E x = it.next();
+                c.add(x);
+            }
+            count.getAndAdd(-n);
+            return n;
+        } finally {
+            takeLock.unlock();
+            if (signalNotFull)
+                signalNotFull();
+        }
+    }
+
+    @Override
+    public E poll() {
+        final AtomicInteger count = this.count;
+        if (count.get() == 0)
+            return null;
+        E x = null;
+        int c = -1;
+        final ReentrantLock takeLock = this.takeLock;
+        takeLock.lock();
+        try {
+            if (count.get() > 0) {
+                x = dequeue();
+                c = count.getAndDecrement();
+                if (c > 1)
+                    notEmpty.signal();
+            }
+        } finally {
+            takeLock.unlock();
+        }
+        if (c == capacity)
+            signalNotFull();
+        return x;
+    }
+
+
+    @Override
+    public E peek() {
+        if (count.get() == 0)
+            return null;
+        final ReentrantLock takeLock = this.takeLock;
+        takeLock.lock();
+        try {
+            Iterator<E> it = delegate.iterator();
+            if(it.hasNext()) {
+                return it.next();
+            } else {
+                return null;
+            }
+        } finally {
+            takeLock.unlock();
+        }
+    }
+
+
+    /**
+     * Creates a node and links it at end of queue.
+     * @param x the item
+     * @return <code>true</code> if this set did not already contain <code>x</code>
+     */
+    private boolean enqueue(E x) {
+        synchronized (delegate) {
+            return delegate.add(x);
+        }
+    }
+
+    /**
+     * Removes a node from head of queue.
+     * @return the node
+     */
+    private E dequeue() {
+        synchronized (delegate) {
+            Iterator<E> it = delegate.iterator();
+            E x = it.next();
+            it.remove();
+            return x;
+        }
+    }
+
+
+
+    /**
+     * Lock to prevent both puts and takes.
+     */
+    void fullyLock() {
+        putLock.lock();
+        takeLock.lock();
+    }
+
+    /**
+     * Unlock to allow both puts and takes.
+     */
+    void fullyUnlock() {
+        takeLock.unlock();
+        putLock.unlock();
+    }
+
+    /**
+     * Signals a waiting take. Called only from put/offer (which do not
+     * otherwise ordinarily lock takeLock.)
+     */
+    private void signalNotEmpty() {
+        final ReentrantLock takeLock = this.takeLock;
+        takeLock.lock();
+        try {
+            notEmpty.signal();
+        } finally {
+            takeLock.unlock();
+        }
+    }
+
+    /**
+     * Signals a waiting put. Called only from take/poll.
+     */
+    private void signalNotFull() {
+        final ReentrantLock putLock = this.putLock;
+        putLock.lock();
+        try {
+            notFull.signal();
+        } finally {
+            putLock.unlock();
+        }
+    }
+
+    /**
+     * Tells whether both locks are held by current thread.
+     */
+    boolean isFullyLocked() {
+        return (putLock.isHeldByCurrentThread() &&
+                takeLock.isHeldByCurrentThread());
+    }
+
+    @Override
+    public Iterator<E> iterator() {
+        final Iterator<E> it = delegate.iterator();
+        return new Iterator<E>() {
+            @Override
+            public boolean hasNext() {
+                fullyLock();
+                try {
+                    return it.hasNext();
+                } finally {
+                    fullyUnlock();
+                }
+            }
+
+            @Override
+            public E next() {
+                fullyLock();
+                try {
+                    return it.next();
+                } finally {
+                    fullyUnlock();
+                }
+            }
+
+            @Override
+            public void remove() {
+                fullyLock();
+                try {
+                    it.remove();
+
+                    // remove counter
+                    count.getAndDecrement();
+                } finally {
+                    fullyUnlock();
+                }
+            }
+        };
+    }
+
+    @Override
+    public int size() {
+        return count.get();
+    }
+
+    @Override
+    public boolean remove(Object o) {
+        if (o == null) return false;
+
+        fullyLock();
+        try {
+            if(delegate.remove(o)) {
+                if(count.getAndDecrement() == capacity) {
+                    notFull.signal();
+                }
+                return true;
+            }
+        } finally {
+            fullyUnlock();
+        }
+
+        return false;
+    }
+
+    @Override
+    public void clear() {
+        fullyLock();
+        try {
+            delegate.clear();
+            count.set(0);
+        } finally {
+            fullyUnlock();
+        }
+    }
+
+
+}

--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/common/cache/queue/QueueTask.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/common/cache/queue/QueueTask.java
@@ -1,0 +1,31 @@
+package pl.allegro.tech.hermes.common.cache.queue;
+
+import java.util.Arrays;
+
+public class QueueTask implements Runnable {
+    private final Runnable operation;
+    private final Object[] payload;
+
+    public QueueTask(Runnable operation, Object... payload) {
+        this.operation = operation;
+        this.payload = payload;
+    }
+
+    @Override
+    public void run() {
+        operation.run();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        QueueTask that = (QueueTask) o;
+        return Arrays.equals(payload, that.payload);
+    }
+
+    @Override
+    public int hashCode() {
+        return Arrays.hashCode(payload);
+    }
+}

--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/common/cache/zookeeper/ZookeeperCacheBase.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/common/cache/zookeeper/ZookeeperCacheBase.java
@@ -2,6 +2,7 @@ package pl.allegro.tech.hermes.common.cache.zookeeper;
 
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.utils.EnsurePath;
+import pl.allegro.tech.hermes.common.cache.queue.LinkedHashSetBlockingQueue;
 import pl.allegro.tech.hermes.common.config.ConfigFactory;
 import pl.allegro.tech.hermes.common.config.Configs;
 import pl.allegro.tech.hermes.common.exception.InternalProcessingException;
@@ -9,18 +10,25 @@ import pl.allegro.tech.hermes.infrastructure.zookeeper.ZookeeperPaths;
 
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+import static pl.allegro.tech.hermes.common.config.Configs.ZOOKEEPER_CACHE_THREAD_POOL_SIZE;
+import static pl.allegro.tech.hermes.common.config.Configs.ZOOKEEPER_TASK_PROCESSING_THREAD_POOL_SIZE;
 
 public abstract class ZookeeperCacheBase {
 
-    protected final ExecutorService executorService;
+    protected final ExecutorService eventExecutor;
+    protected final ExecutorService processingExecutor;
     protected final ZookeeperPaths paths;
     private final CuratorFramework curatorClient;
 
     public ZookeeperCacheBase(ConfigFactory configFactory, CuratorFramework curatorClient) {
         this.curatorClient = curatorClient;
-
-        executorService = Executors.newFixedThreadPool(configFactory.getIntProperty(Configs.ZOOKEEPER_CACHE_THREAD_POOL_SIZE));
-        paths = new ZookeeperPaths(configFactory.getStringProperty(Configs.ZOOKEEPER_ROOT));
+        this.eventExecutor = Executors.newFixedThreadPool(configFactory.getIntProperty(ZOOKEEPER_CACHE_THREAD_POOL_SIZE));
+        this.processingExecutor = new ThreadPoolExecutor(1, configFactory.getIntProperty(ZOOKEEPER_TASK_PROCESSING_THREAD_POOL_SIZE),
+                Integer.MAX_VALUE, TimeUnit.SECONDS, new LinkedHashSetBlockingQueue<>());
+        this.paths = new ZookeeperPaths(configFactory.getStringProperty(Configs.ZOOKEEPER_ROOT));
     }
 
     protected void checkBasePath(StartFunction startFunction) {
@@ -38,6 +46,11 @@ public abstract class ZookeeperCacheBase {
         } catch (Exception e) {
             throw new InternalProcessingException(e);
         }
+    }
+
+    public void stop() {
+        eventExecutor.shutdown();
+        processingExecutor.shutdown();
     }
 
     protected interface StartFunction {

--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/common/config/Configs.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/common/config/Configs.java
@@ -23,6 +23,7 @@ public enum Configs {
     ZOOKEEPER_MAX_RETRIES("zookeeper.max.retries", 2),
     ZOOKEEPER_ROOT("zookeeper.root", "/hermes"),
     ZOOKEEPER_CACHE_THREAD_POOL_SIZE("zookeeper.cache.thread.pool.size", 5),
+    ZOOKEEPER_TASK_PROCESSING_THREAD_POOL_SIZE("zookeeper.cache.processing.thread.pool.size", 5),
 
     KAFKA_ZOOKEEPER_CONNECT_STRING("kafka.zookeeper.connect.string", "localhost:2181"),
 

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/ConsumerMessageSender.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/ConsumerMessageSender.java
@@ -72,7 +72,7 @@ public class ConsumerMessageSender {
                 return;
             } catch (RuntimeException e) {
                 handleFailedSending(message, failedResult(e));
-                if (isTtlExceeded(message)) {
+                if (!consumerIsConsuming || isTtlExceeded(message)) {
                     handleMessageDiscarding(message, failedResult(e));
                     return;
                 }
@@ -140,7 +140,7 @@ public class ConsumerMessageSender {
                 handleMessageSendingSuccess(message, result);
             } else {
                 handleFailedSending(message, result);
-                if (!isTtlExceeded(message) && shouldRetrySending(result)) {
+                if (consumerIsConsuming && !isTtlExceeded(message) && shouldRetrySending(result)) {
                     retrySingleThreadExecutor.schedule(() -> retrySending(result),
                             subscription.getSubscriptionPolicy().getMessageBackoff(), TimeUnit.MILLISECONDS);
                 } else {

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/subscription/cache/zookeeper/GroupsNodeCache.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/subscription/cache/zookeeper/GroupsNodeCache.java
@@ -12,14 +12,16 @@ import java.util.concurrent.ExecutorService;
 import java.util.stream.Collectors;
 
 class GroupsNodeCache extends NodeCache<SubscriptionCallback, TopicsNodeCache> {
+    private final ExecutorService processingExecutor;
 
-    public GroupsNodeCache(CuratorFramework curatorClient, ObjectMapper objectMapper, String path, ExecutorService executorService) {
-        super(curatorClient, objectMapper, path, executorService);
+    public GroupsNodeCache(CuratorFramework curatorClient, ObjectMapper objectMapper, String path, ExecutorService eventExecutor, ExecutorService processingExecutor) {
+        super(curatorClient, objectMapper, path, eventExecutor);
+        this.processingExecutor = processingExecutor;
     }
 
     @Override
     protected TopicsNodeCache createSubcache(String path) {
-        return new TopicsNodeCache(curatorClient, objectMapper, topicsNodePath(path), executorService);
+        return new TopicsNodeCache(curatorClient, objectMapper, topicsNodePath(path), executorService, processingExecutor);
     }
 
     private String topicsNodePath(String path) {

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/subscription/cache/zookeeper/TopicsNodeCache.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/subscription/cache/zookeeper/TopicsNodeCache.java
@@ -12,14 +12,16 @@ import java.util.concurrent.ExecutorService;
 import java.util.stream.Collectors;
 
 class TopicsNodeCache extends NodeCache<SubscriptionCallback, SubscriptionsNodeCache> {
+    private final ExecutorService processingExecutor;
 
-    public TopicsNodeCache(CuratorFramework curatorClient, ObjectMapper objectMapper, String path, ExecutorService executorService) {
-        super(curatorClient, objectMapper, path, executorService);
+    public TopicsNodeCache(CuratorFramework curatorClient, ObjectMapper objectMapper, String path, ExecutorService eventExecutor, ExecutorService processingExecutor) {
+        super(curatorClient, objectMapper, path, eventExecutor);
+        this.processingExecutor = processingExecutor;
     }
 
     @Override
     protected SubscriptionsNodeCache createSubcache(String path) {
-        return new SubscriptionsNodeCache(curatorClient, objectMapper, subscriptionsNodePath(path), executorService);
+        return new SubscriptionsNodeCache(curatorClient, objectMapper, subscriptionsNodePath(path), executorService, processingExecutor);
     }
 
     private String subscriptionsNodePath(String path) {

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/subscription/cache/zookeeper/ZookeeperSubscriptionsCache.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/subscription/cache/zookeeper/ZookeeperSubscriptionsCache.java
@@ -26,7 +26,7 @@ class ZookeeperSubscriptionsCache extends ZookeeperCacheBase implements Subscrip
 
         super(configFactory, curatorClient);
 
-        groupsNodeCache = new GroupsNodeCache(curatorClient, objectMapper, paths.groupsPath(), executorService);
+        groupsNodeCache = new GroupsNodeCache(curatorClient, objectMapper, paths.groupsPath(), eventExecutor, processingExecutor);
     }
 
     @Override
@@ -39,7 +39,7 @@ class ZookeeperSubscriptionsCache extends ZookeeperCacheBase implements Subscrip
     public void stop() {
         try {
             groupsNodeCache.stop();
-            executorService.shutdown();
+            super.stop();
         } catch (Exception ex) {
             throw new InternalProcessingException(ex);
         }

--- a/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/cache/topic/zookeeper/ZookeeperTopicsCache.java
+++ b/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/cache/topic/zookeeper/ZookeeperTopicsCache.java
@@ -27,7 +27,7 @@ public class ZookeeperTopicsCache extends ZookeeperCacheBase implements TopicsCa
 
         super(configFactory, curatorClient);
 
-        groupsNodeCache = new GroupsNodeCache(curatorClient, objectMapper, paths.groupsPath(), executorService);
+        groupsNodeCache = new GroupsNodeCache(curatorClient, objectMapper, paths.groupsPath(), eventExecutor);
     }
 
     @Override
@@ -40,7 +40,7 @@ public class ZookeeperTopicsCache extends ZookeeperCacheBase implements TopicsCa
     public void stop() {
         try {
             groupsNodeCache.stop();
-            executorService.shutdown();
+            super.stop();
         } catch (Exception ex) {
             throw new InternalProcessingException(ex);
         }


### PR DESCRIPTION
1. Introduced handling of consumer commands on separate ThreadPoolExecutor that has a property of providing sequence of unique tasks (via LinkedHashSetBlockingQueue).
2. Consumer suspension doesn't wait for message TTL to expire anymore. 