### PR TITLE
551 added source and target hostname information to tracking

### DIFF
--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/common/config/Configs.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/common/config/Configs.java
@@ -27,6 +27,7 @@ public enum Configs {
     KAFKA_ZOOKEEPER_CONNECT_STRING("kafka.zookeeper.connect.string", "localhost:2181"),
 
     ENVIRONMENT_NAME("environment.name", "dev"),
+    HOSTNAME("hostname", new InetAddressHostnameResolver().resolve()),
 
     KAFKA_CLUSTER_NAME("kafka.cluster.name", "primary"),
     KAFKA_BROKER_LIST("kafka.broker.list", "localhost:9092"),

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/ConsumerMessageSender.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/ConsumerMessageSender.java
@@ -16,6 +16,7 @@ import pl.allegro.tech.hermes.consumers.consumer.sender.MessageSendingResult;
 import pl.allegro.tech.hermes.consumers.consumer.sender.MessageSendingResultLogInfo;
 import pl.allegro.tech.hermes.consumers.consumer.sender.timeout.FutureAsyncTimeout;
 
+import java.net.URI;
 import java.time.Duration;
 import java.util.List;
 import java.util.Objects;
@@ -171,7 +172,7 @@ public class ConsumerMessageSender {
             } else {
                 handleFailedSending(message, result);
 
-                List<String> succeededUris = result.getSucceededUris(ConsumerMessageSender.this::messageSentSucceeded);
+                List<URI> succeededUris = result.getSucceededUris(ConsumerMessageSender.this::messageSentSucceeded);
                 message.incrementRetryCounter(succeededUris);
 
                 long retryDelay = extractRetryDelay(result);
@@ -204,7 +205,7 @@ public class ConsumerMessageSender {
         private void logResultInfo(MessageSendingResultLogInfo logInfo) {
             logger.debug(
                     format("Retrying message send to endpoint %s; messageId %s; offset: %s; partition: %s; sub id: %s; rootCause: %s",
-                            logInfo.getUrl(), message.getId(), message.getOffset(), message.getPartition(),
+                            logInfo.getUrlString(), message.getId(), message.getOffset(), message.getPartition(),
                             subscription.getQualifiedName(), logInfo.getRootCause()),
                     logInfo.getFailure());
         }

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/Message.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/Message.java
@@ -9,7 +9,10 @@ import pl.allegro.tech.hermes.common.kafka.KafkaTopicName;
 import pl.allegro.tech.hermes.common.kafka.offset.PartitionOffset;
 import pl.allegro.tech.hermes.domain.topic.schema.CompiledSchema;
 
+import java.net.URI;
 import java.util.*;
+
+import static java.util.stream.Collectors.toList;
 
 public class Message {
 
@@ -89,9 +92,9 @@ public class Message {
         return currentTimestamp > readingTimestamp + ttlMillis;
     }
 
-    public void incrementRetryCounter(Collection<String> succeededUris) {
+    public void incrementRetryCounter(Collection<URI> succeededUris) {
         this.retryCounter++;
-        this.succeededUris.addAll(succeededUris);
+        this.succeededUris.addAll(succeededUris.stream().map(URI::toString).collect(toList()));
     }
 
     public int getRetryCounter() {

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/result/DefaultErrorHandler.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/result/DefaultErrorHandler.java
@@ -63,7 +63,7 @@ public class DefaultErrorHandler extends AbstractHandler implements ErrorHandler
             result.getLogInfo().stream().forEach(logInfo ->
                     logger.warn(
                             "Abnormal delivery failure: subscription: {}; cause: {}; endpoint: {}; messageId: {}; partition: {}; offset: {}",
-                            subscription.getQualifiedName(), logInfo.getRootCause(), logInfo.getUrl(), message.getId(),
+                            subscription.getQualifiedName(), logInfo.getRootCause(), logInfo.getUrlString(), message.getId(),
                             message.getPartition(), message.getOffset(), logInfo.getFailure()
                     )
             );
@@ -80,7 +80,7 @@ public class DefaultErrorHandler extends AbstractHandler implements ErrorHandler
     public void handleFailed(Message message, Subscription subscription, MessageSendingResult result) {
         hermesMetrics.meter(Meters.FAILED_METER_SUBSCRIPTION, subscription.getTopicName(), subscription.getName()).mark();
         registerFailureMetrics(subscription, result);
-        trackers.get(subscription).logFailed(toMessageMetadata(message, subscription), result.getRootCause());
+        trackers.get(subscription).logFailed(toMessageMetadata(message, subscription), result.getRootCause(), result.getHostname());
     }
 
     private void registerFailureMetrics(Subscription subscription, MessageSendingResult result) {

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/result/DefaultSuccessHandler.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/result/DefaultSuccessHandler.java
@@ -28,7 +28,7 @@ public class DefaultSuccessHandler extends AbstractHandler implements SuccessHan
         updateMeters(subscription, result);
         updateMetrics(Counters.DELIVERED, message, subscription);
 
-        trackers.get(subscription).logSent(toMessageMetadata(message, subscription));
+        trackers.get(subscription).logSent(toMessageMetadata(message, subscription), result.getHostname());
     }
 
     private void updateMeters(Subscription subscription, MessageSendingResult result) {

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/sender/MessageSendingResult.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/sender/MessageSendingResult.java
@@ -3,11 +3,13 @@ package pl.allegro.tech.hermes.consumers.consumer.sender;
 import org.eclipse.jetty.client.api.Result;
 import pl.allegro.tech.hermes.consumers.consumer.sender.resolver.EndpointAddressResolutionException;
 
+import java.net.URI;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
 
+import static java.util.stream.Collectors.joining;
 import static javax.ws.rs.core.Response.Status.OK;
 import static javax.ws.rs.core.Response.Status.SERVICE_UNAVAILABLE;
 
@@ -16,6 +18,10 @@ public interface MessageSendingResult {
 
     static SingleMessageSendingResult succeededResult() {
         return new SingleMessageSendingResult(OK.getStatusCode());
+    }
+
+    static SingleMessageSendingResult succeededResult(URI requestURI) {
+        return new SingleMessageSendingResult(OK.getStatusCode(), requestURI);
     }
 
     static SingleMessageSendingResult failedResult(Throwable cause) {
@@ -66,5 +72,9 @@ public interface MessageSendingResult {
 
     List<MessageSendingResultLogInfo> getLogInfo();
 
-    List<String> getSucceededUris(Predicate<MessageSendingResult> filter) ;
+    List<URI> getSucceededUris(Predicate<MessageSendingResult> filter);
+
+    default String getHostname() {
+        return getLogInfo().stream().filter(i -> i.getUrl().isPresent()).map(i -> i.getUrl().get().getHost()).collect(joining(","));
+    };
 }

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/sender/MessageSendingResultLogInfo.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/sender/MessageSendingResultLogInfo.java
@@ -1,18 +1,25 @@
 package pl.allegro.tech.hermes.consumers.consumer.sender;
 
-public class MessageSendingResultLogInfo {
-    private final String url;
-    private final String rootCause;
-    private final  Throwable failure;
+import java.net.URI;
+import java.util.Optional;
 
-    public MessageSendingResultLogInfo(String url, Throwable failure, String rootCause) {
+public class MessageSendingResultLogInfo {
+    private final Optional<URI> url;
+    private final String rootCause;
+    private final Throwable failure;
+
+    public MessageSendingResultLogInfo(Optional<URI> url, Throwable failure, String rootCause) {
         this.url = url;
         this.failure = failure;
         this.rootCause = rootCause;
     }
 
-    public String getUrl() {
+    public Optional<URI> getUrl() {
         return url;
+    }
+
+    public String getUrlString() {
+        return url.isPresent() ? url.get().toString() : "";
     }
 
     public String getRootCause() {

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/sender/MultiMessageSendingResult.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/sender/MultiMessageSendingResult.java
@@ -3,6 +3,7 @@ package pl.allegro.tech.hermes.consumers.consumer.sender;
 
 import com.google.common.collect.ImmutableList;
 
+import java.net.URI;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
@@ -77,10 +78,12 @@ public class MultiMessageSendingResult implements MessageSendingResult {
     }
 
     @Override
-    public List<String> getSucceededUris(Predicate<MessageSendingResult> filter) {
+    public List<URI> getSucceededUris(Predicate<MessageSendingResult> filter) {
             return children.stream()
                     .filter(filter)
                     .map(SingleMessageSendingResult::getRequestUri)
+                    .filter(Optional::isPresent)
+                    .map(Optional::get)
                     .collect(Collectors.toList());
 
     }
@@ -92,7 +95,7 @@ public class MultiMessageSendingResult implements MessageSendingResult {
     @Override
     public String getRootCause() {
         return children.stream()
-                .map(child -> child.getRequestUri()+":"+child.getRootCause())
+                .map(child -> child.getRequestUri().map(Object::toString).orElse("") + ":" + child.getRootCause())
                 .collect(joining(";"));
     }
 }

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/sender/SingleMessageSendingResult.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/sender/SingleMessageSendingResult.java
@@ -8,6 +8,7 @@ import org.eclipse.jetty.http.HttpHeader;
 import pl.allegro.tech.hermes.common.exception.InternalProcessingException;
 
 import javax.ws.rs.core.Response;
+import java.net.URI;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -28,7 +29,7 @@ public class SingleMessageSendingResult implements MessageSendingResult {
     private boolean ignoreInRateCalculation = false;
 
     private Optional<Long> retryAfterMillis = Optional.empty();
-    private String requestUri = "";
+    private Optional<URI> requestUri = Optional.empty();
     private int statusCode;
     private Response.Status.Family responseFamily;
 
@@ -53,11 +54,16 @@ public class SingleMessageSendingResult implements MessageSendingResult {
         }
 
         this.loggable = !isTimeout() && !hasHttpAnswer();
-        this.requestUri = result.getRequest().getURI().toString();
+        this.requestUri = Optional.ofNullable(result.getRequest().getURI());
     }
 
     SingleMessageSendingResult(int statusCode) {
         initializeForStatusCode(statusCode);
+    }
+
+    SingleMessageSendingResult(int statusCode, URI requestURI) {
+        this(statusCode);
+        this.requestUri = Optional.of(requestURI);
     }
 
     SingleMessageSendingResult(int statusCode, long retryAfterMillis) {
@@ -128,7 +134,7 @@ public class SingleMessageSendingResult implements MessageSendingResult {
         return retryAfterMillis;
     }
 
-    public String getRequestUri() {
+    public Optional<URI> getRequestUri() {
         return requestUri;
     }
 
@@ -154,13 +160,13 @@ public class SingleMessageSendingResult implements MessageSendingResult {
 
     @Override
     public List<MessageSendingResultLogInfo> getLogInfo() {
-        return Collections.singletonList(new MessageSendingResultLogInfo(requestUri, failure, getRootCause()));
+        return Collections.singletonList(new MessageSendingResultLogInfo(getRequestUri(), failure, getRootCause()));
     }
 
     @Override
-    public List<String> getSucceededUris(Predicate<MessageSendingResult> filter) {
-        if(filter.test(this)) {
-            return Collections.singletonList(requestUri);
+    public List<URI> getSucceededUris(Predicate<MessageSendingResult> filter) {
+        if (filter.test(this) && requestUri.isPresent()) {
+            return Collections.singletonList(getRequestUri().get());
         } else {
             return Collections.emptyList();
         }

--- a/hermes-consumers/src/test/groovy/pl/allegro/tech/hermes/consumers/consumer/result/InMemoryLogRepository.groovy
+++ b/hermes-consumers/src/test/groovy/pl/allegro/tech/hermes/consumers/consumer/result/InMemoryLogRepository.groovy
@@ -12,12 +12,12 @@ class InMemoryLogRepository implements LogRepository {
     private final List<MessageMetadata> filtered = []
 
     @Override
-    void logSuccessful(MessageMetadata message, long timestamp) {
+    void logSuccessful(MessageMetadata message, String hostname, long timestamp) {
         successful.add(message)
     }
 
     @Override
-    void logFailed(MessageMetadata message, long timestamp, String reason) {
+    void logFailed(MessageMetadata message, String hostname, long timestamp, String reason) {
         failed.add(message)
     }
 

--- a/hermes-consumers/src/test/groovy/pl/allegro/tech/hermes/consumers/consumer/sender/http/JettyBroadCastMessageSenderTest.groovy
+++ b/hermes-consumers/src/test/groovy/pl/allegro/tech/hermes/consumers/consumer/sender/http/JettyBroadCastMessageSenderTest.groovy
@@ -91,7 +91,7 @@ class JettyBroadCastMessageSenderTest extends Specification {
         !messageSendingResult.succeeded()
 
         and:
-        messageSendingResult.children.find { it.statusCode == 500 && it.requestUri == failedServiceEndpoint.url }
+        messageSendingResult.children.find { it.statusCode == 500 && it.requestUri.get() == failedServiceEndpoint.url }
     }
 
     def "should not send to already sent url on retry"() {

--- a/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/buffer/BackupMessagesLoader.java
+++ b/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/buffer/BackupMessagesLoader.java
@@ -6,7 +6,6 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import pl.allegro.tech.hermes.api.Topic;
-import pl.allegro.tech.hermes.api.TopicName;
 import pl.allegro.tech.hermes.common.config.ConfigFactory;
 import pl.allegro.tech.hermes.common.metric.HermesMetrics;
 import pl.allegro.tech.hermes.frontend.cache.topic.TopicsCache;
@@ -38,7 +37,6 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static pl.allegro.tech.hermes.api.TopicName.fromQualifiedName;
 import static pl.allegro.tech.hermes.common.config.Configs.*;
 
 public class BackupMessagesLoader {
@@ -218,14 +216,14 @@ public class BackupMessagesLoader {
                     @Override
                     public void onUnpublished(Message message, Topic topic, Exception exception) {
                         brokerListeners.onError(message, topic, exception);
-                        trackers.get(topic).logError(message.getId(), topic.getName(), exception.getMessage());
+                        trackers.get(topic).logError(message.getId(), topic.getName(), exception.getMessage(), "");
                         toResend.get().add(ImmutablePair.of(message, topic));
                     }
 
                     @Override
                     public void onPublished(Message message, Topic topic) {
                         brokerListeners.onAcknowledge(message, topic);
-                        trackers.get(topic).logPublished(message.getId(), topic.getName());
+                        trackers.get(topic).logPublished(message.getId(), topic.getName(), "");
                     }
                 }));
     }

--- a/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/publishing/HttpResponder.java
+++ b/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/publishing/HttpResponder.java
@@ -54,12 +54,12 @@ public class HttpResponder {
     }
 
     public void accept() {
-        trackers.get(topic).logInflight(messageId, topic.getName());
+        trackers.get(topic).logInflight(messageId, topic.getName(), remoteHost);
         completeCorrect(SC_ACCEPTED);
     }
 
     public void ok() {
-        trackers.get(topic).logPublished(messageId, topic.getName());
+        trackers.get(topic).logPublished(messageId, topic.getName(), remoteHost);
         completeCorrect(SC_CREATED);
     }
 
@@ -98,7 +98,7 @@ public class HttpResponder {
             asyncContext.complete();
         }
 
-        trackers.get(topic).logError(messageId, topic.getName(), desc.getMessage());
+        trackers.get(topic).logError(messageId, topic.getName(), desc.getMessage(), remoteHost);
     }
 
     private void completeCorrect(int status) {

--- a/hermes-test-helper/src/main/java/pl/allegro/tech/hermes/test/helper/endpoint/RemoteServiceEndpoint.java
+++ b/hermes-test-helper/src/main/java/pl/allegro/tech/hermes/test/helper/endpoint/RemoteServiceEndpoint.java
@@ -9,6 +9,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import pl.allegro.tech.hermes.test.helper.message.TestMessage;
 
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -32,7 +33,7 @@ public class RemoteServiceEndpoint {
 
     private final List<LoggedRequest> receivedRequests = Collections.synchronizedList(new ArrayList<>());
     private final String path;
-    private final String url;
+    private final URI url;
 
     private final WireMock listener;
     private final WireMockServer service;
@@ -50,7 +51,7 @@ public class RemoteServiceEndpoint {
     public RemoteServiceEndpoint(WireMockServer service, final String path) {
         this.listener = new WireMock("localhost", service.port());
         this.path = path;
-        this.url = String.format("http://localhost:%d%s", service.port(), path);
+        this.url = URI.create(String.format("http://localhost:%d%s", service.port(), path));
         this.service = service;
 
         service.resetMappings();
@@ -192,7 +193,7 @@ public class RemoteServiceEndpoint {
         return this;
     }
 
-    public String getUrl() {
+    public URI getUrl() {
         return url;
     }
 

--- a/hermes-tracker-elasticsearch/src/main/java/pl/allegro/tech/hermes/tracker/elasticsearch/LogSchemaAware.java
+++ b/hermes-tracker-elasticsearch/src/main/java/pl/allegro/tech/hermes/tracker/elasticsearch/LogSchemaAware.java
@@ -13,5 +13,7 @@ public interface LogSchemaAware {
     String OFFSET = "offset";
     String REASON = "reason";
     String CLUSTER = "cluster";
+    String SOURCE_HOSTNAME = "hostname";
+    String REMOTE_HOSTNAME = "remote_hostname";
 
 }

--- a/hermes-tracker-elasticsearch/src/main/java/pl/allegro/tech/hermes/tracker/elasticsearch/consumers/ConsumersElasticsearchLogRepository.java
+++ b/hermes-tracker-elasticsearch/src/main/java/pl/allegro/tech/hermes/tracker/elasticsearch/consumers/ConsumersElasticsearchLogRepository.java
@@ -27,9 +27,16 @@ public class ConsumersElasticsearchLogRepository extends BatchingLogRepository<E
 
     private static final int DOCUMENT_EXPECTED_SIZE = 1024;
 
-    private ConsumersElasticsearchLogRepository(Client elasticClient, String clusterName, int queueSize, int commitInterval,
-                                                IndexFactory indexFactory, String typeName, MetricRegistry metricRegistry, PathsCompiler pathsCompiler) {
-        super(queueSize, clusterName, metricRegistry, pathsCompiler);
+    private ConsumersElasticsearchLogRepository(Client elasticClient,
+                                                String clusterName,
+                                                String hostname,
+                                                int queueSize,
+                                                int commitInterval,
+                                                IndexFactory indexFactory,
+                                                String typeName,
+                                                MetricRegistry metricRegistry,
+                                                PathsCompiler pathsCompiler) {
+        super(queueSize, clusterName, hostname, metricRegistry, pathsCompiler);
 
         registerQueueSizeGauge(Gauges.CONSUMER_TRACKER_ELASTICSEARCH_QUEUE_SIZE);
         registerRemainingCapacityGauge(Gauges.CONSUMER_TRACKER_ELASTICSEARCH_REMAINING_CAPACITY);
@@ -39,13 +46,20 @@ public class ConsumersElasticsearchLogRepository extends BatchingLogRepository<E
     }
 
     @Override
-    public void logSuccessful(MessageMetadata message, long timestamp) {
-        queue.offer(document(message, timestamp, SUCCESS));
+    public void logSuccessful(MessageMetadata message, String hostname, long timestamp) {
+        queue.offer(build(() ->
+                notEndedDocument(message, timestamp, SUCCESS.toString())
+                        .field(REMOTE_HOSTNAME, hostname)
+                        .endObject()));
     }
 
     @Override
-    public void logFailed(MessageMetadata message, long timestamp, String reason) {
-        queue.offer(document(message, timestamp, FAILED, reason));
+    public void logFailed(MessageMetadata message, String hostname, long timestamp, String reason) {
+        queue.offer(build(() ->
+                notEndedDocument(message, timestamp, FAILED.toString())
+                        .field(REASON, reason)
+                        .field(REMOTE_HOSTNAME, hostname)
+                        .endObject()));
     }
 
     @Override
@@ -84,13 +98,15 @@ public class ConsumersElasticsearchLogRepository extends BatchingLogRepository<E
                 .field(STATUS, status)
                 .field(OFFSET, message.getOffset())
                 .field(PARTITION, message.getPartition())
-                .field(CLUSTER, clusterName);
+                .field(CLUSTER, clusterName)
+                .field(SOURCE_HOSTNAME, hostname);
     }
 
     public static class Builder {
 
         private Client elasticClient;
         private String clusterName = "primary";
+        private String hostName = "unknown";
         private int queueSize = 1000;
         private int commitInterval = 100;
         private ConsumersIndexFactory indexFactory = new ConsumersDailyIndexFactory();
@@ -112,6 +128,11 @@ public class ConsumersElasticsearchLogRepository extends BatchingLogRepository<E
 
         public Builder withClusterName(String clusterName) {
             this.clusterName = clusterName;
+            return this;
+        }
+
+        public Builder withHostName(String hostName) {
+            this.hostName = hostName;
             return this;
         }
 
@@ -138,6 +159,7 @@ public class ConsumersElasticsearchLogRepository extends BatchingLogRepository<E
         public ConsumersElasticsearchLogRepository build() {
             return new ConsumersElasticsearchLogRepository(elasticClient,
                     clusterName,
+                    hostName,
                     queueSize,
                     commitInterval,
                     indexFactory,

--- a/hermes-tracker-elasticsearch/src/test/java/pl/allegro/tech/hermes/tracker/elasticsearch/frontend/FrontendElasticsearchLogRepositoryTest.java
+++ b/hermes-tracker-elasticsearch/src/test/java/pl/allegro/tech/hermes/tracker/elasticsearch/frontend/FrontendElasticsearchLogRepositoryTest.java
@@ -59,7 +59,11 @@ public class FrontendElasticsearchLogRepositoryTest extends AbstractLogRepositor
     }
 
     @Override
-    protected void awaitUntilMessageIsPersisted(String topic, String id, PublishedMessageTraceStatus status, String reason) throws Exception {
+    protected void awaitUntilMessageIsPersisted(String topic,
+                                                String id,
+                                                PublishedMessageTraceStatus status,
+                                                String reason,
+                                                String remoteHostname) throws Exception {
         awaitUntilMessageIsIndexed(
                 filteredQuery(matchAllQuery(),
                         FilterBuilders.andFilter(
@@ -67,19 +71,24 @@ public class FrontendElasticsearchLogRepositoryTest extends AbstractLogRepositor
                                 FilterBuilders.termFilter(MESSAGE_ID, id),
                                 FilterBuilders.termFilter(STATUS, status.toString()),
                                 FilterBuilders.termFilter(REASON, reason),
-                                FilterBuilders.termFilter(CLUSTER, CLUSTER_NAME)
+                                FilterBuilders.termFilter(CLUSTER, CLUSTER_NAME),
+                                FilterBuilders.termFilter(REMOTE_HOSTNAME, remoteHostname)
                         )));
     }
 
     @Override
-    protected void awaitUntilMessageIsPersisted(String topic, String id, PublishedMessageTraceStatus status) throws Exception {
+    protected void awaitUntilMessageIsPersisted(String topic,
+                                                String id,
+                                                PublishedMessageTraceStatus status,
+                                                String remoteHostname) throws Exception {
         awaitUntilMessageIsIndexed(
                 filteredQuery(matchAllQuery(),
                         FilterBuilders.andFilter(
                                 FilterBuilders.termFilter(TOPIC_NAME, topic),
                                 FilterBuilders.termFilter(MESSAGE_ID, id),
                                 FilterBuilders.termFilter(STATUS, status.toString()),
-                                FilterBuilders.termFilter(CLUSTER, CLUSTER_NAME)
+                                FilterBuilders.termFilter(CLUSTER, CLUSTER_NAME),
+                                FilterBuilders.termFilter(REMOTE_HOSTNAME, remoteHostname)
                         )));
     }
 

--- a/hermes-tracker-mongo/src/main/java/pl/allegro/tech/hermes/tracker/mongo/LogSchemaAware.java
+++ b/hermes-tracker-mongo/src/main/java/pl/allegro/tech/hermes/tracker/mongo/LogSchemaAware.java
@@ -15,5 +15,6 @@ public interface LogSchemaAware {
     String OFFSET = "offset";
     String REASON = "reason";
     String CLUSTER = "cluster";
-
+    String SOURCE_HOSTNAME = "hostname";
+    String REMOTE_HOSTNAME = "remote_hostname";
 }

--- a/hermes-tracker-mongo/src/main/java/pl/allegro/tech/hermes/tracker/mongo/consumers/MongoLogRepository.java
+++ b/hermes-tracker-mongo/src/main/java/pl/allegro/tech/hermes/tracker/mongo/consumers/MongoLogRepository.java
@@ -22,9 +22,10 @@ public class MongoLogRepository extends BatchingLogRepository<DBObject> implemen
                               int queueSize,
                               int commitInterval,
                               String clusterName,
+                              String hostname,
                               MetricRegistry metricRegistry,
                               PathsCompiler pathsCompiler) {
-        super(queueSize, clusterName, metricRegistry, pathsCompiler);
+        super(queueSize, clusterName, hostname, metricRegistry, pathsCompiler);
 
         registerQueueSizeGauge(Gauges.CONSUMER_TRACKER_MONGO_QUEUE_SIZE);
         registerRemainingCapacityGauge(Gauges.CONSUMER_TRACKER_MONGO_REMAINING_CAPACITY);
@@ -34,13 +35,13 @@ public class MongoLogRepository extends BatchingLogRepository<DBObject> implemen
     }
 
     @Override
-    public void logSuccessful(MessageMetadata message, long timestamp) {
-        queue.offer(subscriptionLog(message, timestamp, SUCCESS));
+    public void logSuccessful(MessageMetadata message, String hostname, long timestamp) {
+        queue.offer(subscriptionLog(message, timestamp, SUCCESS).append(REMOTE_HOSTNAME, hostname));
     }
 
     @Override
-    public void logFailed(MessageMetadata message, long timestamp, String reason) {
-        queue.offer(subscriptionLog(message, timestamp, FAILED).append(REASON, reason));
+    public void logFailed(MessageMetadata message, String hostname, long timestamp, String reason) {
+        queue.offer(subscriptionLog(message, timestamp, FAILED).append(REASON, reason).append(REMOTE_HOSTNAME, hostname));
     }
 
     @Override
@@ -69,6 +70,7 @@ public class MongoLogRepository extends BatchingLogRepository<DBObject> implemen
                 .append(PARTITION, message.getPartition())
                 .append(OFFSET, message.getOffset())
                 .append(STATUS, status.toString())
-                .append(CLUSTER, clusterName);
+                .append(CLUSTER, clusterName)
+                .append(SOURCE_HOSTNAME, hostname);
     }
 }

--- a/hermes-tracker-mongo/src/main/java/pl/allegro/tech/hermes/tracker/mongo/frontend/MongoLogRepository.java
+++ b/hermes-tracker-mongo/src/main/java/pl/allegro/tech/hermes/tracker/mongo/frontend/MongoLogRepository.java
@@ -21,9 +21,10 @@ public class MongoLogRepository extends BatchingLogRepository<DBObject> implemen
                               int queueSize,
                               int commitIntervalMs,
                               String clusterName,
+                              String hostname,
                               MetricRegistry metricRegistry,
                               PathsCompiler pathsCompiler) {
-        super(queueSize, clusterName, metricRegistry, pathsCompiler);
+        super(queueSize, clusterName, hostname, metricRegistry, pathsCompiler);
 
         registerQueueSizeGauge(Gauges.PRODUCER_TRACKER_MONGO_QUEUE_SIZE);
         registerRemainingCapacityGauge(Gauges.PRODUCER_TRACKER_MONGO_REMAINING_CAPACITY);
@@ -33,17 +34,17 @@ public class MongoLogRepository extends BatchingLogRepository<DBObject> implemen
     }
 
     @Override
-    public void logPublished(String messageId, long timestamp, String topicName) {
+    public void logPublished(String messageId, long timestamp, String topicName, String hostname) {
         queue.offer(topicLog(messageId, timestamp, topicName, SUCCESS));
     }
 
     @Override
-    public void logError(String messageId, long timestamp, String topicName, String reason) {
+    public void logError(String messageId, long timestamp, String topicName, String reason, String hostname) {
         queue.offer(topicLog(messageId, timestamp, topicName, ERROR).append(REASON, reason));
     }
 
     @Override
-    public void logInflight(String messageId, long timestamp, String topicName) {
+    public void logInflight(String messageId, long timestamp, String topicName, String hostname) {
         queue.offer(topicLog(messageId, timestamp, topicName, INFLIGHT));
     }
 
@@ -53,6 +54,7 @@ public class MongoLogRepository extends BatchingLogRepository<DBObject> implemen
                 .append(TIMESTAMP, timestamp)
                 .append(STATUS, status.toString())
                 .append(TOPIC_NAME, topicName)
-                .append(CLUSTER, clusterName);
+                .append(CLUSTER, clusterName)
+                .append(SOURCE_HOSTNAME, hostname);
     }
 }

--- a/hermes-tracker-mongo/src/test/java/pl/allegro/tech/hermes/tracker/mongo/consumers/MongoLogRepositoryTest.java
+++ b/hermes-tracker-mongo/src/test/java/pl/allegro/tech/hermes/tracker/mongo/consumers/MongoLogRepositoryTest.java
@@ -27,7 +27,7 @@ public class MongoLogRepositoryTest extends AbstractLogRepositoryTest implements
 
     @Override
     protected LogRepository createLogRepository() {
-        return new MongoLogRepository(database, 1000, 100, "cluster", new MetricRegistry(), new PathsCompiler("localhost"));
+        return new MongoLogRepository(database, 1000, 100, "cluster", "host", new MetricRegistry(), new PathsCompiler("localhost"));
     }
 
     protected void awaitUntilMessageIsPersisted(String topic, String subscription, String messageId, SentMessageTraceStatus status) {

--- a/hermes-tracker-mongo/src/test/java/pl/allegro/tech/hermes/tracker/mongo/frontend/MongoLogRepositoryTest.java
+++ b/hermes-tracker-mongo/src/test/java/pl/allegro/tech/hermes/tracker/mongo/frontend/MongoLogRepositoryTest.java
@@ -21,18 +21,33 @@ public class MongoLogRepositoryTest extends AbstractLogRepositoryTest implements
 
     @Override
     protected LogRepository createRepository() {
-        return new MongoLogRepository(database, 1000, 100, "cluster", new MetricRegistry(), new PathsCompiler("localhost"));
+        return new MongoLogRepository(database, 1000, 100, "cluster", "host", new MetricRegistry(), new PathsCompiler("localhost"));
     }
 
     @Override
-    protected void awaitUntilMessageIsPersisted(String topic, String id, PublishedMessageTraceStatus status) throws Exception {
-        awaitUntilMessageIsPersisted(new BasicDBObject(TOPIC_NAME, topic).append(STATUS, status.toString()).append(MESSAGE_ID, id));
-    }
-
-    @Override
-    protected void awaitUntilMessageIsPersisted(String topic, String id, PublishedMessageTraceStatus status, String reason) throws Exception {
+    protected void awaitUntilMessageIsPersisted(String topic,
+                                                String id,
+                                                PublishedMessageTraceStatus status,
+                                                String remoteHostname) throws Exception {
         awaitUntilMessageIsPersisted(
-                new BasicDBObject(TOPIC_NAME, topic).append(STATUS, status.toString()).append(MESSAGE_ID, id).append(REASON, reason));
+                new BasicDBObject(TOPIC_NAME, topic)
+                .append(STATUS, status.toString())
+                .append(MESSAGE_ID, id)
+                .append(REMOTE_HOSTNAME, remoteHostname));
+    }
+
+    @Override
+    protected void awaitUntilMessageIsPersisted(String topic,
+                                                String id,
+                                                PublishedMessageTraceStatus status,
+                                                String reason,
+                                                String remoteHostname) throws Exception {
+        awaitUntilMessageIsPersisted(
+                new BasicDBObject(TOPIC_NAME, topic)
+                .append(STATUS, status.toString())
+                .append(MESSAGE_ID, id)
+                .append(REASON, reason)
+                .append(REMOTE_HOSTNAME, remoteHostname));
     }
 
     private void awaitUntilMessageIsPersisted(DBObject query) throws Exception {

--- a/hermes-tracker/src/main/java/pl/allegro/tech/hermes/tracker/BatchingLogRepository.java
+++ b/hermes-tracker/src/main/java/pl/allegro/tech/hermes/tracker/BatchingLogRepository.java
@@ -12,11 +12,17 @@ public class BatchingLogRepository<T> {
     protected final MetricRegistry metricRegistry;
     protected final PathsCompiler pathsCompiler;
     protected final String clusterName;
+    protected final String hostname;
     protected BlockingQueue<T> queue;
 
-    public BatchingLogRepository(int queueSize, String clusterName, MetricRegistry metricRegistry, PathsCompiler pathsCompiler) {
+    public BatchingLogRepository(int queueSize,
+                                 String clusterName,
+                                 String hostname,
+                                 MetricRegistry metricRegistry,
+                                 PathsCompiler pathsCompiler) {
         this.queue = new LinkedBlockingQueue<>(queueSize);
         this.clusterName = clusterName;
+        this.hostname = hostname;
         this.metricRegistry = metricRegistry;
         this.pathsCompiler = pathsCompiler;
     }

--- a/hermes-tracker/src/main/java/pl/allegro/tech/hermes/tracker/consumers/LogRepository.java
+++ b/hermes-tracker/src/main/java/pl/allegro/tech/hermes/tracker/consumers/LogRepository.java
@@ -2,8 +2,8 @@ package pl.allegro.tech.hermes.tracker.consumers;
 
 public interface LogRepository {
 
-    void logSuccessful(MessageMetadata message, long timestamp);
-    void logFailed(MessageMetadata message, long timestamp, String reason);
+    void logSuccessful(MessageMetadata message, String hostname, long timestamp);
+    void logFailed(MessageMetadata message, String hostname, long timestamp, String reason);
     void logDiscarded(MessageMetadata message, long timestamp, String reason);
     void logInflight(MessageMetadata message, long timestamp);
     void logFiltered(MessageMetadata message, long timestamp, String reason);

--- a/hermes-tracker/src/main/java/pl/allegro/tech/hermes/tracker/consumers/NoOperationSendingTracker.java
+++ b/hermes-tracker/src/main/java/pl/allegro/tech/hermes/tracker/consumers/NoOperationSendingTracker.java
@@ -3,12 +3,12 @@ package pl.allegro.tech.hermes.tracker.consumers;
 public class NoOperationSendingTracker implements SendingTracker {
 
     @Override
-    public void logSent(MessageMetadata message) {
+    public void logSent(MessageMetadata message, String hostname) {
 
     }
 
     @Override
-    public void logFailed(MessageMetadata message, String reason) {
+    public void logFailed(MessageMetadata message, String reason, String hostname) {
 
     }
 

--- a/hermes-tracker/src/main/java/pl/allegro/tech/hermes/tracker/consumers/SendingMessageTracker.java
+++ b/hermes-tracker/src/main/java/pl/allegro/tech/hermes/tracker/consumers/SendingMessageTracker.java
@@ -13,17 +13,17 @@ class SendingMessageTracker implements SendingTracker {
     }
 
     @Override
-    public void logSent(MessageMetadata message) {
-        repositories.forEach(r -> r.logSuccessful(message, clock.millis()));
+    public void logSent(MessageMetadata message, String hostname) {
+        repositories.forEach(r -> r.logSuccessful(message, hostname, clock.millis()));
     }
 
     @Override
-    public void logFailed(MessageMetadata message, final String reason) {
-        repositories.forEach(r -> r.logFailed(message, clock.millis(), reason));
+    public void logFailed(MessageMetadata message, String reason, String hostname) {
+        repositories.forEach(r -> r.logFailed(message, hostname, clock.millis(), reason));
     }
 
     @Override
-    public void logDiscarded(MessageMetadata message, final String reason) {
+    public void logDiscarded(MessageMetadata message, String reason) {
         repositories.forEach(r ->
                 r.logDiscarded(message, clock.millis(), reason));
     }

--- a/hermes-tracker/src/main/java/pl/allegro/tech/hermes/tracker/consumers/SendingTracker.java
+++ b/hermes-tracker/src/main/java/pl/allegro/tech/hermes/tracker/consumers/SendingTracker.java
@@ -1,8 +1,8 @@
 package pl.allegro.tech.hermes.tracker.consumers;
 
 public interface SendingTracker {
-    void logSent(MessageMetadata message);
-    void logFailed(MessageMetadata message, String reason);
+    void logSent(MessageMetadata message, String hostname);
+    void logFailed(MessageMetadata message, String reason, String hostname);
     void logDiscarded(MessageMetadata message, String reason);
     void logInflight(MessageMetadata message);
     void logFiltered(MessageMetadata messageMetadata, String reason);

--- a/hermes-tracker/src/main/java/pl/allegro/tech/hermes/tracker/frontend/LogRepository.java
+++ b/hermes-tracker/src/main/java/pl/allegro/tech/hermes/tracker/frontend/LogRepository.java
@@ -2,10 +2,10 @@ package pl.allegro.tech.hermes.tracker.frontend;
 
 public interface LogRepository {
 
-    void logPublished(String messageId, long timestamp, String topicName);
+    void logPublished(String messageId, long timestamp, String topicName, String hostname);
 
-    void logError(String messageId, long timestamp, String topicName, String reason);
+    void logError(String messageId, long timestamp, String topicName, String reason, String hostname);
 
-    void logInflight(String messageId, long timestamp, String topicName);
+    void logInflight(String messageId, long timestamp, String topicName, String hostname);
 
 }

--- a/hermes-tracker/src/main/java/pl/allegro/tech/hermes/tracker/frontend/NoOperationPublishingTracker.java
+++ b/hermes-tracker/src/main/java/pl/allegro/tech/hermes/tracker/frontend/NoOperationPublishingTracker.java
@@ -5,14 +5,14 @@ import pl.allegro.tech.hermes.api.TopicName;
 public class NoOperationPublishingTracker implements PublishingTracker {
 
     @Override
-    public void logInflight(String messageId, TopicName topicName) {
+    public void logInflight(String messageId, TopicName topicName, String hostname) {
     }
 
     @Override
-    public void logPublished(String messageId, TopicName topicName) {
+    public void logPublished(String messageId, TopicName topicName, String hostname) {
     }
 
     @Override
-    public void logError(String messageId, TopicName topicName, String reason) {
+    public void logError(String messageId, TopicName topicName, String reason, String hostname) {
     }
 }

--- a/hermes-tracker/src/main/java/pl/allegro/tech/hermes/tracker/frontend/PublishingMessageTracker.java
+++ b/hermes-tracker/src/main/java/pl/allegro/tech/hermes/tracker/frontend/PublishingMessageTracker.java
@@ -16,18 +16,18 @@ public class PublishingMessageTracker implements PublishingTracker {
     }
 
     @Override
-    public void logInflight(final String messageId, final TopicName topicName) {
-        repositories.forEach(r -> r.logInflight(messageId, clock.millis(), topicName.qualifiedName()));
+    public void logInflight(final String messageId, final TopicName topicName, final String hostname) {
+        repositories.forEach(r -> r.logInflight(messageId, clock.millis(), topicName.qualifiedName(), hostname));
     }
 
     @Override
-    public void logPublished(final String messageId, final TopicName topicName) {
-        repositories.forEach(r -> r.logPublished(messageId, clock.millis(), topicName.qualifiedName()));
+    public void logPublished(final String messageId, final TopicName topicName, final String hostname) {
+        repositories.forEach(r -> r.logPublished(messageId, clock.millis(), topicName.qualifiedName(), hostname));
     }
 
     @Override
-    public void logError(final String messageId, final TopicName topicName, final String reason) {
-        repositories.forEach(r -> r.logError(messageId, clock.millis(), topicName.qualifiedName(), reason));
+    public void logError(final String messageId, final TopicName topicName, final String reason, final String hostname) {
+        repositories.forEach(r -> r.logError(messageId, clock.millis(), topicName.qualifiedName(), reason, hostname));
     }
 
     public void add(LogRepository logRepository) {

--- a/hermes-tracker/src/main/java/pl/allegro/tech/hermes/tracker/frontend/PublishingTracker.java
+++ b/hermes-tracker/src/main/java/pl/allegro/tech/hermes/tracker/frontend/PublishingTracker.java
@@ -3,7 +3,7 @@ package pl.allegro.tech.hermes.tracker.frontend;
 import pl.allegro.tech.hermes.api.TopicName;
 
 public interface PublishingTracker {
-    void logInflight(String messageId, TopicName topicName);
-    void logPublished(String messageId, TopicName topicName);
-    void logError(String messageId, TopicName topicName, String reason);
+    void logInflight(String messageId, TopicName topicName, String hostname);
+    void logPublished(String messageId, TopicName topicName, String hostname);
+    void logError(String messageId, TopicName topicName, String reason, String hostname);
 }

--- a/hermes-tracker/src/test/java/pl/allegro/tech/hermes/tracker/consumers/AbstractLogRepositoryTest.java
+++ b/hermes-tracker/src/test/java/pl/allegro/tech/hermes/tracker/consumers/AbstractLogRepositoryTest.java
@@ -42,7 +42,7 @@ public abstract class AbstractLogRepositoryTest {
         String topic = "group.sentMessage";
 
         // when
-        logRepository.logSuccessful(TestMessageMetadata.of(id, topic, SUBSCRIPTION), 1234L);
+        logRepository.logSuccessful(TestMessageMetadata.of(id, topic, SUBSCRIPTION), "host", 1234L);
 
         // then
         awaitUntilMessageIsPersisted(topic, SUBSCRIPTION, id, SUCCESS);
@@ -82,7 +82,7 @@ public abstract class AbstractLogRepositoryTest {
         String topic = "group.sentBatchMessage";
 
         // when
-        logRepository.logSuccessful(TestMessageMetadata.of(messageId, batchId, topic, SUBSCRIPTION), 1234L);
+        logRepository.logSuccessful(TestMessageMetadata.of(messageId, batchId, topic, SUBSCRIPTION), "host", 1234L);
 
         // then
         awaitUntilBatchMessageIsPersisted(topic, SUBSCRIPTION, messageId, batchId, SUCCESS);

--- a/hermes-tracker/src/test/java/pl/allegro/tech/hermes/tracker/frontend/AbstractLogRepositoryTest.java
+++ b/hermes-tracker/src/test/java/pl/allegro/tech/hermes/tracker/frontend/AbstractLogRepositoryTest.java
@@ -18,7 +18,7 @@ import static pl.allegro.tech.hermes.api.PublishedMessageTraceStatus.SUCCESS;
 public abstract class AbstractLogRepositoryTest {
 
     private LogRepository logRepository;
-
+    
     @BeforeSuite
     public void setUpRetry(ITestContext context) {
         for (ITestNGMethod method : context.getAllTestMethods()) {
@@ -38,12 +38,13 @@ public abstract class AbstractLogRepositoryTest {
         // given
         String id = "publishedMessage";
         String topic = "group.sentMessage";
+        String hostname = "172.16.254.1";
 
         // when
-        logRepository.logPublished(id, 1234L, topic);
+        logRepository.logPublished(id, 1234L, topic, hostname);
 
         // then
-        awaitUntilMessageIsPersisted(topic, id, SUCCESS);
+        awaitUntilMessageIsPersisted(topic, id, SUCCESS, hostname);
     }
 
     @Test
@@ -51,12 +52,13 @@ public abstract class AbstractLogRepositoryTest {
         // given
         String id = "errorMessage";
         String topic = "group.sentMessage";
+        String hostname = "172.16.254.1";
 
         // when
-        logRepository.logError(id, 1234L, topic, "reason");
+        logRepository.logError(id, 1234L, topic, "reason", hostname);
 
         // then
-        awaitUntilMessageIsPersisted(topic, id, ERROR, "reason");
+        awaitUntilMessageIsPersisted(topic, id, ERROR, "reason", hostname);
     }
 
     @Test
@@ -64,17 +66,18 @@ public abstract class AbstractLogRepositoryTest {
         // given
         String id = "inflightMessage";
         String topic = "group.sentMessage";
+        String hostname = "172.16.254.1";
 
         // when
-        logRepository.logInflight(id, 1234L, topic);
+        logRepository.logInflight(id, 1234L, topic, hostname);
 
         // then
-        awaitUntilMessageIsPersisted(topic, id, INFLIGHT);
+        awaitUntilMessageIsPersisted(topic, id, INFLIGHT, hostname);
     }
 
-    protected abstract void awaitUntilMessageIsPersisted(String topic, String id, PublishedMessageTraceStatus status) throws Exception;
+    protected abstract void awaitUntilMessageIsPersisted(String topic, String id, PublishedMessageTraceStatus status, String remoteHostname) throws Exception;
 
-    protected abstract void awaitUntilMessageIsPersisted(String topic, String id, PublishedMessageTraceStatus status, String reason)
+    protected abstract void awaitUntilMessageIsPersisted(String topic, String id, PublishedMessageTraceStatus status, String reason, String remoteHostname)
             throws Exception;
 
 }

--- a/integration/src/integration/java/pl/allegro/tech/hermes/integration/BroadcastDeliveryTest.java
+++ b/integration/src/integration/java/pl/allegro/tech/hermes/integration/BroadcastDeliveryTest.java
@@ -91,7 +91,7 @@ public class BroadcastDeliveryTest extends IntegrationTest {
         remoteServices = Stream.generate(this::createRemoteServiceEndpoint).limit(4).collect(toList());
         firstRemoteService = remoteServices.get(0);
 
-        return this.remoteServices.stream().map(RemoteServiceEndpoint::getUrl).collect(joining(";"));
+        return this.remoteServices.stream().map(RemoteServiceEndpoint::getUrl).map(Object::toString).collect(joining(";"));
     }
 
 }

--- a/integration/src/integration/java/pl/allegro/tech/hermes/integration/env/ConsumersStarter.java
+++ b/integration/src/integration/java/pl/allegro/tech/hermes/integration/env/ConsumersStarter.java
@@ -38,6 +38,7 @@ public class ConsumersStarter implements Starter<HermesConsumers> {
                         10,
                         1000,
                         configFactory.getStringProperty(Configs.KAFKA_CLUSTER_NAME),
+                        configFactory.getStringProperty(Configs.HOSTNAME),
                         serviceLocator.getService(MetricRegistry.class),
                         serviceLocator.getService(PathsCompiler.class)))
             .build();

--- a/integration/src/integration/java/pl/allegro/tech/hermes/integration/env/FrontendStarter.java
+++ b/integration/src/integration/java/pl/allegro/tech/hermes/integration/env/FrontendStarter.java
@@ -55,6 +55,7 @@ public class FrontendStarter implements Starter<HermesFrontend> {
                     10,
                     1000,
                     configFactory.getStringProperty(Configs.KAFKA_CLUSTER_NAME),
+                    configFactory.getStringProperty(Configs.HOSTNAME),
                     serviceLocator.getService(MetricRegistry.class),
                     serviceLocator.getService(PathsCompiler.class)))
             .withKafkaTopicsNamesMapper(serviceLocator ->


### PR DESCRIPTION
This PR makes inspecting hostname related information for tracked topics/subscriptions much easier than before:

* information which remote host published message (**frontend**) 
* information which node was handling message publishing (**frontend**): useful for locating missing messages that still could be present on disk
* information which node was responsible for message delivery (**consumer**): debugging memory corruption related issues
* information to which host message was delivered (**consumer**): extremely useful for debugging problems on subscriber-side, if you have 150+ potential nodes to check this one can save hours