### PR TITLE
Stale backup files

### DIFF
--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/common/config/Configs.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/common/config/Configs.java
@@ -101,6 +101,7 @@ public enum Configs {
     MESSAGES_LOCAL_STORAGE_MAX_AGE_HOURS("frontend.messages.local.storage.max.age.hours", 72),
     MESSAGES_LOCAL_STORAGE_MAX_RESEND_RETRIES("frontend.messages.local.storage.max.resend.retries", 5),
     MESSAGES_LOADING_WAIT_FOR_TOPICS_CACHE("frontend.messages.loading.wait.for.topics.cache", 10),
+    MESSAGES_LOADING_WAIT_FOR_BROKER_TOPIC_INFO("frontend.messages.loading.wait.for.broker.topic.info", 5),
 
     CONSUMER_COMMIT_OFFSET_PERIOD("consumer.commit.offset.period", 20),
     CONSUMER_SENDER_ASYNC_TIMEOUT_MS("consumer.sender.async.timeout.ms", 5_000),

--- a/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/buffer/BackupFilesManager.java
+++ b/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/buffer/BackupFilesManager.java
@@ -1,5 +1,6 @@
 package pl.allegro.tech.hermes.frontend.buffer;
 
+import com.google.common.io.PatternFilenameFilter;
 import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -7,8 +8,10 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.io.IOException;
 import java.time.Clock;
+import java.util.List;
 import java.util.Optional;
 
+import static com.google.common.collect.Lists.newArrayList;
 import static java.lang.String.format;
 
 public class BackupFilesManager {
@@ -16,6 +19,7 @@ public class BackupFilesManager {
     private static final Logger logger = LoggerFactory.getLogger(BackupFilesManager.class);
 
     private static final String FILE_NAME = "hermes-buffer";
+    private static final String TIMESTAMPED_BACKUP_FILE_PATTERN = FILE_NAME + "-\\d+\\.dat";
 
     private final String baseDir;
     private final Clock clock;
@@ -60,5 +64,9 @@ public class BackupFilesManager {
     
     private File getBackupFile() {
         return new File(format("%s/%s.dat", baseDir, FILE_NAME));
+    }
+
+    public List<File> getRolledBackupFiles() {
+        return newArrayList(new File(baseDir).listFiles(new PatternFilenameFilter(TIMESTAMPED_BACKUP_FILE_PATTERN)));
     }
 }

--- a/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/buffer/BackupMessagesLoader.java
+++ b/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/buffer/BackupMessagesLoader.java
@@ -25,8 +25,10 @@ import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
@@ -34,7 +36,11 @@ import java.util.concurrent.atomic.AtomicReference;
 import static com.jayway.awaitility.Awaitility.await;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static pl.allegro.tech.hermes.api.TopicName.fromQualifiedName;
-import static pl.allegro.tech.hermes.common.config.Configs.*;
+import static pl.allegro.tech.hermes.common.config.Configs.KAFKA_PRODUCER_ACK_TIMEOUT;
+import static pl.allegro.tech.hermes.common.config.Configs.MESSAGES_LOADING_WAIT_FOR_BROKER_TOPIC_INFO;
+import static pl.allegro.tech.hermes.common.config.Configs.MESSAGES_LOADING_WAIT_FOR_TOPICS_CACHE;
+import static pl.allegro.tech.hermes.common.config.Configs.MESSAGES_LOCAL_STORAGE_MAX_AGE_HOURS;
+import static pl.allegro.tech.hermes.common.config.Configs.MESSAGES_LOCAL_STORAGE_MAX_RESEND_RETRIES;
 
 public class BackupMessagesLoader {
 
@@ -47,9 +53,11 @@ public class BackupMessagesLoader {
     private final Trackers trackers;
     private final int secondsToWaitForTopicsCache;
     private final int messageMaxAgeHours;
-    private final int resendSleep;
     private final int maxResendRetries;
+    private final long resendSleep;
+    private final long readTopicInfoSleep;
 
+    private final Set<Topic> topicsAvailabilityCache = new HashSet<>();
     private final AtomicReference<ConcurrentLinkedQueue<Pair<Message, Topic>>> toResend = new AtomicReference<>();
 
     @Inject
@@ -67,6 +75,7 @@ public class BackupMessagesLoader {
         this.secondsToWaitForTopicsCache = config.getIntProperty(MESSAGES_LOADING_WAIT_FOR_TOPICS_CACHE);
         this.messageMaxAgeHours = config.getIntProperty(MESSAGES_LOCAL_STORAGE_MAX_AGE_HOURS);
         this.resendSleep = config.getIntProperty(KAFKA_PRODUCER_ACK_TIMEOUT) + secondsToWaitForTopicsCache * 1000;
+        this.readTopicInfoSleep = TimeUnit.SECONDS.toMillis(config.getIntProperty(MESSAGES_LOADING_WAIT_FOR_BROKER_TOPIC_INFO));
         this.maxResendRetries = config.getIntProperty(MESSAGES_LOCAL_STORAGE_MAX_RESEND_RETRIES);
     }
 
@@ -77,6 +86,11 @@ public class BackupMessagesLoader {
         toResend.set(new ConcurrentLinkedQueue<>());
 
         sendMessages(messages);
+
+        if (toResend.get().size() == 0) {
+            logger.info("No messages to resend.");
+            return;
+        }
 
         do {
             if (retry > 0) {
@@ -92,6 +106,10 @@ public class BackupMessagesLoader {
         } while (toResend.get().size() > 0 && retry <= maxResendRetries);
 
         logger.info("Finished resending messages from backup storage after retry #{} with #{} unsent messages.", retry - 1, toResend.get().size());
+    }
+
+    public void clearTopicsAvailabilityCache() {
+        topicsAvailabilityCache.clear();
     }
 
     private void sendMessages(List<BackupMessage> messages) {
@@ -132,6 +150,7 @@ public class BackupMessagesLoader {
 
     private boolean sendMessageIfNeeded(Message message, Optional<Topic> topic, String contextName) {
         if (topic.isPresent() && isNotStale(message)) {
+            waitOnBrokerTopicAvailability(topic.get());
             sendMessage(message, topic.get());
             return true;
         } else {
@@ -139,6 +158,33 @@ public class BackupMessagesLoader {
                     new String(message.getData(), Charset.defaultCharset()));
             return false;
         }
+    }
+
+    private void waitOnBrokerTopicAvailability(Topic topic) {
+        int tries = 0;
+        while(!isBrokerTopicAvailable(topic)) {
+            try {
+                tries++;
+                logger.info("Broker topic {} is not available, checked {} times.", topic.getQualifiedName(), tries);
+                Thread.sleep(readTopicInfoSleep);
+            } catch (InterruptedException e) {
+                logger.warn("Waiting for broker topic availability interrupted. Topic: {}", topic.getQualifiedName());
+            }
+        }
+    }
+
+    private boolean isBrokerTopicAvailable(Topic topic) {
+        if (topicsAvailabilityCache.contains(topic)) {
+            return true;
+        }
+
+        if (brokerMessageProducer.isTopicAvailable(topic)) {
+            topicsAvailabilityCache.add(topic);
+            logger.info("Broker topic {} is available.", topic.getQualifiedName());
+            return true;
+        }
+
+        return false;
     }
 
     private boolean isNotStale(Message message) {

--- a/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/di/PersistentBufferExtension.java
+++ b/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/di/PersistentBufferExtension.java
@@ -59,7 +59,10 @@ public class PersistentBufferExtension {
                     rolledBackupFiles.size(),
                     rolledBackupFiles.stream().map(f -> f.getName()).collect(joining(", ")));
 
-            hooksHandler.addStartupHook((s) -> rolledBackupFiles.forEach(f -> loadOldMessages(backupFilesManager, f)));
+            hooksHandler.addStartupHook((s) -> {
+                rolledBackupFiles.forEach(f -> loadOldMessages(backupFilesManager, f));
+                backupMessagesLoader.clearTopicsAvailabilityCache();
+            });
         }
 
         if (config.getBooleanProperty(MESSAGES_LOCAL_STORAGE_ENABLED)) {

--- a/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/producer/BrokerMessageProducer.java
+++ b/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/producer/BrokerMessageProducer.java
@@ -1,11 +1,12 @@
 package pl.allegro.tech.hermes.frontend.producer;
 
 import pl.allegro.tech.hermes.api.Topic;
-import pl.allegro.tech.hermes.frontend.listeners.BrokerListeners;
 import pl.allegro.tech.hermes.frontend.publishing.PublishingCallback;
 import pl.allegro.tech.hermes.frontend.publishing.message.Message;
 
 public interface BrokerMessageProducer {
 
     void send(Message message, Topic topic, PublishingCallback callback);
+    boolean isTopicAvailable(Topic topic);
+
 }

--- a/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/producer/kafka/KafkaBrokerMessageProducer.java
+++ b/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/producer/kafka/KafkaBrokerMessageProducer.java
@@ -2,6 +2,8 @@ package pl.allegro.tech.hermes.frontend.producer.kafka;
 
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.clients.producer.RecordMetadata;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import pl.allegro.tech.hermes.api.Topic;
 import pl.allegro.tech.hermes.common.kafka.KafkaNamesMapper;
 import pl.allegro.tech.hermes.common.metric.HermesMetrics;
@@ -15,6 +17,7 @@ import javax.inject.Singleton;
 @Singleton
 public class KafkaBrokerMessageProducer implements BrokerMessageProducer {
 
+    private static final Logger logger = LoggerFactory.getLogger(KafkaBrokerMessageProducer.class);
     private final Producers producers;
     private final KafkaNamesMapper kafkaNamesMapper;
     private final HermesMetrics metrics;
@@ -36,6 +39,23 @@ public class KafkaBrokerMessageProducer implements BrokerMessageProducer {
         } catch (Exception e) {
             callback.onUnpublished(message, topic, e);
         }
+    }
+
+    @Override
+    public boolean isTopicAvailable(Topic topic) {
+        String kafkaTopicName = kafkaNamesMapper.toKafkaTopics(topic).getPrimary().name().asString();
+
+        try {
+            if (producers.get(topic).partitionsFor(kafkaTopicName).size() > 0) {
+                return true;
+            }
+        } catch (Exception e) {
+            logger.warn("Could not read information about partitions for topic {}. {}", kafkaTopicName, e.getMessage());
+            return false;
+        }
+
+        logger.warn("No information about partitions for topic {}", kafkaTopicName);
+        return false;
     }
 
     private class SendCallback implements org.apache.kafka.clients.producer.Callback {


### PR DESCRIPTION
PR contains two unrelated commits with separate functionality:

1. loading backup messages from multiple stale backup files
2. waiting on topic metadata before backup messages are send to kafka-producer. There is no point to send them when kafka nodes are not available in frontend startup phase, because they will not get to internal kafka producer buffer and they will not be send to kafka. Therefore safer way is to wait on broker topic metadata and after that send backup messages.