### PR TITLE
551 added source and target hostname information to tracking

### DIFF
--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/common/config/Configs.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/common/config/Configs.java
@@ -27,6 +27,7 @@ public enum Configs {
     KAFKA_ZOOKEEPER_CONNECT_STRING("kafka.zookeeper.connect.string", "localhost:2181"),
 
     ENVIRONMENT_NAME("environment.name", "dev"),
+    HOSTNAME("hostname", new InetAddressHostnameResolver().resolve()),
 
     KAFKA_CLUSTER_NAME("kafka.cluster.name", "primary"),
     KAFKA_BROKER_LIST("kafka.broker.list", "localhost:9092"),

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/ConsumerMessageSender.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/ConsumerMessageSender.java
@@ -15,6 +15,7 @@ import pl.allegro.tech.hermes.consumers.consumer.sender.MessageSendingResult;
 import pl.allegro.tech.hermes.consumers.consumer.sender.MessageSendingResultLogInfo;
 import pl.allegro.tech.hermes.consumers.consumer.sender.timeout.FutureAsyncTimeout;
 
+import java.net.URI;
 import java.time.Duration;
 import java.util.List;
 import java.util.Objects;
@@ -159,7 +160,7 @@ public class ConsumerMessageSender {
             } else {
                 handleFailedSending(message, result);
 
-                List<String> succeededUris = result.getSucceededUris(ConsumerMessageSender.this::messageSentSucceeded);
+                List<URI> succeededUris = result.getSucceededUris(ConsumerMessageSender.this::messageSentSucceeded);
                 message.incrementRetryCounter(succeededUris);
 
                 long retryDelay = extractRetryDelay(result);
@@ -192,7 +193,7 @@ public class ConsumerMessageSender {
         private void logResultInfo(MessageSendingResultLogInfo logInfo) {
             logger.debug(
                     format("Retrying message send to endpoint %s; messageId %s; offset: %s; partition: %s; sub id: %s; rootCause: %s",
-                            logInfo.getUrl(), message.getId(), message.getOffset(), message.getPartition(),
+                            logInfo.getUrlString(), message.getId(), message.getOffset(), message.getPartition(),
                             subscription.getQualifiedName(), logInfo.getRootCause()),
                     logInfo.getFailure());
         }

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/Message.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/Message.java
@@ -9,7 +9,11 @@ import pl.allegro.tech.hermes.common.kafka.KafkaTopicName;
 import pl.allegro.tech.hermes.common.kafka.offset.PartitionOffset;
 import pl.allegro.tech.hermes.domain.topic.schema.CompiledSchema;
 
+import java.net.URI;
 import java.util.*;
+import java.util.stream.Collectors;
+
+import static java.util.stream.Collectors.toList;
 
 public class Message {
 
@@ -89,9 +93,9 @@ public class Message {
         return currentTimestamp > readingTimestamp + ttlMillis;
     }
 
-    public void incrementRetryCounter(Collection<String> succeededUris) {
+    public void incrementRetryCounter(Collection<URI> succeededUris) {
         this.retryCounter++;
-        this.succeededUris.addAll(succeededUris);
+        this.succeededUris.addAll(succeededUris.stream().map(URI::toString).collect(toList()));
     }
 
     public int getRetryCounter() {

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/result/DefaultErrorHandler.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/result/DefaultErrorHandler.java
@@ -63,7 +63,7 @@ public class DefaultErrorHandler extends AbstractHandler implements ErrorHandler
             result.getLogInfo().stream().forEach(logInfo ->
                     logger.warn(
                             "Abnormal delivery failure: subscription: {}; cause: {}; endpoint: {}; messageId: {}; partition: {}; offset: {}",
-                            subscription.getQualifiedName(), logInfo.getRootCause(), logInfo.getUrl(), message.getId(),
+                            subscription.getQualifiedName(), logInfo.getRootCause(), logInfo.getUrlString(), message.getId(),
                             message.getPartition(), message.getOffset(), logInfo.getFailure()
                     )
             );
@@ -80,7 +80,7 @@ public class DefaultErrorHandler extends AbstractHandler implements ErrorHandler
     public void handleFailed(Message message, Subscription subscription, MessageSendingResult result) {
         hermesMetrics.meter(Meters.FAILED_METER_SUBSCRIPTION, subscription.getTopicName(), subscription.getName()).mark();
         registerFailureMetrics(subscription, result);
-        trackers.get(subscription).logFailed(toMessageMetadata(message, subscription), result.getRootCause());
+        trackers.get(subscription).logFailed(toMessageMetadata(message, subscription), result.getRootCause(), result.getHostname());
     }
 
     private void registerFailureMetrics(Subscription subscription, MessageSendingResult result) {

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/result/DefaultSuccessHandler.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/result/DefaultSuccessHandler.java
@@ -28,7 +28,7 @@ public class DefaultSuccessHandler extends AbstractHandler implements SuccessHan
         updateMeters(subscription, result);
         updateMetrics(Counters.DELIVERED, message, subscription);
 
-        trackers.get(subscription).logSent(toMessageMetadata(message, subscription));
+        trackers.get(subscription).logSent(toMessageMetadata(message, subscription), result.getHostname());
     }
 
     private void updateMeters(Subscription subscription, MessageSendingResult result) {

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/sender/MessageSendingResult.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/sender/MessageSendingResult.java
@@ -3,11 +3,14 @@ package pl.allegro.tech.hermes.consumers.consumer.sender;
 import org.eclipse.jetty.client.api.Result;
 import pl.allegro.tech.hermes.consumers.consumer.sender.resolver.EndpointAddressResolutionException;
 
+import java.net.URI;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
+import static java.util.stream.Collectors.joining;
 import static javax.ws.rs.core.Response.Status.OK;
 import static javax.ws.rs.core.Response.Status.SERVICE_UNAVAILABLE;
 
@@ -16,6 +19,10 @@ public interface MessageSendingResult {
 
     static SingleMessageSendingResult succeededResult() {
         return new SingleMessageSendingResult(OK.getStatusCode());
+    }
+
+    static SingleMessageSendingResult succeededResult(URI requestURI) {
+        return new SingleMessageSendingResult(OK.getStatusCode(), requestURI);
     }
 
     static SingleMessageSendingResult failedResult(Throwable cause) {
@@ -66,5 +73,9 @@ public interface MessageSendingResult {
 
     List<MessageSendingResultLogInfo> getLogInfo();
 
-    List<String> getSucceededUris(Predicate<MessageSendingResult> filter) ;
+    List<URI> getSucceededUris(Predicate<MessageSendingResult> filter) ;
+
+    default String getHostname() {
+        return getLogInfo().stream().filter(i -> i.getUrl().isPresent()).map(i -> i.getUrl().get().getHost()).collect(joining(","));
+    };
 }

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/sender/MessageSendingResultLogInfo.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/sender/MessageSendingResultLogInfo.java
@@ -1,18 +1,25 @@
 package pl.allegro.tech.hermes.consumers.consumer.sender;
 
-public class MessageSendingResultLogInfo {
-    private final String url;
-    private final String rootCause;
-    private final  Throwable failure;
+import java.net.URI;
+import java.util.Optional;
 
-    public MessageSendingResultLogInfo(String url, Throwable failure, String rootCause) {
+public class MessageSendingResultLogInfo {
+    private final Optional<URI> url;
+    private final String rootCause;
+    private final Throwable failure;
+
+    public MessageSendingResultLogInfo(Optional<URI> url, Throwable failure, String rootCause) {
         this.url = url;
         this.failure = failure;
         this.rootCause = rootCause;
     }
 
-    public String getUrl() {
+    public Optional<URI> getUrl() {
         return url;
+    }
+
+    public String getUrlString() {
+        return url.isPresent()? url.get().toString() : "";
     }
 
     public String getRootCause() {

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/sender/MultiMessageSendingResult.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/sender/MultiMessageSendingResult.java
@@ -3,6 +3,7 @@ package pl.allegro.tech.hermes.consumers.consumer.sender;
 
 import com.google.common.collect.ImmutableList;
 
+import java.net.URI;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
@@ -76,10 +77,12 @@ public class MultiMessageSendingResult implements MessageSendingResult {
 
     }
 
-    public List<String> getSucceededUris(Predicate<MessageSendingResult> filter) {
+    public List<URI> getSucceededUris(Predicate<MessageSendingResult> filter) {
             return children.stream()
                     .filter(filter)
                     .map(SingleMessageSendingResult::getRequestUri)
+                    .filter(Optional::isPresent)
+                    .map(Optional::get)
                     .collect(Collectors.toList());
 
     }
@@ -91,7 +94,7 @@ public class MultiMessageSendingResult implements MessageSendingResult {
     @Override
     public String getRootCause() {
         return children.stream()
-                .map(child -> child.getRequestUri()+":"+child.getRootCause())
+                .map(child -> child.getRequestUri().map(Object::toString).orElse("") +":"+child.getRootCause())
                 .collect(joining(";"));
     }
 }

--- a/hermes-consumers/src/test/groovy/pl/allegro/tech/hermes/consumers/consumer/result/InMemoryLogRepository.groovy
+++ b/hermes-consumers/src/test/groovy/pl/allegro/tech/hermes/consumers/consumer/result/InMemoryLogRepository.groovy
@@ -12,12 +12,12 @@ class InMemoryLogRepository implements LogRepository {
     private final List<MessageMetadata> filtered = []
 
     @Override
-    void logSuccessful(MessageMetadata message, long timestamp) {
+    void logSuccessful(MessageMetadata message, String hostname, long timestamp) {
         successful.add(message)
     }
 
     @Override
-    void logFailed(MessageMetadata message, long timestamp, String reason) {
+    void logFailed(MessageMetadata message, String hostname, long timestamp, String reason) {
         failed.add(message)
     }
 

--- a/hermes-consumers/src/test/groovy/pl/allegro/tech/hermes/consumers/consumer/sender/http/JettyBroadCastMessageSenderTest.groovy
+++ b/hermes-consumers/src/test/groovy/pl/allegro/tech/hermes/consumers/consumer/sender/http/JettyBroadCastMessageSenderTest.groovy
@@ -91,7 +91,7 @@ class JettyBroadCastMessageSenderTest extends Specification {
         !messageSendingResult.succeeded()
 
         and:
-        messageSendingResult.children.find { it.statusCode == 500 && it.requestUri == failedServiceEndpoint.url }
+        messageSendingResult.children.find { it.statusCode == 500 && it.requestUri.get() == failedServiceEndpoint.url }
     }
 
     def "should not send to already sent url on retry"() {

--- a/hermes-test-helper/src/main/java/pl/allegro/tech/hermes/test/helper/endpoint/RemoteServiceEndpoint.java
+++ b/hermes-test-helper/src/main/java/pl/allegro/tech/hermes/test/helper/endpoint/RemoteServiceEndpoint.java
@@ -9,6 +9,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import pl.allegro.tech.hermes.test.helper.message.TestMessage;
 
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -32,7 +33,7 @@ public class RemoteServiceEndpoint {
 
     private final List<LoggedRequest> receivedRequests = Collections.synchronizedList(new ArrayList<>());
     private final String path;
-    private final String url;
+    private final URI url;
 
     private final WireMock listener;
     private final WireMockServer service;
@@ -50,7 +51,7 @@ public class RemoteServiceEndpoint {
     public RemoteServiceEndpoint(WireMockServer service, final String path) {
         this.listener = new WireMock("localhost", service.port());
         this.path = path;
-        this.url = String.format("http://localhost:%d%s", service.port(), path);
+        this.url = URI.create(String.format("http://localhost:%d%s", service.port(), path));
         this.service = service;
 
         service.resetMappings();
@@ -192,7 +193,7 @@ public class RemoteServiceEndpoint {
         return this;
     }
 
-    public String getUrl() {
+    public URI getUrl() {
         return url;
     }
 

--- a/hermes-tracker-elasticsearch/src/main/java/pl/allegro/tech/hermes/tracker/elasticsearch/LogSchemaAware.java
+++ b/hermes-tracker-elasticsearch/src/main/java/pl/allegro/tech/hermes/tracker/elasticsearch/LogSchemaAware.java
@@ -13,5 +13,7 @@ public interface LogSchemaAware {
     String OFFSET = "offset";
     String REASON = "reason";
     String CLUSTER = "cluster";
+    String SOURCE_HOSTNAME = "hostname";
+    String TARGET_HOSTNAME = "target_hostname";
 
 }

--- a/hermes-tracker-elasticsearch/src/main/java/pl/allegro/tech/hermes/tracker/elasticsearch/frontend/FrontendElasticsearchLogRepository.java
+++ b/hermes-tracker-elasticsearch/src/main/java/pl/allegro/tech/hermes/tracker/elasticsearch/frontend/FrontendElasticsearchLogRepository.java
@@ -26,13 +26,14 @@ public class FrontendElasticsearchLogRepository extends BatchingLogRepository<El
 
     private FrontendElasticsearchLogRepository(Client elasticClient,
                                                String clusterName,
+                                               String hostname,
                                                int queueSize,
                                                int commitInterval,
                                                IndexFactory indexFactory,
                                                String typeName,
                                                MetricRegistry metricRegistry,
                                                PathsCompiler pathsCompiler) {
-        super(queueSize, clusterName, metricRegistry, pathsCompiler);
+        super(queueSize, clusterName, hostname, metricRegistry, pathsCompiler);
 
         registerQueueSizeGauge(Gauges.PRODUCER_TRACKER_ELASTICSEARCH_QUEUE_SIZE);
         registerRemainingCapacityGauge(Gauges.PRODUCER_TRACKER_ELASTICSEARCH_REMAINING_CAPACITY);
@@ -74,13 +75,15 @@ public class FrontendElasticsearchLogRepository extends BatchingLogRepository<El
                 .field(TIMESTAMP, timestamp)
                 .field(TOPIC_NAME, topicName)
                 .field(STATUS, status)
-                .field(CLUSTER, clusterName);
+                .field(CLUSTER, clusterName)
+                .field(SOURCE_HOSTNAME, hostname);
     }
 
     public static class Builder {
 
         private Client elasticClient;
         private String clusterName = "primary";
+        private String hostName = "unknown";
         private int queueSize = 1000;
         private int commitInterval = 100;
         private FrontendIndexFactory indexFactory = new FrontendDailyIndexFactory();
@@ -102,6 +105,11 @@ public class FrontendElasticsearchLogRepository extends BatchingLogRepository<El
 
         public Builder withClusterName(String clusterName) {
             this.clusterName = clusterName;
+            return this;
+        }
+
+        public Builder withHostName(String hostName) {
+            this.hostName = hostName;
             return this;
         }
 
@@ -128,6 +136,7 @@ public class FrontendElasticsearchLogRepository extends BatchingLogRepository<El
         public FrontendElasticsearchLogRepository build() {
             return new FrontendElasticsearchLogRepository(elasticClient,
                     clusterName,
+                    hostName,
                     queueSize,
                     commitInterval,
                     indexFactory,

--- a/hermes-tracker-mongo/src/main/java/pl/allegro/tech/hermes/tracker/mongo/LogSchemaAware.java
+++ b/hermes-tracker-mongo/src/main/java/pl/allegro/tech/hermes/tracker/mongo/LogSchemaAware.java
@@ -15,5 +15,6 @@ public interface LogSchemaAware {
     String OFFSET = "offset";
     String REASON = "reason";
     String CLUSTER = "cluster";
-
+    String SOURCE_HOSTNAME = "hostname";
+    String TARGET_HOSTNAME = "target_hostname";
 }

--- a/hermes-tracker-mongo/src/main/java/pl/allegro/tech/hermes/tracker/mongo/consumers/MongoLogRepository.java
+++ b/hermes-tracker-mongo/src/main/java/pl/allegro/tech/hermes/tracker/mongo/consumers/MongoLogRepository.java
@@ -22,9 +22,10 @@ public class MongoLogRepository extends BatchingLogRepository<DBObject> implemen
                               int queueSize,
                               int commitInterval,
                               String clusterName,
+                              String hostname,
                               MetricRegistry metricRegistry,
                               PathsCompiler pathsCompiler) {
-        super(queueSize, clusterName, metricRegistry, pathsCompiler);
+        super(queueSize, clusterName, hostname, metricRegistry, pathsCompiler);
 
         registerQueueSizeGauge(Gauges.CONSUMER_TRACKER_MONGO_QUEUE_SIZE);
         registerRemainingCapacityGauge(Gauges.CONSUMER_TRACKER_MONGO_REMAINING_CAPACITY);
@@ -34,13 +35,13 @@ public class MongoLogRepository extends BatchingLogRepository<DBObject> implemen
     }
 
     @Override
-    public void logSuccessful(MessageMetadata message, long timestamp) {
-        queue.offer(subscriptionLog(message, timestamp, SUCCESS));
+    public void logSuccessful(MessageMetadata message, String hostname, long timestamp) {
+        queue.offer(subscriptionLog(message, timestamp, SUCCESS).append(TARGET_HOSTNAME, hostname));
     }
 
     @Override
-    public void logFailed(MessageMetadata message, long timestamp, String reason) {
-        queue.offer(subscriptionLog(message, timestamp, FAILED).append(REASON, reason));
+    public void logFailed(MessageMetadata message, String hostname, long timestamp, String reason) {
+        queue.offer(subscriptionLog(message, timestamp, FAILED).append(REASON, reason).append(TARGET_HOSTNAME, hostname));
     }
 
     @Override
@@ -69,6 +70,7 @@ public class MongoLogRepository extends BatchingLogRepository<DBObject> implemen
                 .append(PARTITION, message.getPartition())
                 .append(OFFSET, message.getOffset())
                 .append(STATUS, status.toString())
-                .append(CLUSTER, clusterName);
+                .append(CLUSTER, clusterName)
+                .append(SOURCE_HOSTNAME, hostname);
     }
 }

--- a/hermes-tracker-mongo/src/main/java/pl/allegro/tech/hermes/tracker/mongo/frontend/MongoLogRepository.java
+++ b/hermes-tracker-mongo/src/main/java/pl/allegro/tech/hermes/tracker/mongo/frontend/MongoLogRepository.java
@@ -21,9 +21,10 @@ public class MongoLogRepository extends BatchingLogRepository<DBObject> implemen
                               int queueSize,
                               int commitIntervalMs,
                               String clusterName,
+                              String hostname,
                               MetricRegistry metricRegistry,
                               PathsCompiler pathsCompiler) {
-        super(queueSize, clusterName, metricRegistry, pathsCompiler);
+        super(queueSize, clusterName, hostname, metricRegistry, pathsCompiler);
 
         registerQueueSizeGauge(Gauges.PRODUCER_TRACKER_MONGO_QUEUE_SIZE);
         registerRemainingCapacityGauge(Gauges.PRODUCER_TRACKER_MONGO_REMAINING_CAPACITY);
@@ -53,6 +54,7 @@ public class MongoLogRepository extends BatchingLogRepository<DBObject> implemen
                 .append(TIMESTAMP, timestamp)
                 .append(STATUS, status.toString())
                 .append(TOPIC_NAME, topicName)
-                .append(CLUSTER, clusterName);
+                .append(CLUSTER, clusterName)
+                .append(SOURCE_HOSTNAME, hostname);
     }
 }

--- a/hermes-tracker-mongo/src/test/java/pl/allegro/tech/hermes/tracker/mongo/consumers/MongoLogRepositoryTest.java
+++ b/hermes-tracker-mongo/src/test/java/pl/allegro/tech/hermes/tracker/mongo/consumers/MongoLogRepositoryTest.java
@@ -27,7 +27,7 @@ public class MongoLogRepositoryTest extends AbstractLogRepositoryTest implements
 
     @Override
     protected LogRepository createLogRepository() {
-        return new MongoLogRepository(database, 1000, 100, "cluster", new MetricRegistry(), new PathsCompiler("localhost"));
+        return new MongoLogRepository(database, 1000, 100, "cluster", "host", new MetricRegistry(), new PathsCompiler("localhost"));
     }
 
     protected void awaitUntilMessageIsPersisted(String topic, String subscription, String messageId, SentMessageTraceStatus status) {

--- a/hermes-tracker-mongo/src/test/java/pl/allegro/tech/hermes/tracker/mongo/frontend/MongoLogRepositoryTest.java
+++ b/hermes-tracker-mongo/src/test/java/pl/allegro/tech/hermes/tracker/mongo/frontend/MongoLogRepositoryTest.java
@@ -21,7 +21,7 @@ public class MongoLogRepositoryTest extends AbstractLogRepositoryTest implements
 
     @Override
     protected LogRepository createRepository() {
-        return new MongoLogRepository(database, 1000, 100, "cluster", new MetricRegistry(), new PathsCompiler("localhost"));
+        return new MongoLogRepository(database, 1000, 100, "cluster", "host", new MetricRegistry(), new PathsCompiler("localhost"));
     }
 
     @Override

--- a/hermes-tracker/src/main/java/pl/allegro/tech/hermes/tracker/BatchingLogRepository.java
+++ b/hermes-tracker/src/main/java/pl/allegro/tech/hermes/tracker/BatchingLogRepository.java
@@ -12,11 +12,17 @@ public class BatchingLogRepository<T> {
     protected final MetricRegistry metricRegistry;
     protected final PathsCompiler pathsCompiler;
     protected final String clusterName;
+    protected final String hostname;
     protected BlockingQueue<T> queue;
 
-    public BatchingLogRepository(int queueSize, String clusterName, MetricRegistry metricRegistry, PathsCompiler pathsCompiler) {
+    public BatchingLogRepository(int queueSize,
+                                 String clusterName,
+                                 String hostname,
+                                 MetricRegistry metricRegistry,
+                                 PathsCompiler pathsCompiler) {
         this.queue = new LinkedBlockingQueue<>(queueSize);
         this.clusterName = clusterName;
+        this.hostname = hostname;
         this.metricRegistry = metricRegistry;
         this.pathsCompiler = pathsCompiler;
     }

--- a/hermes-tracker/src/main/java/pl/allegro/tech/hermes/tracker/consumers/LogRepository.java
+++ b/hermes-tracker/src/main/java/pl/allegro/tech/hermes/tracker/consumers/LogRepository.java
@@ -2,8 +2,8 @@ package pl.allegro.tech.hermes.tracker.consumers;
 
 public interface LogRepository {
 
-    void logSuccessful(MessageMetadata message, long timestamp);
-    void logFailed(MessageMetadata message, long timestamp, String reason);
+    void logSuccessful(MessageMetadata message, String hostname, long timestamp);
+    void logFailed(MessageMetadata message, String hostname, long timestamp, String reason);
     void logDiscarded(MessageMetadata message, long timestamp, String reason);
     void logInflight(MessageMetadata message, long timestamp);
     void logFiltered(MessageMetadata message, long timestamp, String reason);

--- a/hermes-tracker/src/main/java/pl/allegro/tech/hermes/tracker/consumers/NoOperationSendingTracker.java
+++ b/hermes-tracker/src/main/java/pl/allegro/tech/hermes/tracker/consumers/NoOperationSendingTracker.java
@@ -3,12 +3,12 @@ package pl.allegro.tech.hermes.tracker.consumers;
 public class NoOperationSendingTracker implements SendingTracker {
 
     @Override
-    public void logSent(MessageMetadata message) {
+    public void logSent(MessageMetadata message, String hostname) {
 
     }
 
     @Override
-    public void logFailed(MessageMetadata message, String reason) {
+    public void logFailed(MessageMetadata message, String reason, String hostname) {
 
     }
 

--- a/hermes-tracker/src/main/java/pl/allegro/tech/hermes/tracker/consumers/SendingMessageTracker.java
+++ b/hermes-tracker/src/main/java/pl/allegro/tech/hermes/tracker/consumers/SendingMessageTracker.java
@@ -13,17 +13,17 @@ class SendingMessageTracker implements SendingTracker {
     }
 
     @Override
-    public void logSent(MessageMetadata message) {
-        repositories.forEach(r -> r.logSuccessful(message, clock.millis()));
+    public void logSent(MessageMetadata message, String hostname) {
+        repositories.forEach(r -> r.logSuccessful(message, hostname, clock.millis()));
     }
 
     @Override
-    public void logFailed(MessageMetadata message, final String reason) {
-        repositories.forEach(r -> r.logFailed(message, clock.millis(), reason));
+    public void logFailed(MessageMetadata message, String reason, String hostname) {
+        repositories.forEach(r -> r.logFailed(message, hostname, clock.millis(), reason));
     }
 
     @Override
-    public void logDiscarded(MessageMetadata message, final String reason) {
+    public void logDiscarded(MessageMetadata message, String reason) {
         repositories.forEach(r ->
                 r.logDiscarded(message, clock.millis(), reason));
     }

--- a/hermes-tracker/src/main/java/pl/allegro/tech/hermes/tracker/consumers/SendingTracker.java
+++ b/hermes-tracker/src/main/java/pl/allegro/tech/hermes/tracker/consumers/SendingTracker.java
@@ -1,8 +1,8 @@
 package pl.allegro.tech.hermes.tracker.consumers;
 
 public interface SendingTracker {
-    void logSent(MessageMetadata message);
-    void logFailed(MessageMetadata message, String reason);
+    void logSent(MessageMetadata message, String hostname);
+    void logFailed(MessageMetadata message, String reason, String hostname);
     void logDiscarded(MessageMetadata message, String reason);
     void logInflight(MessageMetadata message);
     void logFiltered(MessageMetadata messageMetadata, String reason);

--- a/hermes-tracker/src/test/java/pl/allegro/tech/hermes/tracker/consumers/AbstractLogRepositoryTest.java
+++ b/hermes-tracker/src/test/java/pl/allegro/tech/hermes/tracker/consumers/AbstractLogRepositoryTest.java
@@ -42,7 +42,7 @@ public abstract class AbstractLogRepositoryTest {
         String topic = "group.sentMessage";
 
         // when
-        logRepository.logSuccessful(TestMessageMetadata.of(id, topic, SUBSCRIPTION), 1234L);
+        logRepository.logSuccessful(TestMessageMetadata.of(id, topic, SUBSCRIPTION), "host", 1234L);
 
         // then
         awaitUntilMessageIsPersisted(topic, SUBSCRIPTION, id, SUCCESS);
@@ -82,7 +82,7 @@ public abstract class AbstractLogRepositoryTest {
         String topic = "group.sentBatchMessage";
 
         // when
-        logRepository.logSuccessful(TestMessageMetadata.of(messageId, batchId, topic, SUBSCRIPTION), 1234L);
+        logRepository.logSuccessful(TestMessageMetadata.of(messageId, batchId, topic, SUBSCRIPTION), "host", 1234L);
 
         // then
         awaitUntilBatchMessageIsPersisted(topic, SUBSCRIPTION, messageId, batchId, SUCCESS);

--- a/integration/src/integration/java/pl/allegro/tech/hermes/integration/BroadcastDeliveryTest.java
+++ b/integration/src/integration/java/pl/allegro/tech/hermes/integration/BroadcastDeliveryTest.java
@@ -91,7 +91,7 @@ public class BroadcastDeliveryTest extends IntegrationTest {
         remoteServices = Stream.generate(this::createRemoteServiceEndpoint).limit(4).collect(toList());
         firstRemoteService = remoteServices.get(0);
 
-        return this.remoteServices.stream().map(RemoteServiceEndpoint::getUrl).collect(joining(";"));
+        return this.remoteServices.stream().map(RemoteServiceEndpoint::getUrl).map(Object::toString).collect(joining(";"));
     }
 
 }

--- a/integration/src/integration/java/pl/allegro/tech/hermes/integration/env/ConsumersStarter.java
+++ b/integration/src/integration/java/pl/allegro/tech/hermes/integration/env/ConsumersStarter.java
@@ -38,6 +38,7 @@ public class ConsumersStarter implements Starter<HermesConsumers> {
                         10,
                         1000,
                         configFactory.getStringProperty(Configs.KAFKA_CLUSTER_NAME),
+                        configFactory.getStringProperty(Configs.HOSTNAME),
                         serviceLocator.getService(MetricRegistry.class),
                         serviceLocator.getService(PathsCompiler.class)))
             .build();


### PR DESCRIPTION
This PR makes inspecting hostname related information for tracked topics/subscriptions much easier than before:
* information which node was handling message publishing (**frontend**): useful for locating missing messages that still could be present on disk
* information which node was responsible for message delivery (**consumer**)
* information to which host message was delivered (**consumer**): extremely useful for debugging problems on subscriber-side, if you have 150+ potential nodes to check this one can save hours