### PR TITLE
add rate limiting to filtered messages

### DIFF
--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/BatchConsumer.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/BatchConsumer.java
@@ -21,6 +21,7 @@ import pl.allegro.tech.hermes.consumers.consumer.batch.MessageBatchingResult;
 import pl.allegro.tech.hermes.consumers.consumer.converter.MessageConverterResolver;
 import pl.allegro.tech.hermes.consumers.consumer.offset.OffsetQueue;
 import pl.allegro.tech.hermes.consumers.consumer.offset.SubscriptionPartitionOffset;
+import pl.allegro.tech.hermes.consumers.consumer.rate.BatchConsumerRateLimiter;
 import pl.allegro.tech.hermes.consumers.consumer.receiver.MessageReceiver;
 import pl.allegro.tech.hermes.consumers.consumer.receiver.ReceiverFactory;
 import pl.allegro.tech.hermes.consumers.consumer.sender.MessageBatchSender;
@@ -119,7 +120,7 @@ public class BatchConsumer implements Consumer {
     @Override
     public void initialize() {
         logger.debug("Consumer: preparing receiver for subscription {}", subscription.getQualifiedName());
-        MessageReceiver receiver = messageReceiverFactory.createMessageReceiver(topic, subscription);
+        MessageReceiver receiver = messageReceiverFactory.createMessageReceiver(topic, subscription, new BatchConsumerRateLimiter());
 
         logger.debug("Consumer: preparing batch receiver for subscription {}", subscription.getQualifiedName());
         this.receiver = new MessageBatchReceiver(receiver, batchFactory, hermesMetrics, messageConverterResolver, messageContentWrapper, topic, trackers);

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/ConsumerMessageSender.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/ConsumerMessageSender.java
@@ -5,8 +5,8 @@ import org.slf4j.LoggerFactory;
 import pl.allegro.tech.hermes.api.Subscription;
 import pl.allegro.tech.hermes.common.metric.HermesMetrics;
 import pl.allegro.tech.hermes.common.metric.timer.ConsumerLatencyTimer;
-import pl.allegro.tech.hermes.consumers.consumer.rate.ConsumerRateLimiter;
 import pl.allegro.tech.hermes.consumers.consumer.rate.InflightsPool;
+import pl.allegro.tech.hermes.consumers.consumer.rate.SerialConsumerRateLimiter;
 import pl.allegro.tech.hermes.consumers.consumer.result.ErrorHandler;
 import pl.allegro.tech.hermes.consumers.consumer.result.SuccessHandler;
 import pl.allegro.tech.hermes.consumers.consumer.sender.MessageSender;
@@ -16,8 +16,8 @@ import pl.allegro.tech.hermes.consumers.consumer.sender.MessageSendingResultLogI
 import pl.allegro.tech.hermes.consumers.consumer.sender.timeout.FutureAsyncTimeout;
 
 import java.time.Duration;
-import java.util.Objects;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -25,7 +25,6 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
 import static java.lang.String.format;
-import static pl.allegro.tech.hermes.consumers.consumer.sender.MessageSendingResult.failedResult;
 
 public class ConsumerMessageSender {
 
@@ -34,7 +33,7 @@ public class ConsumerMessageSender {
     private final ExecutorService deliveryReportingExecutor;
     private final SuccessHandler successHandler;
     private final ErrorHandler errorHandler;
-    private final ConsumerRateLimiter rateLimiter;
+    private final SerialConsumerRateLimiter rateLimiter;
     private final MessageSenderFactory messageSenderFactory;
     private final InflightsPool inflight;
     private final FutureAsyncTimeout<MessageSendingResult> async;
@@ -46,9 +45,15 @@ public class ConsumerMessageSender {
 
     private volatile boolean running = true;
 
-    public ConsumerMessageSender(Subscription subscription, MessageSenderFactory messageSenderFactory, SuccessHandler successHandler,
-                                 ErrorHandler errorHandler, ConsumerRateLimiter rateLimiter, ExecutorService deliveryReportingExecutor,
-                                 InflightsPool inflight, HermesMetrics hermesMetrics, int asyncTimeoutMs,
+    public ConsumerMessageSender(Subscription subscription,
+                                 MessageSenderFactory messageSenderFactory,
+                                 SuccessHandler successHandler,
+                                 ErrorHandler errorHandler,
+                                 SerialConsumerRateLimiter rateLimiter,
+                                 ExecutorService deliveryReportingExecutor,
+                                 InflightsPool inflight,
+                                 HermesMetrics hermesMetrics,
+                                 int asyncTimeoutMs,
                                  FutureAsyncTimeout<MessageSendingResult> futureAsyncTimeout) {
         this.deliveryReportingExecutor = deliveryReportingExecutor;
         this.successHandler = successHandler;

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/ConsumerMessageSenderFactory.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/ConsumerMessageSenderFactory.java
@@ -7,7 +7,7 @@ import pl.allegro.tech.hermes.common.message.undelivered.UndeliveredMessageLog;
 import pl.allegro.tech.hermes.common.metric.HermesMetrics;
 import pl.allegro.tech.hermes.common.metric.executor.InstrumentedExecutorServiceFactory;
 import pl.allegro.tech.hermes.consumers.consumer.offset.OffsetQueue;
-import pl.allegro.tech.hermes.consumers.consumer.rate.ConsumerRateLimiter;
+import pl.allegro.tech.hermes.consumers.consumer.rate.SerialConsumerRateLimiter;
 import pl.allegro.tech.hermes.consumers.consumer.rate.InflightsPool;
 import pl.allegro.tech.hermes.consumers.consumer.result.DefaultErrorHandler;
 import pl.allegro.tech.hermes.consumers.consumer.result.DefaultSuccessHandler;
@@ -53,7 +53,7 @@ public class ConsumerMessageSenderFactory {
                 configFactory.getBooleanProperty(Configs.CONSUMER_RATE_LIMITER_REPORTING_THREAD_POOL_MONITORING));
     }
     
-    public ConsumerMessageSender create(Subscription subscription, ConsumerRateLimiter consumerRateLimiter,
+    public ConsumerMessageSender create(Subscription subscription, SerialConsumerRateLimiter consumerRateLimiter,
                                         OffsetQueue offsetQueue, InflightsPool inflight) {
         
         SuccessHandler successHandler = new DefaultSuccessHandler(offsetQueue, hermesMetrics, trackers);

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/SerialConsumer.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/SerialConsumer.java
@@ -10,7 +10,7 @@ import pl.allegro.tech.hermes.consumers.consumer.converter.MessageConverterResol
 import pl.allegro.tech.hermes.consumers.consumer.offset.OffsetQueue;
 import pl.allegro.tech.hermes.consumers.consumer.offset.SubscriptionPartitionOffset;
 import pl.allegro.tech.hermes.consumers.consumer.rate.AdjustableSemaphore;
-import pl.allegro.tech.hermes.consumers.consumer.rate.ConsumerRateLimiter;
+import pl.allegro.tech.hermes.consumers.consumer.rate.SerialConsumerRateLimiter;
 import pl.allegro.tech.hermes.consumers.consumer.receiver.MessageReceiver;
 import pl.allegro.tech.hermes.consumers.consumer.receiver.MessageReceivingTimeoutException;
 import pl.allegro.tech.hermes.consumers.consumer.receiver.ReceiverFactory;
@@ -28,7 +28,7 @@ public class SerialConsumer implements Consumer {
 
     private final ReceiverFactory messageReceiverFactory;
     private final HermesMetrics hermesMetrics;
-    private final ConsumerRateLimiter rateLimiter;
+    private final SerialConsumerRateLimiter rateLimiter;
     private final Trackers trackers;
     private final MessageConverterResolver messageConverterResolver;
     private final ConsumerMessageSender sender;
@@ -46,7 +46,7 @@ public class SerialConsumer implements Consumer {
     public SerialConsumer(ReceiverFactory messageReceiverFactory,
                           HermesMetrics hermesMetrics,
                           Subscription subscription,
-                          ConsumerRateLimiter rateLimiter,
+                          SerialConsumerRateLimiter rateLimiter,
                           ConsumerMessageSenderFactory consumerMessageSenderFactory,
                           Trackers trackers,
                           MessageConverterResolver messageConverterResolver,
@@ -120,7 +120,7 @@ public class SerialConsumer implements Consumer {
     }
 
     private void initializeMessageReceiver() {
-        this.messageReceiver = messageReceiverFactory.createMessageReceiver(topic, subscription);
+        this.messageReceiver = messageReceiverFactory.createMessageReceiver(topic, subscription, rateLimiter);
     }
 
     @Override

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/rate/BatchConsumerRateLimiter.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/rate/BatchConsumerRateLimiter.java
@@ -1,0 +1,34 @@
+package pl.allegro.tech.hermes.consumers.consumer.rate;
+
+import pl.allegro.tech.hermes.api.Subscription;
+
+public class BatchConsumerRateLimiter implements ConsumerRateLimiter {
+
+    @Override
+    public void initialize() {
+    }
+
+    @Override
+    public void shutdown() {
+    }
+
+    @Override
+    public void acquire() {
+    }
+
+    @Override
+    public void adjustConsumerRate() {
+    }
+
+    @Override
+    public void updateSubscription(Subscription newSubscription) {
+    }
+
+    @Override
+    public void registerSuccessfulSending() {
+    }
+
+    @Override
+    public void registerFailedSending() {
+    }
+}

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/rate/ConsumerRateLimitSupervisor.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/rate/ConsumerRateLimitSupervisor.java
@@ -4,14 +4,15 @@ import pl.allegro.tech.hermes.common.config.ConfigFactory;
 import pl.allegro.tech.hermes.common.config.Configs;
 
 import javax.inject.Inject;
+import java.util.Collections;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
-import org.boon.collections.ConcurrentHashSet;
 
 public class ConsumerRateLimitSupervisor implements Runnable {
 
-    private final Set<ConsumerRateLimiter> consumerRateLimiters = new ConcurrentHashSet<>();
+    private final Set<ConsumerRateLimiter> consumerRateLimiters = Collections.newSetFromMap(new ConcurrentHashMap<>());
 
     @Inject
     public ConsumerRateLimitSupervisor(ConfigFactory configFactory) {

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/rate/ConsumerRateLimiter.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/rate/ConsumerRateLimiter.java
@@ -1,97 +1,20 @@
 package pl.allegro.tech.hermes.consumers.consumer.rate;
 
-import com.google.common.util.concurrent.RateLimiter;
 import pl.allegro.tech.hermes.api.Subscription;
-import pl.allegro.tech.hermes.common.metric.HermesMetrics;
-import pl.allegro.tech.hermes.consumers.consumer.rate.calculator.OutputRateCalculationResult;
-import pl.allegro.tech.hermes.consumers.consumer.rate.calculator.OutputRateCalculator;
 
-public class ConsumerRateLimiter {
+public interface ConsumerRateLimiter {
 
-    private Subscription subscription;
+    void initialize();
 
-    private final HermesMetrics hermesMetrics;
+    void shutdown();
 
-    private final ConsumerRateLimitSupervisor rateLimitSupervisor;
+    void acquire();
 
-    private final RateLimiter rateLimiter;
+    void adjustConsumerRate();
 
-    private final OutputRateCalculator outputRateCalculator;
+    void updateSubscription(Subscription newSubscription);
 
-    private final DeliveryCounters deliveryCounters = new DeliveryCounters();
+    void registerSuccessfulSending();
 
-    private OutputRateCalculator.Mode currentMode;
-
-    public ConsumerRateLimiter(Subscription subscription, OutputRateCalculator outputRateCalculator,
-            HermesMetrics hermesMetrics, ConsumerRateLimitSupervisor rateLimitSupervisor) {
-
-        this.subscription = subscription;
-        this.hermesMetrics = hermesMetrics;
-        this.rateLimitSupervisor = rateLimitSupervisor;
-        this.outputRateCalculator = outputRateCalculator;
-        this.currentMode = OutputRateCalculator.Mode.NORMAL;
-        this.rateLimiter = RateLimiter.create(calculateInitialRate().rate());
-    }
-
-    public void initialize() {
-        adjustConsumerRate();
-        hermesMetrics.registerOutputRateGauge(subscription.getTopicName(), subscription.getName(), rateLimiter::getRate);
-        rateLimitSupervisor.register(this);
-    }
-
-    public void shutdown() {
-        hermesMetrics.unregisterOutputRateGauge(subscription.getTopicName(), subscription.getName());
-        rateLimitSupervisor.unregister(this);
-    }
-
-    public void acquire() {
-        rateLimiter.acquire();
-    }
-
-    public void adjustConsumerRate() {
-        OutputRateCalculationResult result = recalculate();
-        rateLimiter.setRate(result.rate());
-        currentMode = result.mode();
-        deliveryCounters.reset();
-    }
-
-    private OutputRateCalculationResult calculateInitialRate() {
-        return outputRateCalculator.recalculateRate(subscription, deliveryCounters, currentMode, 0.0);
-    }
-
-    private OutputRateCalculationResult recalculate() {
-        return outputRateCalculator.recalculateRate(subscription, deliveryCounters, currentMode, rateLimiter.getRate());
-    }
-
-    public void updateSubscription(Subscription newSubscription) {
-        this.subscription = newSubscription;
-    }
-
-    public void registerSuccessfulSending() {
-        deliveryCounters.incrementSuccesses();
-    }
-
-    public void registerFailedSending() {
-        deliveryCounters.incrementFailures();
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-
-        ConsumerRateLimiter that = (ConsumerRateLimiter) o;
-
-        return subscription.equals(that.subscription);
-    }
-
-    @Override
-    public int hashCode() {
-        return subscription.hashCode();
-    }
+    void registerFailedSending();
 }

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/rate/SerialConsumerRateLimiter.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/rate/SerialConsumerRateLimiter.java
@@ -1,0 +1,106 @@
+package pl.allegro.tech.hermes.consumers.consumer.rate;
+
+import com.google.common.util.concurrent.RateLimiter;
+import pl.allegro.tech.hermes.api.Subscription;
+import pl.allegro.tech.hermes.common.metric.HermesMetrics;
+import pl.allegro.tech.hermes.consumers.consumer.rate.calculator.OutputRateCalculationResult;
+import pl.allegro.tech.hermes.consumers.consumer.rate.calculator.OutputRateCalculator;
+
+import java.util.Objects;
+
+public class SerialConsumerRateLimiter implements ConsumerRateLimiter {
+
+    private Subscription subscription;
+
+    private final HermesMetrics hermesMetrics;
+
+    private final ConsumerRateLimitSupervisor rateLimitSupervisor;
+
+    private final RateLimiter rateLimiter;
+
+    private final OutputRateCalculator outputRateCalculator;
+
+    private final DeliveryCounters deliveryCounters = new DeliveryCounters();
+
+    private OutputRateCalculator.Mode currentMode;
+
+    public SerialConsumerRateLimiter(Subscription subscription, OutputRateCalculator outputRateCalculator,
+                                     HermesMetrics hermesMetrics, ConsumerRateLimitSupervisor rateLimitSupervisor) {
+
+        this.subscription = subscription;
+        this.hermesMetrics = hermesMetrics;
+        this.rateLimitSupervisor = rateLimitSupervisor;
+        this.outputRateCalculator = outputRateCalculator;
+        this.currentMode = OutputRateCalculator.Mode.NORMAL;
+        this.rateLimiter = RateLimiter.create(calculateInitialRate().rate());
+    }
+
+    @Override
+    public void initialize() {
+        adjustConsumerRate();
+        hermesMetrics.registerOutputRateGauge(subscription.getTopicName(), subscription.getName(), rateLimiter::getRate);
+        rateLimitSupervisor.register(this);
+    }
+
+    @Override
+    public void shutdown() {
+        hermesMetrics.unregisterOutputRateGauge(subscription.getTopicName(), subscription.getName());
+        rateLimitSupervisor.unregister(this);
+    }
+
+    @Override
+    public void acquire() {
+        rateLimiter.acquire();
+    }
+
+    @Override
+    public void adjustConsumerRate() {
+        OutputRateCalculationResult result = recalculate();
+        rateLimiter.setRate(result.rate());
+        currentMode = result.mode();
+        deliveryCounters.reset();
+    }
+
+    private OutputRateCalculationResult calculateInitialRate() {
+        return outputRateCalculator.recalculateRate(subscription, deliveryCounters, currentMode, 0.0);
+    }
+
+    private OutputRateCalculationResult recalculate() {
+        return outputRateCalculator.recalculateRate(subscription, deliveryCounters, currentMode, rateLimiter.getRate());
+    }
+
+    @Override
+    public void updateSubscription(Subscription newSubscription) {
+        this.subscription = newSubscription;
+    }
+
+    @Override
+    public void registerSuccessfulSending() {
+        deliveryCounters.incrementSuccesses();
+    }
+
+    @Override
+    public void registerFailedSending() {
+        deliveryCounters.incrementFailures();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        SerialConsumerRateLimiter that = (SerialConsumerRateLimiter) o;
+
+        return Objects.equals(subscription.getQualifiedName(), that.subscription.getQualifiedName());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(subscription.getQualifiedName());
+    }
+}

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/receiver/ReceiverFactory.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/receiver/ReceiverFactory.java
@@ -2,10 +2,12 @@ package pl.allegro.tech.hermes.consumers.consumer.receiver;
 
 import pl.allegro.tech.hermes.api.Subscription;
 import pl.allegro.tech.hermes.api.Topic;
-import pl.allegro.tech.hermes.consumers.consumer.batch.MessageBatchReceiver;
+import pl.allegro.tech.hermes.consumers.consumer.rate.ConsumerRateLimiter;
 
 public interface ReceiverFactory {
 
-    MessageReceiver createMessageReceiver(Topic receivingTopic, Subscription subscription);
+    MessageReceiver createMessageReceiver(Topic receivingTopic,
+                                          Subscription subscription,
+                                          ConsumerRateLimiter consumerRateLimiter);
 
 }

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/ConsumerFactory.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/ConsumerFactory.java
@@ -13,7 +13,7 @@ import pl.allegro.tech.hermes.consumers.consumer.batch.MessageBatchFactory;
 import pl.allegro.tech.hermes.consumers.consumer.converter.MessageConverterResolver;
 import pl.allegro.tech.hermes.consumers.consumer.offset.OffsetQueue;
 import pl.allegro.tech.hermes.consumers.consumer.rate.ConsumerRateLimitSupervisor;
-import pl.allegro.tech.hermes.consumers.consumer.rate.ConsumerRateLimiter;
+import pl.allegro.tech.hermes.consumers.consumer.rate.SerialConsumerRateLimiter;
 import pl.allegro.tech.hermes.consumers.consumer.rate.calculator.OutputRateCalculator;
 import pl.allegro.tech.hermes.consumers.consumer.receiver.ReceiverFactory;
 import pl.allegro.tech.hermes.consumers.consumer.sender.MessageBatchSenderFactory;
@@ -82,7 +82,7 @@ public class ConsumerFactory {
                     subscription,
                     topic);
         } else {
-            ConsumerRateLimiter consumerRateLimiter = new ConsumerRateLimiter(subscription, outputRateCalculator, hermesMetrics,
+            SerialConsumerRateLimiter consumerRateLimiter = new SerialConsumerRateLimiter(subscription, outputRateCalculator, hermesMetrics,
                     consumerRateLimitSupervisor);
 
             return new SerialConsumer(

--- a/hermes-consumers/src/test/java/pl/allegro/tech/hermes/consumers/consumer/ConsumerMessageSenderTest.java
+++ b/hermes-consumers/src/test/java/pl/allegro/tech/hermes/consumers/consumer/ConsumerMessageSenderTest.java
@@ -11,7 +11,7 @@ import pl.allegro.tech.hermes.common.metric.HermesMetrics;
 import pl.allegro.tech.hermes.common.metric.Meters;
 import pl.allegro.tech.hermes.common.metric.timer.ConsumerLatencyTimer;
 import pl.allegro.tech.hermes.consumers.consumer.rate.AdjustableSemaphore;
-import pl.allegro.tech.hermes.consumers.consumer.rate.ConsumerRateLimiter;
+import pl.allegro.tech.hermes.consumers.consumer.rate.SerialConsumerRateLimiter;
 import pl.allegro.tech.hermes.consumers.consumer.result.ErrorHandler;
 import pl.allegro.tech.hermes.consumers.consumer.result.SuccessHandler;
 import pl.allegro.tech.hermes.consumers.consumer.sender.MessageSender;
@@ -60,7 +60,7 @@ public class ConsumerMessageSenderTest {
     private ErrorHandler errorHandler;
 
     @Mock
-    private ConsumerRateLimiter rateLimiter;
+    private SerialConsumerRateLimiter rateLimiter;
 
     @Mock
     private HermesMetrics hermesMetrics;


### PR DESCRIPTION
We rate limit sending messages, but we have no limits for filtered messages. This means that if lag on filtered subscription is high and most of the messages get filtered, we spend a lot of time reading & discarding messages. This PR adds rate limiting to filtered messages. Rate limiter is shared with sending rate limiter.