### PR TITLE
395 timeouts in schema repo jersey client

### DIFF
--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/common/config/Configs.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/common/config/Configs.java
@@ -152,6 +152,8 @@ public enum Configs {
     SCHEMA_CACHE_RELOAD_THREAD_POOL_SIZE("schema.cache.reload.thread.pool.size", 2),
     SCHEMA_REPOSITORY_TYPE("schema.repository.type", "zookeeper"),
     SCHEMA_REPOSITORY_SERVER_URL("schema.repository.serverUrl", "http://localhost:2876/schema-repo/"),
+    SCHEMA_REPOSITORY_HTTP_READ_TIMEOUT_MS("schema.repository.http.read.timeout.ms", 2000),
+    SCHEMA_REPOSITORY_HTTP_CONNECT_TIMEOUT_MS("schema.repository.http.connect.timeout.ms", 2000),
 
     UNDELIVERED_MESSAGE_LOG_PERSIST_PERIOD_MS("undelivered.message.log.persist.period.ms", 5000);
 

--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/infrastructure/schema/repo/SchemaRepoClientFactory.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/infrastructure/schema/repo/SchemaRepoClientFactory.java
@@ -1,6 +1,8 @@
 package pl.allegro.tech.hermes.infrastructure.schema.repo;
 
 import org.glassfish.hk2.api.Factory;
+import org.glassfish.jersey.client.ClientConfig;
+import org.glassfish.jersey.client.ClientProperties;
 import pl.allegro.tech.hermes.common.config.ConfigFactory;
 import pl.allegro.tech.hermes.common.config.Configs;
 
@@ -19,7 +21,11 @@ public class SchemaRepoClientFactory implements Factory<SchemaRepoClient> {
 
     @Override
     public SchemaRepoClient provide() {
-        return new JerseySchemaRepoClient(ClientBuilder.newClient(), URI.create(configFactory.getStringProperty(Configs.SCHEMA_REPOSITORY_SERVER_URL)));
+        ClientConfig config = new ClientConfig()
+                .property(ClientProperties.READ_TIMEOUT, configFactory.getIntProperty(Configs.SCHEMA_REPOSITORY_HTTP_READ_TIMEOUT_MS))
+                .property(ClientProperties.CONNECT_TIMEOUT, configFactory.getIntProperty(Configs.SCHEMA_REPOSITORY_HTTP_CONNECT_TIMEOUT_MS));
+
+        return new JerseySchemaRepoClient(ClientBuilder.newClient(config), URI.create(configFactory.getStringProperty(Configs.SCHEMA_REPOSITORY_SERVER_URL)));
     }
 
     @Override

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/config/SchemaRepositoryConfiguration.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/config/SchemaRepositoryConfiguration.java
@@ -23,6 +23,7 @@ import pl.allegro.tech.hermes.management.infrastructure.schema.TopicFieldSchemaS
 import pl.allegro.tech.hermes.management.infrastructure.schema.SchemaRepoSchemaSourceRepository;
 import pl.allegro.tech.hermes.management.infrastructure.schema.ZookeeperSchemaSourceRepository;
 
+import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
 import java.net.URI;
 
@@ -61,8 +62,8 @@ public class SchemaRepositoryConfiguration {
     @Bean
     @ConditionalOnMissingBean(SchemaSourceRepository.class)
     @ConditionalOnProperty(value = "schema.repository.type", havingValue = "schema_repo")
-    public SchemaSourceRepository schemaRepoSchemaSourceRepository() {
-        SchemaRepoClient client = new JerseySchemaRepoClient(ClientBuilder.newClient(), URI.create(schemaRepositoryProperties.getServerUrl()));
+    public SchemaSourceRepository schemaRepoSchemaSourceRepository(Client jerseyClient) {
+        SchemaRepoClient client = new JerseySchemaRepoClient(jerseyClient, URI.create(schemaRepositoryProperties.getServerUrl()));
         return new SchemaRepoSchemaSourceRepository(client);
     }
 


### PR DESCRIPTION
Introduces configurable timeouts in jersey client to schema repo with reasonable defaults.