### PR TITLE
489 replaced avropath with simple avro filter

### DIFF
--- a/hermes-consumers/build.gradle
+++ b/hermes-consumers/build.gradle
@@ -11,7 +11,6 @@ dependencies {
     compile group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.1'
     compile group: 'com.github.rholder', name: 'guava-retrying', version: '2.0.0'
 
-    compile group: 'com.wandoulabs.avro', name: 'wandou-avpath_2.11', version: '0.1.0'
     compile group: 'com.jayway.jsonpath', name: 'json-path', version: '2.2.0'
 
     compile(group: 'org.hornetq', name: 'hornetq-jms-client', version: '2.4.1.Final') {

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/filtering/avro/AvroPathSubscriptionMessageFilterCompiler.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/filtering/avro/AvroPathSubscriptionMessageFilterCompiler.java
@@ -3,7 +3,6 @@ package pl.allegro.tech.hermes.consumers.consumer.filtering.avro;
 import pl.allegro.tech.hermes.api.MessageFilterSpecification;
 import pl.allegro.tech.hermes.consumers.consumer.Message;
 import pl.allegro.tech.hermes.consumers.consumer.filtering.SubscriptionMessageFilterCompiler;
-import wandou.avpath.Parser;
 
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
@@ -17,7 +16,6 @@ public class AvroPathSubscriptionMessageFilterCompiler implements SubscriptionMe
 
     @Override
     public Predicate<Message> compile(MessageFilterSpecification specification) {
-        return new AvroPathPredicate(new Parser().parse(specification.getPath()),
-                Pattern.compile(specification.getMatcher()));
+        return new AvroPathPredicate(specification.getPath(), Pattern.compile(specification.getMatcher()));
     }
 }

--- a/hermes-consumers/src/test/resources/cake.avsc
+++ b/hermes-consumers/src/test/resources/cake.avsc
@@ -21,53 +21,46 @@
     },
     {
       "name": "topping",
-      "type": {
-        "type": "array",
-        "items": {
-          "name": "toppingType",
-          "type": "record",
-          "fields": [
-            {
-              "name": "id",
-              "type": "string"
-            },
-            {
-              "name": "type",
-              "type": "string"
-            }
-          ]
-        }
-      },
-      "default": []
+      "type": [ "null", {
+             "name": "toppingType",
+             "type": "record",
+             "fields": [
+               {
+                 "name": "id",
+                 "type": "string"
+               },
+               {
+                 "name": "type",
+                 "type": "string"
+               },
+               {
+                 "name": "description",
+                 "default": null,
+                 "type": [ "null", "string" ]
+               }
+             ]
+           }
+         ],
+      "default": null
     },
     {
-      "name": "batters",
-      "type": {
+      "name": "batter",
+      "type": [ "null", {
         "type": "record",
         "name": "batterType",
         "fields": [
           {
-            "name": "batter",
-            "type": {
-              "type": "array",
-              "items": {
-                "name": "batter",
-                "type": "record",
-                "fields": [
-                  {
-                    "name": "id",
-                    "type": "string"
-                  },
-                  {
-                    "name": "type",
-                    "type": "string"
-                  }
-                ]
-              }
-            }
+            "name": "id",
+            "type": "string"
+          },
+          {
+            "name": "type",
+            "type": "string"
           }
         ]
       }
+    ],
+    "default": null
     }
   ]
 }


### PR DESCRIPTION
This PR removed usage of avpath library because it seems to no longer be maintained. As a replacement we have simple selector that understands paths like ".foo.bar". Matching over collections and any sort of complex querying is not supported at the moment. With that being said this filter supports all cases that we encountered in production at the moment.