### PR TITLE
#477 | Upgrade to OkHttp Client 3.2

### DIFF
--- a/docs/docs/user/java-client.md
+++ b/docs/docs/user/java-client.md
@@ -18,7 +18,7 @@ At the moment there are three implementations of `HermesSender`:
   uses [AsyncRestTemplate](http://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/web/client/AsyncRestTemplate.html)
   for asynchronous transmission
 * **JerseyHermesSender** - recommended for services using  [Jersey](<https://jersey.java.net/>)
-* **OkHttpHermesSender** - supports both HTTP/1.1 and HTTP/2 protocols, uses [OkHttp client](http://square.github.io/okhttp/)
+* **OkHttpHermesSender** - supports both HTTP/1.1 and HTTP/2 protocols, uses [OkHttp3 client](http://square.github.io/okhttp/)
 
 
 ## Creating
@@ -149,7 +149,7 @@ HermesClient client = HermesClientBuilder.hermesClient(new JerseyHermesSender(Cl
 
 ### OkHttp Client
 
-Requirement: `com.squareup.okhttp:okhttp` must be provided at runtime.
+Requirement: `com.squareup.okhttp3:okhttp` must be provided at runtime.
 
 ```java
 HermesClient client = HermesClientBuilder.hermesClient(new OkHttpHermesSender(new OkHttpClient()))
@@ -170,8 +170,10 @@ java -Xbootclasspath/p:<path_to_alpn_boot_jar> ...
 OkHttp Client configured with [SSL support](https://github.com/square/okhttp/wiki/HTTPS):
 
 ```java
-OkHttpClient okHttpClient = new OkHttpClient();
-okHttpClient.setSslSocketFactory(getSslContext().getSocketFactory());
+OkHttpClient client = new OkHttpClient.Builder()
+        .sslSocketFactory(sslContext.getSocketFactory())
+        .build();
+        
 HermesClient client = HermesClientBuilder.hermesClient(new OkHttpHermesSender(okHttpClient))
     .withURI(URI.create("https://localhost:8443"))
     .build();

--- a/hermes-client/build.gradle
+++ b/hermes-client/build.gradle
@@ -6,7 +6,7 @@ dependencies {
     provided group: 'io.dropwizard.metrics', name: 'metrics-core', version: '3.1.1'
     provided group: 'org.glassfish.jersey.core', name: 'jersey-client', version: versions.jersey
     provided group: 'org.springframework', name: 'spring-web', version: '4.1.4.RELEASE'
-    provided group: 'com.squareup.okhttp', name: 'okhttp', version: '2.4.0'
+    provided group: 'com.squareup.okhttp3', name: 'okhttp', version: '3.2.0'
     provided group: 'org.eclipse.jetty.alpn', name: 'alpn-api', version: versions.alpn_api
 
 

--- a/hermes-client/src/main/java/pl/allegro/tech/hermes/client/HermesResponse.java
+++ b/hermes-client/src/main/java/pl/allegro/tech/hermes/client/HermesResponse.java
@@ -9,6 +9,7 @@ import static java.net.HttpURLConnection.HTTP_CREATED;
 public interface HermesResponse {
 
     String MESSAGE_ID = "Hermes-Message-Id";
+    String HTTP_1_1 = "http/1.1";
 
     int getHttpStatus();
 
@@ -45,4 +46,6 @@ public interface HermesResponse {
     default String getMessageId() {
         return getHeader(MESSAGE_ID);
     }
+
+    default String getProtocol() { return HTTP_1_1; }
 }

--- a/hermes-client/src/main/java/pl/allegro/tech/hermes/client/HermesResponseBuilder.java
+++ b/hermes-client/src/main/java/pl/allegro/tech/hermes/client/HermesResponseBuilder.java
@@ -7,6 +7,7 @@ public class HermesResponseBuilder {
 
     private int statusCode = -1;
     private String body = "";
+    private String protocol = "http/1.1";
     private Throwable failureCause;
     private Function<String, String> headerSupplier = (header) -> null;
 
@@ -38,6 +39,11 @@ public class HermesResponseBuilder {
         return this;
     }
 
+    public HermesResponseBuilder withProtocol(String protocol) {
+        this.protocol = protocol;
+        return this;
+    }
+
     public HermesResponse build() {
         return new HermesResponse() {
 
@@ -59,6 +65,11 @@ public class HermesResponseBuilder {
             @Override
             public String getHeader(String header) {
                 return headerSupplier.apply(header);
+            }
+
+            @Override
+            public String getProtocol() {
+                return protocol;
             }
         };
     }

--- a/hermes-client/src/main/java/pl/allegro/tech/hermes/client/okhttp/OkHttpHermesSender.java
+++ b/hermes-client/src/main/java/pl/allegro/tech/hermes/client/okhttp/OkHttpHermesSender.java
@@ -1,6 +1,12 @@
 package pl.allegro.tech.hermes.client.okhttp;
 
-import com.squareup.okhttp.*;
+import okhttp3.Call;
+import okhttp3.Callback;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
 import pl.allegro.tech.hermes.client.HermesMessage;
 import pl.allegro.tech.hermes.client.HermesResponse;
 import pl.allegro.tech.hermes.client.HermesSender;
@@ -33,12 +39,12 @@ public class OkHttpHermesSender implements HermesSender {
 
         client.newCall(request).enqueue(new Callback() {
             @Override
-            public void onFailure(Request request, IOException e) {
+            public void onFailure(Call call, IOException e) {
                 future.completeExceptionally(e);
             }
 
             @Override
-            public void onResponse(Response response) throws IOException {
+            public void onResponse(Call call, Response response) throws IOException {
                 future.complete(fromOkHttpResponse(response));
             }
         });
@@ -46,11 +52,12 @@ public class OkHttpHermesSender implements HermesSender {
         return future;
     }
 
-    private HermesResponse fromOkHttpResponse(Response response) throws IOException {
+    HermesResponse fromOkHttpResponse(Response response) throws IOException {
         return hermesResponse()
                 .withHeaderSupplier(response::header)
                 .withHttpStatus(response.code())
                 .withBody(response.body().string())
+                .withProtocol(response.protocol().toString())
                 .build();
     }
 }

--- a/hermes-client/src/test/groovy/pl/allegro/tech/hermes/client/HermesSenderTest.groovy
+++ b/hermes-client/src/test/groovy/pl/allegro/tech/hermes/client/HermesSenderTest.groovy
@@ -2,7 +2,7 @@ package pl.allegro.tech.hermes.client
 
 import com.github.tomakehurst.wiremock.client.WireMock
 import com.github.tomakehurst.wiremock.junit.WireMockClassRule
-import com.squareup.okhttp.OkHttpClient
+import okhttp3.OkHttpClient
 import org.junit.ClassRule
 import org.springframework.web.client.AsyncRestTemplate
 import pl.allegro.tech.hermes.client.jersey.JerseyHermesSender

--- a/integration/build.gradle
+++ b/integration/build.gradle
@@ -63,7 +63,7 @@ dependencies {
     testCompile group: 'org.apache.curator', name: 'curator-test', version: versions.curator
     testCompile group: 'com.github.fakemongo', name: 'fongo', version: versions.fongo
     testCompile group: 'org.springframework', name: 'spring-web', version: '4.1.4.RELEASE'
-    testCompile group: 'com.squareup.okhttp', name: 'okhttp', version: '2.4.0'
+    testCompile group: 'com.squareup.okhttp3', name: 'okhttp', version: '3.2.0'
 
     testCompile files('./lib/schema-repo-server-0.1.3-jersey2.jar');
     testCompile 'org.glassfish.jersey.containers:jersey-container-grizzly2-http:2.15'

--- a/integration/src/integration/java/pl/allegro/tech/hermes/integration/HermesClientPublishingTest.java
+++ b/integration/src/integration/java/pl/allegro/tech/hermes/integration/HermesClientPublishingTest.java
@@ -1,6 +1,6 @@
 package pl.allegro.tech.hermes.integration;
 
-import com.squareup.okhttp.OkHttpClient;
+import okhttp3.OkHttpClient;
 import org.springframework.web.client.AsyncRestTemplate;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -80,7 +80,7 @@ public class HermesClientPublishingTest extends IntegrationTest {
         HermesResponse response = client.publish(topic.qualifiedName(), message.body()).join();
 
         // then
-        assertThat(response.getHeader("OkHttp-Selected-Protocol")).isEqualTo("h2");
+        assertThat(response.getProtocol()).isEqualTo("h2");
     }
 
     private void runTestSuiteForHermesClient(HermesClient client) {
@@ -109,9 +109,9 @@ public class HermesClientPublishingTest extends IntegrationTest {
     }
 
     private OkHttpClient getOkHttpClientWithSslContextConfigured() {
-        OkHttpClient okHttpClient = new OkHttpClient();
-        okHttpClient.setSslSocketFactory(getSslContext().getSocketFactory());
-        return okHttpClient;
+        return new OkHttpClient.Builder()
+                .sslSocketFactory(getSslContext().getSocketFactory())
+                .build();
     }
 
     private SSLContext getSslContext() {

--- a/integration/src/integration/java/pl/allegro/tech/hermes/integration/env/FrontendStarter.java
+++ b/integration/src/integration/java/pl/allegro/tech/hermes/integration/env/FrontendStarter.java
@@ -2,8 +2,8 @@ package pl.allegro.tech.hermes.integration.env;
 
 import com.codahale.metrics.MetricRegistry;
 import com.jayway.awaitility.Duration;
-import com.squareup.okhttp.OkHttpClient;
-import com.squareup.okhttp.Request;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import pl.allegro.tech.hermes.common.config.ConfigFactory;


### PR DESCRIPTION
The biggest change is the HermesResponse#getProtocol() method that has been agreed with Adam. It will help Hermes users to troubleshoot switching to HTTP/2.