### PR TITLE
413 fix for batch receiver shutdown

### DIFF
--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/batch/MessageBatchReceiver.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/batch/MessageBatchReceiver.java
@@ -116,5 +116,6 @@ public class MessageBatchReceiver {
 
     public void stop() {
         receiving = false;
+        receiver.stop();
     }
 }


### PR DESCRIPTION
Batch receiver is not shutdown properly which results in threads leaking