### PR TITLE
Subscription metadata visibility

### DIFF
--- a/hermes-console/static/js/console/subscription/SubscriptionController.js
+++ b/hermes-console/static/js/console/subscription/SubscriptionController.js
@@ -52,6 +52,15 @@ subscriptions.controller('SubscriptionController', ['SubscriptionRepository', 'S
                 $scope.undelivered = [];
             });
 
+        $scope.notSupportedEndpointAddressResolverMetadataEntries = function(metadataEntries) {
+          var filtered = {};
+          _.each(metadataEntries, function(entry, key) {
+              if (key in config.endpointAddressResolverMetadata === false) {
+                  filtered[key] = entry;
+              }
+          });
+          return filtered;
+        }
 
         $scope.edit = function () {
             $modal.open({

--- a/hermes-console/static/partials/subscription.html
+++ b/hermes-console/static/partials/subscription.html
@@ -156,9 +156,13 @@
                         <strong>Monitoring reaction:</strong> {{subscription.monitoringDetails.reaction}}
                         <span uib-popover='Information for monitoring how to react when the subscription becomes unhealthy (e.g. team name or Pager Duty ID).' popover-trigger="mouseenter" class="fa helpme pull-right">&#xf128;</span>
                     </p>
-                    <p ng-repeat="(key, value) in subscription.endpointAddressResolverMetadata" ng-init="entry = endpointAddressResolverMetadataConfig[key]">
-                        <strong>{{entry.title || key}}:</strong> {{entry.options[value] || value}}
+                    <p ng-repeat="(key, entry) in endpointAddressResolverMetadataConfig">
+                        <strong>{{entry.title}}:</strong>
+                        {{entry.options[subscription.endpointAddressResolverMetadata[key]] || subscription.endpointAddressResolverMetadata[key]}}
                         <span ng-show="entry.hint" uib-popover="{{entry.hint}}" popover-trigger="mouseenter" class="fa helpme pull-right">&#xf128;</span>
+                    </p>
+                    <p ng-repeat="(key, value) in notSupportedEndpointAddressResolverMetadataEntries(subscription.endpointAddressResolverMetadata)">
+                        <strong>{{key}}:</strong> {{value}}
                     </p>
                 </div>
             </div>


### PR DESCRIPTION
Fixing subscription metadata visibility in the console: available metadata entries will always be visible, even when not set for subscription.