### PR TITLE
Subsciption request timeout max value increased to 5 min

### DIFF
--- a/hermes-api/src/main/java/pl/allegro/tech/hermes/api/SubscriptionPolicy.java
+++ b/hermes-api/src/main/java/pl/allegro/tech/hermes/api/SubscriptionPolicy.java
@@ -28,7 +28,7 @@ public class SubscriptionPolicy {
     private int messageBackoff = DEFAULT_MESSAGE_BACKOFF;
 
     @Min(100)
-    @Max(60000)
+    @Max(300_000)
     private int requestTimeout = DEFAULT_REQUEST_TIMEOUT;
 
     @Min(1)


### PR DESCRIPTION
Consumers request timeout max value increased from 1 to 5 mins.