### PR TITLE
488 added expire_after_access to CachedCompiledSchemaRepository

### DIFF
--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/common/config/Configs.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/common/config/Configs.java
@@ -159,6 +159,7 @@ public enum Configs {
 
     SCHEMA_CACHE_REFRESH_AFTER_WRITE_MINUTES("schema.cache.refresh.after.write.minutes", 10),
     SCHEMA_CACHE_EXPIRE_AFTER_WRITE_MINUTES("schema.cache.expire.after.write.minutes", 60 * 24),
+    SCHEMA_CACHE_COMPILED_EXPIRE_AFTER_ACCESS_MINUTES("schema.cache.compiled.expire.after.access.minutes", 60 * 48),
     SCHEMA_CACHE_RELOAD_THREAD_POOL_SIZE("schema.cache.reload.thread.pool.size", 2),
     SCHEMA_CACHE_ENABLED("schema.cache.enabled", true),
     SCHEMA_CACHE_COMPILED_MAXIMUM_SIZE("schema.cache.compiled.maximum.size", 2000),

--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/domain/topic/schema/CachedCompiledSchemaRepository.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/domain/topic/schema/CachedCompiledSchemaRepository.java
@@ -6,15 +6,17 @@ import com.google.common.cache.LoadingCache;
 import pl.allegro.tech.hermes.api.Topic;
 
 import java.util.Objects;
+import java.util.concurrent.TimeUnit;
 
 public class CachedCompiledSchemaRepository<T> implements CompiledSchemaRepository<T> {
 
     private final LoadingCache<TopicAndSchemaVersion, CompiledSchema<T>> cache;
 
-    public CachedCompiledSchemaRepository(CompiledSchemaRepository<T> delegate, long maximumCacheSize) {
+    public CachedCompiledSchemaRepository(CompiledSchemaRepository<T> delegate, long maximumCacheSize, int expireAfterAccessMinutes) {
         this.cache = CacheBuilder
                 .newBuilder()
                 .maximumSize(maximumCacheSize)
+                .expireAfterAccess(expireAfterAccessMinutes, TimeUnit.MINUTES)
                 .build(new SchemaSourceLoader<>(delegate));
     }
 

--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/infrastructure/schema/AvroCompiledSchemaRepositoryFactory.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/infrastructure/schema/AvroCompiledSchemaRepositoryFactory.java
@@ -23,7 +23,8 @@ public class AvroCompiledSchemaRepositoryFactory implements Factory<CompiledSche
     public CompiledSchemaRepository<Schema> provide() {
         return new CachedCompiledSchemaRepository<>(
                 new DirectCompiledSchemaRepository<>(schemaSourceProvider, SchemaCompilersFactory.avroSchemaCompiler()),
-                configFactory.getIntProperty(Configs.SCHEMA_CACHE_COMPILED_MAXIMUM_SIZE));
+                configFactory.getIntProperty(Configs.SCHEMA_CACHE_COMPILED_MAXIMUM_SIZE),
+                configFactory.getIntProperty(Configs.SCHEMA_CACHE_COMPILED_EXPIRE_AFTER_ACCESS_MINUTES));
     }
 
     @Override

--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/infrastructure/schema/JsonCompiledSchemaRepositoryFactory.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/infrastructure/schema/JsonCompiledSchemaRepositoryFactory.java
@@ -26,7 +26,8 @@ public class JsonCompiledSchemaRepositoryFactory implements Factory<CompiledSche
     public CompiledSchemaRepository<JsonSchema> provide() {
         return new CachedCompiledSchemaRepository<>(
                 new DirectCompiledSchemaRepository<>(schemaSourceProvider, SchemaCompilersFactory.jsonSchemaCompiler(objectMapper)),
-                configFactory.getIntProperty(Configs.SCHEMA_CACHE_COMPILED_MAXIMUM_SIZE));
+                configFactory.getIntProperty(Configs.SCHEMA_CACHE_COMPILED_MAXIMUM_SIZE),
+                configFactory.getIntProperty(Configs.SCHEMA_CACHE_COMPILED_EXPIRE_AFTER_ACCESS_MINUTES));
     }
 
     @Override

--- a/hermes-common/src/test/groovy/pl/allegro/tech/hermes/domain/topic/schema/CachedCompiledSchemaRepositoryTest.groovy
+++ b/hermes-common/src/test/groovy/pl/allegro/tech/hermes/domain/topic/schema/CachedCompiledSchemaRepositoryTest.groovy
@@ -7,7 +7,7 @@ import static pl.allegro.tech.hermes.test.helper.builder.TopicBuilder.topic
 class CachedCompiledSchemaRepositoryTest extends Specification {
 
     def delegate = Stub(CompiledSchemaRepository)
-    def repository = new CachedCompiledSchemaRepository(delegate, 100)
+    def repository = new CachedCompiledSchemaRepository(delegate, 100, 100)
 
     def topic = topic("group", "topic").build()
 


### PR DESCRIPTION
Added expire-after-access to second level schema repository cache. Main idea is that cache is self maintaining and invalidates entries that were not used for *n* minutes/hours/days. This should reduce memory footprint for our dev/test environment and also partially support workflow where user wants to  delete entire topic with all its schemas and replace it with topic with the same name. In this solution on  *topic reboot* it is required to wait until all caches invalidate. Previously we had to reset entire module to clear caches with compiled schemas.