### PR TITLE
Spring context bootstrap phase check fix

### DIFF
--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/spring/ApplicationEnvironmentPreparedEventListener.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/spring/ApplicationEnvironmentPreparedEventListener.java
@@ -2,6 +2,7 @@ package pl.allegro.tech.hermes.management.spring;
 
 import org.springframework.boot.context.event.ApplicationEnvironmentPreparedEvent;
 import org.springframework.context.ApplicationListener;
+import org.springframework.core.env.MutablePropertySources;
 
 
 public abstract class ApplicationEnvironmentPreparedEventListener implements ApplicationListener<ApplicationEnvironmentPreparedEvent>{
@@ -11,7 +12,8 @@ public abstract class ApplicationEnvironmentPreparedEventListener implements App
     @Override
     public void onApplicationEvent(ApplicationEnvironmentPreparedEvent event) {
         // don't listen to events in a bootstrap context
-        if (event.getEnvironment().getPropertySources().contains("bootstrapInProgress")) {
+        MutablePropertySources propertySources = event.getEnvironment().getPropertySources();
+        if (propertySources.contains("bootstrapInProgress") || propertySources.contains("bootstrap")) {
             return;
         }
 


### PR DESCRIPTION
This PR fixes bootstrap phase check for compatible with `spring-cloud-context 1.1.0.RELEASE`.
