### PR TITLE
process interrupts in highly filtered subscriptions

### DIFF
--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/common/config/Configs.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/common/config/Configs.java
@@ -104,7 +104,7 @@ public enum Configs {
     MESSAGES_LOADING_WAIT_FOR_BROKER_TOPIC_INFO("frontend.messages.loading.wait.for.broker.topic.info", 5),
 
     CONSUMER_COMMIT_OFFSET_PERIOD("consumer.commit.offset.period", 15),
-    CONSUMER_COMMIT_OFFSET_QUEUES_SIZE("consumer.commit.offset.queues.size", 200_000),
+    CONSUMER_COMMIT_OFFSET_QUEUES_SIZE("consumer.commit.offset.queues.size", 500_000),
     CONSUMER_SENDER_ASYNC_TIMEOUT_MS("consumer.sender.async.timeout.ms", 5_000),
     CONSUMER_SENDER_ASYNC_TIMEOUT_THREAD_POOL_SIZE("consumer.sender.async.timeout.thread.pool.size", 32),
     CONSUMER_SENDER_ASYNC_TIMEOUT_THREAD_POOL_MONITORING("consumer.sender.async.timeout.thread.pool.monitoring", false),

--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/common/metric/counter/zookeeper/CounterMatcher.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/common/metric/counter/zookeeper/CounterMatcher.java
@@ -16,11 +16,16 @@ class CounterMatcher {
     private void parseCounter(String counterName) {
         String[] splitted = counterName.split("\\.");
         if (isTopicPublished()) {
-            topicName = splitted[splitted.length-2] + "." + splitted[splitted.length-1];
+            topicName = splitted[splitted.length - 2] + "." + splitted[splitted.length - 1];
             subscription = Optional.empty();
-        } else if (isSubscriptionDelivered() || isSubscriptionDiscarded() || isSubscriptionInflight()) {
-            subscription = Optional.of(splitted[splitted.length -1]);
-            topicName = splitted[splitted.length-3] + "." + splitted[splitted.length-2];
+        } else if (
+                isSubscriptionDelivered()
+                        || isSubscriptionDiscarded()
+                        || isSubscriptionInflight()
+                        || isSubscriptionFiltered()
+                ) {
+            subscription = Optional.of(splitted[splitted.length - 1]);
+            topicName = splitted[splitted.length - 3] + "." + splitted[splitted.length - 2];
         }
     }
 
@@ -38,6 +43,10 @@ class CounterMatcher {
 
     public boolean isSubscriptionInflight() {
         return counterName.startsWith("inflight.");
+    }
+
+    public boolean isSubscriptionFiltered() {
+        return counterName.startsWith("filtered.");
     }
 
     public String getTopicName() {

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/SerialConsumer.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/SerialConsumer.java
@@ -12,10 +12,10 @@ import pl.allegro.tech.hermes.consumers.consumer.offset.SubscriptionPartitionOff
 import pl.allegro.tech.hermes.consumers.consumer.rate.AdjustableSemaphore;
 import pl.allegro.tech.hermes.consumers.consumer.rate.SerialConsumerRateLimiter;
 import pl.allegro.tech.hermes.consumers.consumer.receiver.MessageReceiver;
-import pl.allegro.tech.hermes.consumers.consumer.receiver.MessageReceivingTimeoutException;
 import pl.allegro.tech.hermes.consumers.consumer.receiver.ReceiverFactory;
 import pl.allegro.tech.hermes.tracker.consumers.Trackers;
 
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 import static pl.allegro.tech.hermes.common.config.Configs.CONSUMER_INFLIGHT_SIZE;
@@ -84,20 +84,23 @@ public class SerialConsumer implements Consumer {
                 signalsInterrupt.run();
             } while (!inflightSemaphore.tryAcquire(signalProcessingInterval, TimeUnit.MILLISECONDS));
 
-            Message message = messageReceiver.next();
+            Optional<Message> maybeMessage = messageReceiver.next();
 
-            if (logger.isDebugEnabled()) {
-                logger.debug(
-                        "Read message {} partition {} offset {}",
-                        message.getContentType(), message.getPartition(), message.getOffset()
-                );
+            if (maybeMessage.isPresent()) {
+                Message message = maybeMessage.get();
+
+                if (logger.isDebugEnabled()) {
+                    logger.debug(
+                            "Read message {} partition {} offset {}",
+                            message.getContentType(), message.getPartition(), message.getOffset()
+                    );
+                }
+
+                Message convertedMessage = messageConverterResolver.converterFor(message, subscription).convert(message, topic);
+                sendMessage(convertedMessage);
+            } else {
+                inflightSemaphore.release();
             }
-
-            Message convertedMessage = messageConverterResolver.converterFor(message, subscription).convert(message, topic);
-            sendMessage(convertedMessage);
-        } catch (MessageReceivingTimeoutException messageReceivingTimeoutException) {
-            inflightSemaphore.release();
-            logger.trace("Timeout while reading message for subscription {}. Trying to read message again", subscription.getQualifiedName(), messageReceivingTimeoutException);
         } catch (Exception e) {
             logger.error("Consumer loop failed for {}", subscription.getQualifiedName(), e);
         }

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/batch/MessageBatchReceiver.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/batch/MessageBatchReceiver.java
@@ -11,7 +11,6 @@ import pl.allegro.tech.hermes.common.metric.HermesMetrics;
 import pl.allegro.tech.hermes.consumers.consumer.Message;
 import pl.allegro.tech.hermes.consumers.consumer.converter.MessageConverterResolver;
 import pl.allegro.tech.hermes.consumers.consumer.receiver.MessageReceiver;
-import pl.allegro.tech.hermes.consumers.consumer.receiver.MessageReceivingTimeoutException;
 import pl.allegro.tech.hermes.tracker.consumers.MessageMetadata;
 import pl.allegro.tech.hermes.tracker.consumers.Trackers;
 
@@ -19,6 +18,7 @@ import javax.annotation.concurrent.NotThreadSafe;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.Queue;
 
 import static com.google.common.base.Preconditions.checkArgument;
@@ -69,9 +69,12 @@ public class MessageBatchReceiver {
         List<MessageMetadata> discarded = new ArrayList<>();
 
         while (isReceiving() && !batch.isReadyForDelivery()) {
-            try {
-                signalsInterrupt.run();
-                Message message = inflight.isEmpty() ? receive(subscription, batch.getId()) : inflight.poll();
+            signalsInterrupt.run();
+            Optional<Message> maybeMessage = inflight.isEmpty() ?
+                    receiver.next() : Optional.ofNullable(inflight.poll());
+
+            if (maybeMessage.isPresent()) {
+                Message message = transform(maybeMessage.get(), subscription, batch.getId());
 
                 if (batch.canFit(message.getData())) {
                     batch.append(message.getData(), messageMetadata(subscription, batch.getId(), message));
@@ -87,8 +90,6 @@ public class MessageBatchReceiver {
                     checkArgument(inflight.offer(message));
                     break;
                 }
-            } catch (MessageReceivingTimeoutException ex) {
-                // ignore
             }
         }
         if (logger.isDebugEnabled()) {
@@ -97,13 +98,12 @@ public class MessageBatchReceiver {
         return new MessageBatchingResult(batch.close(), discarded);
     }
 
-    private Message receive(Subscription subscription, String batchId) {
-        Message next = receiver.next();
-        next = messageConverterResolver.converterFor(next, subscription).convert(next, topic);
-        next = message().fromMessage(next).withData(wrap(subscription, next)).build();
+    private Message transform(Message message, Subscription subscription, String batchId) {
+        Message transformed = messageConverterResolver.converterFor(message, subscription).convert(message, topic);
+        transformed = message().fromMessage(transformed).withData(wrap(subscription, transformed)).build();
         hermesMetrics.incrementInflightCounter(subscription);
-        trackers.get(subscription).logInflight(messageMetadata(subscription, batchId, next));
-        return next;
+        trackers.get(subscription).logInflight(messageMetadata(subscription, batchId, transformed));
+        return transformed;
     }
 
     private byte[] wrap(Subscription subscription, Message next) {

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/filtering/FilteredMessageHandler.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/filtering/FilteredMessageHandler.java
@@ -55,7 +55,5 @@ public class FilteredMessageHandler {
     protected void updateMetrics(Message message, Subscription subscription) {
         metrics.meter(Meters.FILTERED_METER).mark();
         metrics.counter(Counters.FILTERED, subscription.getTopicName(), subscription.getName()).inc();
-        metrics.decrementInflightCounter(subscription);
-        metrics.inflightTimeHistogram(subscription).update(System.currentTimeMillis() - message.getReadingTimestamp());
     }
 }

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/receiver/MessageReceiver.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/receiver/MessageReceiver.java
@@ -4,9 +4,11 @@ import pl.allegro.tech.hermes.api.Subscription;
 import pl.allegro.tech.hermes.api.Topic;
 import pl.allegro.tech.hermes.consumers.consumer.Message;
 
+import java.util.Optional;
+
 public interface MessageReceiver {
 
-    Message next();
+    Optional<Message> next();
 
     default void stop() {}
 

--- a/hermes-consumers/src/test/java/pl/allegro/tech/hermes/consumers/consumer/receiver/kafka/KafkaMessageReceiverTest.java
+++ b/hermes-consumers/src/test/java/pl/allegro/tech/hermes/consumers/consumer/receiver/kafka/KafkaMessageReceiverTest.java
@@ -31,6 +31,7 @@ import pl.allegro.tech.hermes.test.helper.builder.SubscriptionBuilder;
 import java.time.Clock;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import static com.googlecode.catchexception.CatchException.catchException;
 import static com.googlecode.catchexception.CatchException.caughtException;
@@ -99,22 +100,23 @@ public class KafkaMessageReceiverTest {
         when(kafkaStream.iterator().next()).thenReturn(messageAndMetadata);
 
         // when
-        Message msg = kafkaMsgReceiver.next();
+        Optional<Message> message = kafkaMsgReceiver.next();
 
         // then
-        assertThat(new String(msg.getData())).isEqualTo(CONTENT);
+        assertThat(message).isPresent();
+        assertThat(new String(message.get().getData())).isEqualTo(CONTENT);
     }
 
     @Test
-    public void shouldThrowTimeoutExceptionWhilePollingFromEmptyQueue() {
+    public void shouldReturnEmptyOptionalWhilePollingFromEmptyQueue() {
         // given
         when(kafkaStream.iterator().next()).thenThrow(new ConsumerTimeoutException());
 
         // when
-        catchException(kafkaMsgReceiver).next();
+        Optional<Message> message = kafkaMsgReceiver.next();
 
         // then
-        assertThat((Throwable) caughtException()).isInstanceOf(MessageReceivingTimeoutException.class);
+        assertThat(message).isEmpty();
     }
 
 }

--- a/integration/src/integration/java/pl/allegro/tech/hermes/integration/BatchDeliveryTest.java
+++ b/integration/src/integration/java/pl/allegro/tech/hermes/integration/BatchDeliveryTest.java
@@ -25,6 +25,7 @@ import static pl.allegro.tech.hermes.test.helper.builder.SubscriptionBuilder.sub
 import static pl.allegro.tech.hermes.test.helper.builder.TopicBuilder.topic;
 
 public class BatchDeliveryTest extends IntegrationTest {
+
     private RemoteServiceEndpoint remoteService;
 
     private ObjectMapper mapper = new ObjectMapper();
@@ -164,7 +165,7 @@ public class BatchDeliveryTest extends IntegrationTest {
             assertThat(batch).hasSize(expectedContents.length);
             for (int i = 0; i < expectedContents.length; i++) {
                 assertThat(batch.get(i).get("message")).isEqualTo(expectedContents[i].getContent());
-                assertThat((String)((Map) batch.get(i).get("metadata")).get("id")).isNotEmpty();
+                assertThat((String) ((Map) batch.get(i).get("metadata")).get("id")).isNotEmpty();
             }
         });
     }


### PR DESCRIPTION
Currently if Consumer spends 99.999% of its time filtering out events, it will be marked as unhealthy, as it will never process incoming signals.

This PR changes the API of `MessageResolver`, so that it communicates with `Optional<Message>` instead of throwing exceptions or spinning. If message needs to be filtered out or read timed out, `Optional.empty()` is returned.