### PR TITLE
Kafka consumers rebalance

### DIFF
--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/common/config/Configs.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/common/config/Configs.java
@@ -13,7 +13,6 @@ public enum Configs {
     ZOOKEEPER_BASE_SLEEP_TIME("zookeeper.base.sleep.time", 1000),
     ZOOKEEPER_CONNECTION_TIMEOUT("zookeeper.connection.timeout", 10000),
     ZOOKEEPER_SESSION_TIMEOUT("zookeeper.session.timeout", 10000),
-    ZOOKEEPER_SYNC_TIME("zookeeper.sync.time", 20000),
 
     ZOOKEEPER_AUTHORIZATION_ENABLED("zookeeper.authorization.enabled", false),
     ZOOKEEPER_AUTHORIZATION_SCHEME("zookeeper.authorization.scheme", "digest"),
@@ -36,8 +35,10 @@ public enum Configs {
     KAFKA_CONSUMER_AUTO_OFFSET_RESET("kafka.consumer.auto.offset.reset", "largest"),
     KAFKA_CONSUMER_OFFSETS_STORAGE("kafka.consumer.offsets.storage", "kafka"),
     KAFKA_CONSUMER_DUAL_COMMIT_ENABLED("kafka.consumer.dual.commit.enabled", true),
-    KAFKA_CONSUMER_METADATA_READ_TIMEOUT("kafka.consumers.metadata.read.timeout", 5000),
+    KAFKA_CONSUMER_METADATA_READ_TIMEOUT("kafka.consumer.metadata.read.timeout", 5000),
     KAFKA_CONSUMER_OFFSET_COMMITTER_BROKER_CONNECTION_EXPIRATION("kafka.consumer.offset.commiter.broker.connection.expiration", 60),
+    KAFKA_CONSUMER_REBALANCE_MAX_RETRIES("kafka.consumer.rebalance.max.retries", 150),
+    KAFKA_CONSUMER_REBALANCE_BACKOFF("kafka.consumer.rebalance.backoff", 4000),
 
     KAFKA_SIMPLE_CONSUMER_TIMEOUT_MS("kafka.simple.consumer.timeout.ms", 5000),
     KAFKA_SIMPLE_CONSUMER_BUFFER_SIZE("kafka.simple.consumer.buffer.size", 64 * 1024),

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/receiver/kafka/KafkaMessageReceiverFactory.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/receiver/kafka/KafkaMessageReceiverFactory.java
@@ -66,13 +66,14 @@ public class KafkaMessageReceiverFactory implements ReceiverFactory {
         props.put("zookeeper.connect", configFactory.getStringProperty(Configs.KAFKA_ZOOKEEPER_CONNECT_STRING));
         props.put("zookeeper.connection.timeout.ms", configFactory.getIntPropertyAsString(Configs.ZOOKEEPER_CONNECTION_TIMEOUT));
         props.put("zookeeper.session.timeout.ms", configFactory.getIntPropertyAsString(Configs.ZOOKEEPER_SESSION_TIMEOUT));
-        props.put("zookeeper.sync.time.ms", configFactory.getIntPropertyAsString(Configs.ZOOKEEPER_SYNC_TIME));
         props.put("auto.commit.enable", "false");
         props.put("fetch.wait.max.ms", "10000");
         props.put("consumer.timeout.ms", configFactory.getIntPropertyAsString(Configs.KAFKA_CONSUMER_TIMEOUT_MS));
         props.put("auto.offset.reset", configFactory.getStringProperty(Configs.KAFKA_CONSUMER_AUTO_OFFSET_RESET));
         props.put("offsets.storage", configFactory.getStringProperty(Configs.KAFKA_CONSUMER_OFFSETS_STORAGE));
         props.put("dual.commit.enabled", Boolean.toString(configFactory.getBooleanProperty(Configs.KAFKA_CONSUMER_DUAL_COMMIT_ENABLED)));
+        props.put("rebalance.max.retries", configFactory.getIntPropertyAsString(Configs.KAFKA_CONSUMER_REBALANCE_MAX_RETRIES));
+        props.put("rebalance.backoff.ms", configFactory.getIntPropertyAsString(Configs.KAFKA_CONSUMER_REBALANCE_BACKOFF));
 
         return new ConsumerConfig(props);
     }

--- a/integration/src/integration/java/pl/allegro/tech/hermes/integration/BatchDeliveryTest.java
+++ b/integration/src/integration/java/pl/allegro/tech/hermes/integration/BatchDeliveryTest.java
@@ -36,7 +36,7 @@ public class BatchDeliveryTest extends IntegrationTest {
     private static final TestMessage SINGLE_MESSAGE = TestMessage.simple();
 
     @Test
-    public void shouldDeliverMessagesInBatch() throws IOException, InterruptedException {
+    public void shouldDeliverMessagesInBatch() throws IOException {
         // given
         Topic topic = operations.buildTopic("batchSizeTest", "topic");
         operations.createBatchSubscription(topic, HTTP_ENDPOINT_URL, buildBatchPolicy()
@@ -52,7 +52,6 @@ public class BatchDeliveryTest extends IntegrationTest {
 
         // then
         expectSingleBatch(SMALL_BATCH);
-        Thread.sleep(10000);
     }
 
     @Test


### PR DESCRIPTION
Hermes does not configure max number of rebalance retries for kafka consumers. Default value is 4. I have noticed that when `kafka.common.ConsumerRebalanceFailedException: ... can't rebalance after 4 retries` is thrown then some topic partitions can be blocked and messages from them are not read. 

This is one of the reason why we should migrate to 0.9 kafka-consumer. In the meantime I propose this PR which increase max number of rebalance retries and decrease backoff time between retries from 20s to 4s, consequently it should speed up kafka-consumer startup when first rebalance fails.