### PR TITLE
Backup messages only for 202

### DIFF
--- a/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/producer/kafka/KafkaBrokerMessageProducer.java
+++ b/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/producer/kafka/KafkaBrokerMessageProducer.java
@@ -29,13 +29,9 @@ public class KafkaBrokerMessageProducer implements BrokerMessageProducer {
 
     @Override
     public void send(Message message, Topic topic, final PublishingCallback callback) {
-        try {
             String kafkaTopicName = kafkaNamesMapper.toKafkaTopics(topic).getPrimary().name().asString();
             ProducerRecord<byte[], byte[]> producerRecord = new ProducerRecord<>(kafkaTopicName, message.getData());
             producers.get(topic).send(producerRecord, new SendCallback(message, topic, callback));
-        } catch (Exception e) {
-            callback.onUnpublished(message, topic, e);
-        }
     }
 
     private class SendCallback implements org.apache.kafka.clients.producer.Callback {

--- a/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/publishing/PublishingServlet.java
+++ b/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/publishing/PublishingServlet.java
@@ -109,11 +109,10 @@ public class PublishingServlet extends HttpServlet {
                         Message message = messageFactory.create(request, topic, messageId, messageContent);
                         asyncContext.addListener(new BrokerTimeoutAsyncListener(httpResponder, message, topic, messageState, listeners));
                         messagePublisher.publish(message, topic, messageState,
-                                listeners,
                                 new AsyncContextExecutionCallback(asyncContext, new MessageStatePublishingCallback(messageState),
                                         new HttpPublishingCallback(httpResponder),
                                         new MetricsPublishingCallback(hermesMetrics, topic),
-                                        new BrokerListenersPublishingCallback(listeners)));
+                                        new BrokerListenersPublishingCallback(listeners, messageState)));
 
                     } catch (InvalidMessageException | AvroConversionException | UnsupportedContentTypeException exception) {
                         httpResponder.badRequest(exception);

--- a/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/publishing/callbacks/BrokerListenersPublishingCallback.java
+++ b/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/publishing/callbacks/BrokerListenersPublishingCallback.java
@@ -4,18 +4,23 @@ import pl.allegro.tech.hermes.api.Topic;
 import pl.allegro.tech.hermes.frontend.listeners.BrokerListeners;
 import pl.allegro.tech.hermes.frontend.publishing.message.Message;
 import pl.allegro.tech.hermes.frontend.publishing.PublishingCallback;
+import pl.allegro.tech.hermes.frontend.publishing.message.MessageState;
 
 public class BrokerListenersPublishingCallback implements PublishingCallback {
 
     private final BrokerListeners listeners;
+    private final MessageState messageState;
 
-    public BrokerListenersPublishingCallback(BrokerListeners listeners) {
+    public BrokerListenersPublishingCallback(BrokerListeners listeners, MessageState messageState) {
         this.listeners = listeners;
+        this.messageState = messageState;
     }
 
     @Override
     public void onUnpublished(Message message, Topic topic, Exception exception) {
-        listeners.onError(message, topic, exception);
+        if (messageState.wasDelegatedToKafka()) {
+            listeners.onError(message, topic, exception);
+        }
     }
 
     @Override


### PR DESCRIPTION
This is a minimalistic PR fixing memory leak problem when kafka is down.

Currently when kafka is down frontend persists all messages in backup storage. Backup storage allocates memory off heap. So it quickly can lead to no free memory on the machine. This fix does not persist messages in backup storage when there is no free space in internal kafka producer buffer. For this situation 5xx status code is returned. 

With this fix message will be only persisted in backup storage when 202 status code is returned.