### PR TITLE
Consumers graceful shutdown

### DIFF
--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/common/config/Configs.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/common/config/Configs.java
@@ -38,7 +38,7 @@ public enum Configs {
     KAFKA_CONSUMER_DUAL_COMMIT_ENABLED("kafka.consumer.dual.commit.enabled", true),
     KAFKA_CONSUMER_METADATA_READ_TIMEOUT("kafka.consumer.metadata.read.timeout", 5000),
     KAFKA_CONSUMER_OFFSET_COMMITTER_BROKER_CONNECTION_EXPIRATION("kafka.consumer.offset.commiter.broker.connection.expiration", 60),
-    KAFKA_CONSUMER_REBALANCE_MAX_RETRIES("kafka.consumer.rebalance.max.retries", 150),
+    KAFKA_CONSUMER_REBALANCE_MAX_RETRIES("kafka.consumer.rebalance.max.retries", 60),
     KAFKA_CONSUMER_REBALANCE_BACKOFF("kafka.consumer.rebalance.backoff", 4000),
 
     KAFKA_SIMPLE_CONSUMER_TIMEOUT_MS("kafka.simple.consumer.timeout.ms", 5000),
@@ -138,7 +138,8 @@ public enum Configs {
     CONSUMER_FILTERING_ENABLED("consumer.filtering.enabled", true),
 
     CONSUMER_BACKGROUND_SUPERVISOR_INTERVAL("consumer.supervisor.background.interval", 20_000),
-    CONSUMER_BACKGROUND_SUPERVISOR_UNHEALTHY_AFTER("consumer.supervisor.background.unhealty.after", 300_000),
+    CONSUMER_BACKGROUND_SUPERVISOR_UNHEALTHY_AFTER("consumer.supervisor.background.unhealty.after", 600_000),
+    CONSUMER_BACKGROUND_SUPERVISOR_KILL_AFTER("consumer.supervisor.background.kill.after", 300_000),
     CONSUMER_SIGNAL_PROCESSING_INTERVAL("consumer.supervisor.signal.processing.interval.ms", 5_000),
 
     OAUTH_MISSING_SUBSCRIPTION_HANDLERS_CREATION_DELAY("oauth.missing.subscription.handlers.creation.delay", 10_000L),

--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/common/config/Configs.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/common/config/Configs.java
@@ -131,6 +131,7 @@ public enum Configs {
     CONSUMER_WORKLOAD_ASSIGNMENT_PROCESSING_THREAD_POOL_SIZE("consumer.workload.assignment.processing.thread.pool.size", 5),
     CONSUMER_WORKLOAD_NODE_ID("consumer.workload.node.id",
             new InetAddressHostnameResolver().resolve().replaceAll("\\.", "_") + "$" + abs(randomUUID().getMostSignificantBits())),
+    CONSUMER_WORKLOAD_MONITOR_SCAN_INTERVAL("consumer.workload.monitor.scan.interval.seconds", 120),
     CONSUMER_BATCH_POOLABLE_SIZE("consumer.batch.poolable.size", 1024),
     CONSUMER_BATCH_MAX_POOL_SIZE("consumer.batch.max.pool.size", 64*1024*1024),
     CONSUMER_BATCH_CONNECTION_TIMEOUT("consumer.batch.connection.timeout", 500),

--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/infrastructure/zookeeper/cache/CacheListeners.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/infrastructure/zookeeper/cache/CacheListeners.java
@@ -4,9 +4,6 @@ import org.apache.curator.framework.recipes.cache.PathChildrenCacheEvent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.function.Consumer;
@@ -26,7 +23,8 @@ class CacheListeners {
             try {
                 callback.accept(event);
             } catch (Exception exception) {
-                logger.error("Failed to run callback action {}", callback.getClass().getSimpleName(), exception);
+                logger.error("Failed to run callback action {} for event with data: {}",
+                        callback.getClass().getSimpleName(), event.getData(), exception);
             }
         }
     }

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/HermesConsumers.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/HermesConsumers.java
@@ -12,6 +12,7 @@ import pl.allegro.tech.hermes.common.kafka.KafkaNamesMapperHolder;
 import pl.allegro.tech.hermes.consumers.consumer.sender.MessageSenderFactory;
 import pl.allegro.tech.hermes.consumers.consumer.sender.ProtocolMessageSenderProvider;
 import pl.allegro.tech.hermes.consumers.health.HealthCheckServer;
+import pl.allegro.tech.hermes.consumers.supervisor.monitor.ConsumersRuntimeMonitor;
 import pl.allegro.tech.hermes.consumers.supervisor.workload.SupervisorController;
 import pl.allegro.tech.hermes.tracker.consumers.LogRepository;
 import pl.allegro.tech.hermes.tracker.consumers.Trackers;
@@ -84,6 +85,7 @@ public class HermesConsumers {
             kafkaNamesMapper.ifPresent(it -> ((KafkaNamesMapperHolder) serviceLocator.getService(KafkaNamesMapper.class)).setKafkaNamespaceMapper(it.apply(serviceLocator)));
 
             supervisorController.start();
+            serviceLocator.getService(ConsumersRuntimeMonitor.class).start();
             healthCheckServer.start();
             hooksHandler.startup(serviceLocator);
         } catch (Exception e) {

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/di/ConsumersBinder.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/di/ConsumersBinder.java
@@ -68,6 +68,8 @@ import pl.allegro.tech.hermes.consumers.supervisor.ConsumerFactory;
 import pl.allegro.tech.hermes.consumers.supervisor.ConsumersExecutorService;
 import pl.allegro.tech.hermes.consumers.supervisor.ConsumersSupervisor;
 import pl.allegro.tech.hermes.consumers.supervisor.NonblockingConsumersSupervisor;
+import pl.allegro.tech.hermes.consumers.supervisor.monitor.ConsumersRuntimeMonitor;
+import pl.allegro.tech.hermes.consumers.supervisor.monitor.ConsumersRuntimeMonitorFactory;
 import pl.allegro.tech.hermes.consumers.supervisor.process.Retransmitter;
 import pl.allegro.tech.hermes.consumers.supervisor.workload.SubscriptionAssignmentRegistry;
 import pl.allegro.tech.hermes.consumers.supervisor.workload.SubscriptionAssignmentRegistryFactory;
@@ -131,6 +133,7 @@ public class ConsumersBinder extends AbstractBinder {
         bindFactory(WorkTrackerFactory.class).in(Singleton.class).to(WorkTracker.class);
         bindFactory(SubscriptionAssignmentRegistryFactory.class).in(Singleton.class).to(SubscriptionAssignmentRegistry.class);
         bindFactory(SupervisorControllerFactory.class).in(Singleton.class).to(SupervisorController.class);
+        bindFactory(ConsumersRuntimeMonitorFactory.class).in(Singleton.class).to(ConsumersRuntimeMonitor.class);
 
         bindSingleton(UndeliveredMessageLogPersister.class);
         bindFactory(ByteBufferMessageBatchFactoryProvider.class).in(Singleton.class).to(MessageBatchFactory.class);

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/ConsumersSupervisor.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/ConsumersSupervisor.java
@@ -4,6 +4,8 @@ import pl.allegro.tech.hermes.api.Subscription;
 import pl.allegro.tech.hermes.api.SubscriptionName;
 import pl.allegro.tech.hermes.api.Topic;
 
+import java.util.Set;
+
 public interface ConsumersSupervisor {
 
     void assignConsumerForSubscription(Subscription subscription);
@@ -19,6 +21,8 @@ public interface ConsumersSupervisor {
     void retransmit(SubscriptionName subscription) throws Exception;
 
     void restartConsumer(SubscriptionName subscription) throws Exception;
+
+    Set<SubscriptionName> runningConsumers();
 
     void start() throws Exception;
 }

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/NonblockingConsumersSupervisor.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/NonblockingConsumersSupervisor.java
@@ -89,7 +89,7 @@ public class NonblockingConsumersSupervisor implements ConsumersSupervisor {
             }
             logger.info("Consumer for {} was added for execution", subscription.getQualifiedName());
         } catch (Exception ex) {
-            logger.error("Failed to create consumer for subscription {}", subscription.getQualifiedName(), ex);
+            logger.error("Failed to create consumea jr for subscription {}", subscription.getQualifiedName(), ex);
         }
     }
 

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/NonblockingConsumersSupervisor.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/NonblockingConsumersSupervisor.java
@@ -89,7 +89,7 @@ public class NonblockingConsumersSupervisor implements ConsumersSupervisor {
             }
             logger.info("Consumer for {} was added for execution", subscription.getQualifiedName());
         } catch (Exception ex) {
-            logger.error("Failed to create consumea jr for subscription {}", subscription.getQualifiedName(), ex);
+            logger.error("Failed to create consumer for subscription {}", subscription.getQualifiedName(), ex);
         }
     }
 

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/NonblockingConsumersSupervisor.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/NonblockingConsumersSupervisor.java
@@ -22,6 +22,7 @@ import pl.allegro.tech.hermes.domain.subscription.SubscriptionRepository;
 import javax.inject.Inject;
 import java.time.Clock;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadFactory;
@@ -116,6 +117,11 @@ public class NonblockingConsumersSupervisor implements ConsumersSupervisor {
     @Override
     public void restartConsumer(SubscriptionName subscription) {
         backgroundProcess.accept(Signal.of(Signal.SignalType.RESTART, subscription));
+    }
+
+    @Override
+    public Set<SubscriptionName> runningConsumers() {
+        return backgroundProcess.existingConsumers();
     }
 
     @Override

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/monitor/ConsumersRuntimeMonitor.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/monitor/ConsumersRuntimeMonitor.java
@@ -1,0 +1,98 @@
+package pl.allegro.tech.hermes.consumers.supervisor.monitor;
+
+import com.google.common.collect.Sets;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import pl.allegro.tech.hermes.api.SubscriptionName;
+import pl.allegro.tech.hermes.common.config.ConfigFactory;
+import pl.allegro.tech.hermes.common.config.Configs;
+import pl.allegro.tech.hermes.common.metric.HermesMetrics;
+import pl.allegro.tech.hermes.consumers.supervisor.ConsumersSupervisor;
+import pl.allegro.tech.hermes.consumers.supervisor.workload.SupervisorController;
+
+import java.util.Set;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+public class ConsumersRuntimeMonitor implements Runnable {
+
+    private static final Logger logger = LoggerFactory.getLogger(ConsumersRuntimeMonitor.class);
+
+    private final ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor(
+            new ThreadFactoryBuilder().setNameFormat("consumer-monitor-%d").build()
+    );
+
+    private final int scanIntervalSeconds;
+
+    private final ConsumersSupervisor consumerSupervisor;
+
+    private final SupervisorController workloadSupervisor;
+
+    private final HermesMetrics hermesMetrics;
+
+    public ConsumersRuntimeMonitor(ConsumersSupervisor consumerSupervisor,
+                                   SupervisorController workloadSupervisor,
+                                   HermesMetrics hermesMetrics,
+                                   ConfigFactory configFactory) {
+        this.consumerSupervisor = consumerSupervisor;
+        this.workloadSupervisor = workloadSupervisor;
+        this.hermesMetrics = hermesMetrics;
+        this.scanIntervalSeconds = configFactory.getIntProperty(Configs.CONSUMER_WORKLOAD_MONITOR_SCAN_INTERVAL);
+    }
+
+    public void checkCorrectness() {
+        Set<SubscriptionName> assignedSubscriptions = workloadSupervisor.assignedSubscriptions();
+        Set<SubscriptionName> existingSubscriptions = consumerSupervisor.runningConsumers();
+
+        Set<SubscriptionName> missingSubscriptions = missing(assignedSubscriptions, existingSubscriptions);
+        hermesMetrics.counter("consumers-workload.monitor.missing").inc(missingSubscriptions.size());
+        for (SubscriptionName subscriptionName : missingSubscriptions) {
+            logger.warn("Missing consumer process for subscription: {}", subscriptionName);
+        }
+
+
+        Set<SubscriptionName> oversusbcribedSubscriptions = oversubscribed(assignedSubscriptions, existingSubscriptions);
+        hermesMetrics.counter("consumers-workload.monitor.oversubscribed").inc(oversusbcribedSubscriptions.size());
+        for (SubscriptionName subscriptionName : missingSubscriptions) {
+            logger.warn("Unwanted consumer process for subscription: {}", subscriptionName);
+        }
+
+        logger.info(
+                "Subscriptions assigned: {}, existing subscriptions: {}, missing: {}, oversusbcribed: {}",
+                assignedSubscriptions.size(),
+                existingSubscriptions.size(),
+                missingSubscriptions.size(),
+                oversusbcribedSubscriptions.size()
+        );
+    }
+
+    @Override
+    public void run() {
+        try {
+            checkCorrectness();
+        } catch (Exception exception) {
+            logger.error("Could not check correctnes of assignments", exception);
+        }
+    }
+
+    private Set<SubscriptionName> missing(Set<SubscriptionName> assignedSubscriptions,
+                                          Set<SubscriptionName> existingSubscriptions) {
+        return Sets.difference(assignedSubscriptions, existingSubscriptions).immutableCopy();
+    }
+
+    private Set<SubscriptionName> oversubscribed(Set<SubscriptionName> assignedSubscriptions,
+                                                 Set<SubscriptionName> existingSubscriptions) {
+        return Sets.difference(existingSubscriptions, assignedSubscriptions).immutableCopy();
+    }
+
+    public void start() {
+        executor.scheduleWithFixedDelay(this, scanIntervalSeconds, scanIntervalSeconds, TimeUnit.SECONDS);
+    }
+
+    public void shutdown() throws InterruptedException {
+        executor.shutdown();
+        executor.awaitTermination(1, TimeUnit.MINUTES);
+    }
+}

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/monitor/ConsumersRuntimeMonitorFactory.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/monitor/ConsumersRuntimeMonitorFactory.java
@@ -1,0 +1,42 @@
+package pl.allegro.tech.hermes.consumers.supervisor.monitor;
+
+import org.glassfish.hk2.api.Factory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import pl.allegro.tech.hermes.common.config.ConfigFactory;
+import pl.allegro.tech.hermes.common.metric.HermesMetrics;
+import pl.allegro.tech.hermes.consumers.supervisor.ConsumersSupervisor;
+import pl.allegro.tech.hermes.consumers.supervisor.workload.SupervisorController;
+
+import javax.inject.Inject;
+
+public class ConsumersRuntimeMonitorFactory implements Factory<ConsumersRuntimeMonitor> {
+
+    private static final Logger logger = LoggerFactory.getLogger(ConsumersRuntimeMonitorFactory.class);
+
+    private final ConsumersRuntimeMonitor monitor;
+
+    @Inject
+    public ConsumersRuntimeMonitorFactory(
+            ConsumersSupervisor consumerSupervisor,
+            SupervisorController workloadSupervisor,
+            HermesMetrics hermesMetrics,
+            ConfigFactory configFactory
+    ) {
+        monitor = new ConsumersRuntimeMonitor(consumerSupervisor, workloadSupervisor, hermesMetrics, configFactory);
+    }
+
+    @Override
+    public ConsumersRuntimeMonitor provide() {
+        return monitor;
+    }
+
+    @Override
+    public void dispose(ConsumersRuntimeMonitor instance) {
+        try {
+            monitor.shutdown();
+        } catch (InterruptedException exception) {
+            logger.warn("Got exception when stopping consumers runtime monitor", exception);
+        }
+    }
+}

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/monitor/DifferenceCalculator.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/monitor/DifferenceCalculator.java
@@ -1,0 +1,16 @@
+package pl.allegro.tech.hermes.consumers.supervisor.monitor;
+
+import com.google.common.collect.Sets;
+
+import java.util.Set;
+
+class DifferenceCalculator {
+
+    static <E> SetDifference<E> calculate(Set<E> collection1, Set<E> collection2) {
+        return new SetDifference<>(
+                Sets.difference(collection2, collection1).immutableCopy(),
+                Sets.difference(collection1, collection2).immutableCopy()
+        );
+    }
+
+}

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/monitor/SetDifference.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/monitor/SetDifference.java
@@ -1,0 +1,37 @@
+package pl.allegro.tech.hermes.consumers.supervisor.monitor;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+class SetDifference<E> {
+
+    private final Set<E> added;
+
+    private final Set<E> removed;
+
+    SetDifference(Set<E> added, Set<E> removed) {
+        this.added = Collections.unmodifiableSet(new HashSet<>(added));
+        this.removed = Collections.unmodifiableSet(new HashSet<>(removed));
+    }
+
+    Set<E> added() {
+        return added;
+    }
+
+    Set<E> removed() {
+        return removed;
+    }
+
+    boolean containsChanges() {
+        return !added.isEmpty() || !removed.isEmpty();
+    }
+
+    @Override
+    public String toString() {
+        return "SetDifference{" +
+                "added=" + added +
+                ", removed=" + removed +
+                '}';
+    }
+}

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/process/ConsumerProcess.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/process/ConsumerProcess.java
@@ -8,7 +8,6 @@ import pl.allegro.tech.hermes.consumers.consumer.Consumer;
 
 import java.time.Clock;
 import java.util.Objects;
-import java.util.function.BiConsumer;
 
 public class ConsumerProcess implements Runnable {
 
@@ -24,11 +23,9 @@ public class ConsumerProcess implements Runnable {
 
     private final Retransmitter retransmitter;
 
-    private final BiConsumer<SubscriptionName, Signal.SignalType> shutdownCallback;
+    private final java.util.function.Consumer<SubscriptionName> shutdownCallback;
 
     private volatile boolean running = true;
-
-    private Signal.SignalType shutdownReason;
 
     private long healtcheckRefreshTime;
 
@@ -36,7 +33,7 @@ public class ConsumerProcess implements Runnable {
             SubscriptionName subscriptionName,
             Consumer consumer,
             Retransmitter retransmitter,
-            BiConsumer<SubscriptionName, Signal.SignalType> shutdownCallback,
+            java.util.function.Consumer<SubscriptionName> shutdownCallback,
             Clock clock
     ) {
         this.subscriptionName = subscriptionName;
@@ -60,7 +57,7 @@ public class ConsumerProcess implements Runnable {
 
         } finally {
             logger.info("Releasing consumer process thred of subscription {}", subscriptionName);
-            shutdownCallback.accept(subscriptionName, shutdownReason);
+            shutdownCallback.accept(subscriptionName);
             refreshHealthcheck();
             Thread.currentThread().setName("consumer-released-thread");
         }
@@ -90,9 +87,7 @@ public class ConsumerProcess implements Runnable {
             case RESTART:
                 restart();
                 break;
-            case STOP_RESTART:
             case STOP:
-                this.shutdownReason = signal.getType();
                 this.running = false;
                 break;
             case RETRANSMIT:

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/process/ConsumerProcess.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/process/ConsumerProcess.java
@@ -50,7 +50,7 @@ public class ConsumerProcess implements Runnable {
             Thread.currentThread().setName("consumer-" + subscriptionName);
 
             start();
-            while (running) {
+            while (running && !Thread.interrupted()) {
                 consumer.consume(() -> processSignals());
             }
             stop();

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/process/ConsumerProcessSupervisor.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/process/ConsumerProcessSupervisor.java
@@ -78,7 +78,9 @@ public class ConsumerProcessSupervisor implements Runnable {
     private void restartUnhealthy() {
         runningProcesses.stream()
                 .filter(consumerProcess -> !isHealthy(consumerProcess))
-                .forEach(consumerProcess -> taskQueue.offer(Signal.of(Signal.SignalType.RESTART_UNHEALTHY, consumerProcess.getSubscriptionName())));
+                .forEach(consumerProcess -> taskQueue.offer(Signal.of(
+                        Signal.SignalType.RESTART_UNHEALTHY, consumerProcess.getSubscriptionName())
+                ));
     }
 
     private void processSignal(Signal signal) {

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/process/RunningConsumerProcesses.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/process/RunningConsumerProcesses.java
@@ -1,11 +1,10 @@
 package pl.allegro.tech.hermes.consumers.supervisor.process;
 
-import pl.allegro.tech.hermes.api.Subscription;
 import pl.allegro.tech.hermes.api.SubscriptionName;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.Set;
 import java.util.concurrent.Future;
 import java.util.stream.Stream;
 
@@ -39,6 +38,10 @@ class RunningConsumerProcesses {
 
     Stream<ConsumerProcess> stream() {
         return processes.values().stream().map(p -> p.process);
+    }
+
+    Set<SubscriptionName> existingConsumers() {
+        return processes.keySet();
     }
 
     private static class RunningProcess {

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/process/RunningConsumerProcesses.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/process/RunningConsumerProcesses.java
@@ -5,6 +5,7 @@ import pl.allegro.tech.hermes.api.SubscriptionName;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Future;
 import java.util.stream.Stream;
 
@@ -16,12 +17,16 @@ class RunningConsumerProcesses {
         this.processes.put(process.getSubscriptionName(), new RunningProcess(process, executionHandle));
     }
 
+    void remove(SubscriptionName subscriptionName) {
+        processes.remove(subscriptionName);
+    }
+
     void remove(ConsumerProcess process) {
         processes.remove(process.getSubscriptionName());
     }
 
-    Future getExecutionHandle(ConsumerProcess process) {
-        return processes.get(process.getSubscriptionName()).executionHandle;
+    Future getExecutionHandle(SubscriptionName subscriptionName) {
+        return processes.get(subscriptionName).executionHandle;
     }
 
     ConsumerProcess getProcess(SubscriptionName subscriptionName) {

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/process/Signal.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/process/Signal.java
@@ -2,50 +2,55 @@ package pl.allegro.tech.hermes.consumers.supervisor.process;
 
 import pl.allegro.tech.hermes.api.SubscriptionName;
 
-import java.util.Optional;
-
 public class Signal {
 
     private final SignalType type;
 
     private final SubscriptionName target;
 
-    private final Optional<Object> payload;
+    private final Object payload;
+
+    private final long executeAfterTimestamp;
 
     public enum SignalType {
-        START, RESTART, STOP, RETRANSMIT, UPDATE_SUBSCRIPTION, UPDATE_TOPIC, KILL_RESTART, CLEANUP
+        START, STOP, RETRANSMIT, UPDATE_SUBSCRIPTION, UPDATE_TOPIC, KILL,
+        RESTART, RESTART_UNHEALTHY, STOP_RESTART, KILL_UNHEALTHY, CLEANUP
     }
 
-    private Signal(SignalType type, SubscriptionName target, Optional<Object> payload) {
+    private Signal(SignalType type, SubscriptionName target, Object payload, long executeAfterTimestamp) {
         this.type = type;
         this.target = target;
         this.payload = payload;
+        this.executeAfterTimestamp = executeAfterTimestamp;
     }
 
     public static Signal of(SignalType type, SubscriptionName target, Object payload) {
-        return new Signal(type, target, Optional.of(payload));
+        return new Signal(type, target, payload, -1);
     }
 
     public static Signal of(SignalType type, SubscriptionName target) {
-        return new Signal(type, target, Optional.empty());
+        return new Signal(type, target, null, -1);
     }
 
-    public SignalType getType() {
+    public static Signal of(SignalType type, SubscriptionName target, long executeAfterTimestamp) {
+        return new Signal(type, target, null, executeAfterTimestamp);
+    }
+
+    SignalType getType() {
         return type;
     }
 
-    public SubscriptionName getTarget() {
+    SubscriptionName getTarget() {
         return target;
     }
 
-    @SuppressWarnings("unchecked")
-    public <T> Optional<T> getPayload() {
-        return (Optional<T>) payload;
+    boolean canExecuteNow(long currentTimestamp) {
+        return currentTimestamp > executeAfterTimestamp;
     }
 
     @SuppressWarnings("unchecked")
-    public <T> T getExtractedPayload() {
-        return (T) payload.get();
+    <T> T getPayload() {
+        return (T) payload;
     }
 
     @Override

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/process/Signal.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/process/Signal.java
@@ -2,6 +2,8 @@ package pl.allegro.tech.hermes.consumers.supervisor.process;
 
 import pl.allegro.tech.hermes.api.SubscriptionName;
 
+import java.util.Objects;
+
 public class Signal {
 
     private final SignalType type;
@@ -59,5 +61,19 @@ public class Signal {
                 "type=" + type +
                 ", target=" + target +
                 '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Signal)) return false;
+        Signal signal = (Signal) o;
+        return type == signal.type &&
+                Objects.equals(target, signal.target);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(type, target);
     }
 }

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/process/Signal.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/process/Signal.java
@@ -65,8 +65,12 @@ public class Signal {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof Signal)) return false;
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof Signal)) {
+            return false;
+        }
         Signal signal = (Signal) o;
         return type == signal.type &&
                 Objects.equals(target, signal.target);

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/process/SignalsFilter.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/process/SignalsFilter.java
@@ -1,0 +1,74 @@
+package pl.allegro.tech.hermes.consumers.supervisor.process;
+
+import com.google.common.collect.ImmutableMap;
+import org.jctools.queues.MpscArrayQueue;
+import pl.allegro.tech.hermes.api.SubscriptionName;
+import pl.allegro.tech.hermes.consumers.supervisor.process.Signal.SignalType;
+
+import java.time.Clock;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+class SignalsFilter {
+
+    private static final Map<SignalType, SignalType> MERGEABLE_SIGNALS = ImmutableMap.<SignalType, SignalType>builder()
+            .put(SignalType.START, SignalType.STOP)
+            .put(SignalType.STOP, SignalType.START)
+            .build();
+
+    private static final Map<SignalType, SignalType> OVERRULING_SIGNALS = ImmutableMap.<SignalType, SignalType>builder()
+            .put(SignalType.START, SignalType.KILL_UNHEALTHY)
+            .build();
+
+    private final Clock clock;
+
+    private final MpscArrayQueue<Signal> taskQueue;
+
+    SignalsFilter(MpscArrayQueue<Signal> taskQueue, Clock clock) {
+        this.taskQueue = taskQueue;
+        this.clock = clock;
+    }
+
+    Set<Signal> filterSignals(List<Signal> signals, Set<SubscriptionName> exisitingConsumers) {
+        Set<Signal> filteredSignals = Collections.newSetFromMap(new LinkedHashMap<>(signals.size()));
+
+        for (Signal signal : signals) {
+            boolean merged = merge(filteredSignals, signal);
+            if (!merged) {
+                negate(filteredSignals, signal);
+
+                if (signal.getType() == SignalType.START || exisitingConsumers.contains(signal.getTarget())) {
+                    if (signal.canExecuteNow(clock.millis())) {
+                        filteredSignals.add(signal);
+                    } else {
+                        taskQueue.offer(signal);
+                    }
+                }
+            }
+        }
+
+        return filteredSignals;
+    }
+
+    private boolean merge(Set<Signal> filteredSignals, Signal signal) {
+        SignalType signalTypeToMerge = MERGEABLE_SIGNALS.get(signal.getType());
+        if (signalTypeToMerge != null) {
+            return filteredSignals.remove(equalSignal(signalTypeToMerge, signal.getTarget()));
+        }
+        return false;
+    }
+
+    private void negate(Set<Signal> filteredSignals, Signal signal) {
+        SignalType signalToRemove = OVERRULING_SIGNALS.get(signal.getType());
+        if (signalToRemove != null) {
+            filteredSignals.remove(equalSignal(signalToRemove, signal.getTarget()));
+        }
+    }
+
+    private Signal equalSignal(SignalType type, SubscriptionName target) {
+        return Signal.of(type, target);
+    }
+}

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/workload/SupervisorController.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/workload/SupervisorController.java
@@ -1,12 +1,18 @@
 package pl.allegro.tech.hermes.consumers.supervisor.workload;
 
+import pl.allegro.tech.hermes.api.SubscriptionName;
 import pl.allegro.tech.hermes.common.admin.AdminOperationsCallback;
 import pl.allegro.tech.hermes.domain.notifications.SubscriptionCallback;
 import pl.allegro.tech.hermes.domain.notifications.TopicCallback;
 
+import java.util.Set;
+
 public interface SupervisorController extends SubscriptionCallback, TopicCallback, SubscriptionAssignmentAware, AdminOperationsCallback {
+
+    Set<SubscriptionName> assignedSubscriptions();
 
     void start() throws Exception;
 
     void shutdown() throws InterruptedException;
+
 }

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/workload/mirror/MirroringSupervisorController.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/workload/mirror/MirroringSupervisorController.java
@@ -16,6 +16,7 @@ import pl.allegro.tech.hermes.consumers.supervisor.workload.WorkTracker;
 import pl.allegro.tech.hermes.consumers.supervisor.workload.SubscriptionAssignmentRegistry;
 import pl.allegro.tech.hermes.domain.notifications.InternalNotificationsBus;
 
+import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
@@ -25,6 +26,8 @@ import static pl.allegro.tech.hermes.common.config.Configs.CONSUMER_WORKLOAD_NOD
 public class MirroringSupervisorController implements SupervisorController {
 
     private static final Logger logger = LoggerFactory.getLogger(MirroringSupervisorController.class);
+
+    private final String consumerNodeId;
 
     private final ConsumersSupervisor supervisor;
     private final InternalNotificationsBus notificationsBus;
@@ -43,6 +46,8 @@ public class MirroringSupervisorController implements SupervisorController {
                                          WorkTracker workTracker,
                                          ZookeeperAdminCache adminCache,
                                          ConfigFactory configFactory) {
+        this.consumerNodeId = configFactory.getStringProperty(CONSUMER_WORKLOAD_NODE_ID);
+
         this.supervisor = supervisor;
         this.notificationsBus = notificationsBus;
         this.assignementRegistry = assignementRegistry;
@@ -115,6 +120,11 @@ public class MirroringSupervisorController implements SupervisorController {
         supervisor.start();
         assignementRegistry.start();
         logger.info("Consumer boot complete. Workload config: [{}]", configFactory.print(CONSUMER_WORKLOAD_NODE_ID, CONSUMER_WORKLOAD_ALGORITHM));
+    }
+
+    @Override
+    public Set<SubscriptionName> assignedSubscriptions() {
+        return assignementRegistry.createSnapshot().getSubscriptionsForConsumerNode(consumerNodeId);
     }
 
     @Override

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/workload/selective/SelectiveSupervisorController.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/workload/selective/SelectiveSupervisorController.java
@@ -15,6 +15,7 @@ import pl.allegro.tech.hermes.consumers.supervisor.workload.SupervisorController
 import pl.allegro.tech.hermes.consumers.supervisor.workload.WorkTracker;
 import pl.allegro.tech.hermes.domain.notifications.InternalNotificationsBus;
 
+import java.util.Set;
 import java.util.concurrent.ExecutorService;
 
 import static pl.allegro.tech.hermes.common.config.Configs.*;
@@ -121,6 +122,11 @@ public class SelectiveSupervisorController implements SupervisorController {
                         CONSUMER_WORKLOAD_CONSUMERS_PER_SUBSCRIPTION,
                         CONSUMER_WORKLOAD_MAX_SUBSCRIPTIONS_PER_CONSUMER));
         registry.start();
+    }
+
+    @Override
+    public Set<SubscriptionName> assignedSubscriptions() {
+        return registry.createSnapshot().getSubscriptionsForConsumerNode(getId());
     }
 
     @Override

--- a/hermes-consumers/src/test/groovy/pl/allegro/tech/hermes/consumers/supervisor/process/ConsumerProcessTest.groovy
+++ b/hermes-consumers/src/test/groovy/pl/allegro/tech/hermes/consumers/supervisor/process/ConsumerProcessTest.groovy
@@ -28,7 +28,7 @@ class ConsumerProcessTest extends Specification {
             subscription,
             consumer,
             retransmitter,
-            { a, b -> shutdownRun = true },
+            { a -> shutdownRun = true },
             Clock.fixed(Instant.ofEpochMilli(1024), ZoneId.systemDefault())
     )
 

--- a/hermes-consumers/src/test/groovy/pl/allegro/tech/hermes/consumers/supervisor/process/ConsumerProcessTest.groovy
+++ b/hermes-consumers/src/test/groovy/pl/allegro/tech/hermes/consumers/supervisor/process/ConsumerProcessTest.groovy
@@ -28,8 +28,11 @@ class ConsumerProcessTest extends Specification {
             subscription,
             consumer,
             retransmitter,
+            { a, b -> shutdownRun = true },
             Clock.fixed(Instant.ofEpochMilli(1024), ZoneId.systemDefault())
     )
+
+    private boolean shutdownRun = false
 
     def "should run main loop till stop signal sent"() {
         when:
@@ -44,6 +47,16 @@ class ConsumerProcessTest extends Specification {
         consumer.tornDown
     }
 
+    def "should run shutdown callback on Consumer stop"() {
+        when:
+        executor.submit(process)
+        process.accept(Signal.of(Signal.SignalType.STOP, subscription))
+        waiter.waitForSignalProcessing()
+
+        then:
+        shutdownRun
+    }
+
     def "should refresh healthcheck when signals are processed"() {
         given:
         executor.submit(process)
@@ -56,7 +69,7 @@ class ConsumerProcessTest extends Specification {
         process.healtcheckRefreshTime() == 1024
     }
 
-    def "should tear down and initialize consumer on restart"() {
+    def "should tear down and initialize consumer on restart but not call shutdown hook"() {
         given:
         executor.submit(process)
 
@@ -71,6 +84,7 @@ class ConsumerProcessTest extends Specification {
         cleanup:
         process.accept(Signal.of(Signal.SignalType.STOP, subscription))
         waiter.waitForSignalProcessing()
+        !shutdownRun
     }
 
     def "should stop, retransmit and start consumer on retransmission"() {

--- a/hermes-consumers/src/test/groovy/pl/allegro/tech/hermes/consumers/supervisor/process/SignalsFilterTest.groovy
+++ b/hermes-consumers/src/test/groovy/pl/allegro/tech/hermes/consumers/supervisor/process/SignalsFilterTest.groovy
@@ -1,0 +1,146 @@
+package pl.allegro.tech.hermes.consumers.supervisor.process
+
+import org.jctools.queues.MpscArrayQueue
+import pl.allegro.tech.hermes.api.SubscriptionName
+import pl.allegro.tech.hermes.consumers.supervisor.process.Signal.SignalType
+import spock.lang.Specification
+
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneId
+
+class SignalsFilterTest extends Specification {
+
+    private final Clock clock = Clock.fixed(Instant.ofEpochMilli(1024), ZoneId.systemDefault())
+
+    private final MpscArrayQueue<Signal> taskQueue = new MpscArrayQueue<>(10);
+
+    private final SignalsFilter filter = new SignalsFilter(taskQueue, clock)
+
+    def "should filter out contradicting signals like START & STOP or STOP & START for the same subscription"() {
+        given:
+        List<Signal> signals = [
+                Signal.of(SignalType.STOP, subscription('A')),
+                Signal.of(SignalType.STOP, subscription('B')),
+                Signal.of(SignalType.STOP, subscription('C')),
+                Signal.of(SignalType.START, subscription('D')),
+                Signal.of(SignalType.START, subscription('A'))
+        ]
+
+        Set<SubscriptionName> existingConsumers = [
+                subscription('A'), subscription('B'), subscription('C'), subscription('D')
+        ]
+
+        when:
+        Set<Signal> filteredSignals = filter.filterSignals(signals, existingConsumers)
+
+        then:
+        filteredSignals == [
+                Signal.of(SignalType.STOP, subscription('B')),
+                Signal.of(SignalType.STOP, subscription('C')),
+                Signal.of(SignalType.START, subscription('D'))
+        ] as Set
+    }
+
+    def "should remove all pending KILL_UNHEALTHY signals if START signals appears"() {
+        given:
+        List<Signal> signals = [
+                Signal.of(SignalType.KILL_UNHEALTHY, subscription('A')),
+                Signal.of(SignalType.UPDATE_TOPIC, subscription('B')),
+                Signal.of(SignalType.STOP, subscription('C')),
+                Signal.of(SignalType.KILL_UNHEALTHY, subscription('A')),
+                Signal.of(SignalType.START, subscription('D')),
+                Signal.of(SignalType.START, subscription('A'))
+        ]
+
+        Set<SubscriptionName> existingConsumers = [
+                subscription('A'), subscription('B'), subscription('C'), subscription('D')
+        ]
+
+        when:
+        Set<Signal> filteredSignals = filter.filterSignals(signals, existingConsumers)
+
+        then:
+        filteredSignals == [
+                Signal.of(SignalType.UPDATE_TOPIC, subscription('B')),
+                Signal.of(SignalType.STOP, subscription('C')),
+                Signal.of(SignalType.START, subscription('D')),
+                Signal.of(SignalType.START, subscription('A'))
+        ] as Set
+    }
+
+    def "should remove duplicate signals keeping the most recent one"() {
+        given:
+        List<Signal> signals = [
+                Signal.of(SignalType.UPDATE_TOPIC, subscription('A'), 'first-update'),
+                Signal.of(SignalType.UPDATE_TOPIC, subscription('A'), 'second-update'),
+        ]
+
+        Set<SubscriptionName> existingConsumers = [subscription('A')]
+
+        when:
+        Set<Signal> filteredSignals = filter.filterSignals(signals, existingConsumers)
+
+        then:
+        filteredSignals == [
+                Signal.of(SignalType.UPDATE_TOPIC, subscription('A')),
+        ] as Set
+        filteredSignals
+    }
+
+    def "should remove signals that should be executed later and put them back on task queue"() {
+        given:
+        List<Signal> signals = [
+                Signal.of(SignalType.KILL_UNHEALTHY, subscription('A'), 2048),
+        ]
+
+        Set<SubscriptionName> existingConsumers = [subscription('A')]
+
+        when:
+        Set<Signal> filteredSignals = filter.filterSignals(signals, existingConsumers)
+
+        then:
+        filteredSignals == [] as Set
+        taskQueue.drain({ s -> s == Signal.of(SignalType.KILL_UNHEALTHY, subscription('A')) })
+    }
+
+    def "should filter out signals for consumer processes that do not exist"() {
+        given:
+        List<Signal> signals = [
+                Signal.of(SignalType.KILL, subscription('A')),
+                Signal.of(SignalType.KILL, subscription('B')),
+        ]
+
+        Set<SubscriptionName> existingConsumers = [subscription('A')]
+
+        when:
+        Set<Signal> filteredSignals = filter.filterSignals(signals, existingConsumers)
+
+        then:
+        filteredSignals == [
+                Signal.of(SignalType.KILL, subscription('A'))
+        ] as Set
+    }
+
+    def "should allow on processing START signal for processes that do not exist"() {
+        given:
+        List<Signal> signals = [
+                Signal.of(SignalType.START, subscription('A')),
+        ]
+
+        Set<SubscriptionName> existingConsumers = []
+
+        when:
+        Set<Signal> filteredSignals = filter.filterSignals(signals, existingConsumers)
+
+        then:
+        filteredSignals == [
+                Signal.of(SignalType.START, subscription('A'))
+        ] as Set
+    }
+
+
+    private SubscriptionName subscription(String suffix) {
+        return SubscriptionName.fromString("group.topic\$sub$suffix")
+    }
+}

--- a/integration/src/integration/java/pl/allegro/tech/hermes/integration/MessageBufferLoadingTest.java
+++ b/integration/src/integration/java/pl/allegro/tech/hermes/integration/MessageBufferLoadingTest.java
@@ -39,8 +39,10 @@ import static javax.ws.rs.core.Response.Status.ACCEPTED;
 import static javax.ws.rs.core.Response.Status.CREATED;
 import static org.apache.commons.io.FileUtils.copyFile;
 import static org.assertj.core.api.Assertions.assertThat;
+import static pl.allegro.tech.hermes.common.config.Configs.KAFKA_BROKER_LIST;
+import static pl.allegro.tech.hermes.common.config.Configs.KAFKA_ZOOKEEPER_CONNECT_STRING;
+import static pl.allegro.tech.hermes.common.config.Configs.MESSAGES_LOCAL_STORAGE_DIRECTORY;
 import static pl.allegro.tech.hermes.test.helper.builder.TopicBuilder.topic;
-import static pl.allegro.tech.hermes.common.config.Configs.*;
 
 public class MessageBufferLoadingTest extends IntegrationTest {
 


### PR DESCRIPTION
This PR fixes two sources of instability of new Consumer Process model:

* consumers have graceful shutdown period - by default Consuemr has 5 minutes to shutdown before it gets killed, the rebalance timeout has been adjusted accordingly (4 minutes)
* consumers filter out unwanted signals - calling START & STOP immediately will result in no action, calling multiple updates will make only the most recent one to be applied etc

Also i added a way to monitor assignments vs real consumer processes.