### PR TITLE
shutdown retry executor on ConsumerProcess stop

### DIFF
--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/SerialConsumer.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/SerialConsumer.java
@@ -124,6 +124,7 @@ public class SerialConsumer implements Consumer {
     public void initialize() {
         logger.info("Consumer: preparing message receiver for subscription {}", subscription.getQualifiedName());
         initializeMessageReceiver();
+        sender.initialize();
         rateLimiter.initialize();
         consumerAuthorizationHandler.createSubscriptionHandler(subscription.getQualifiedName());
     }

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/process/ConsumerProcess.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/process/ConsumerProcess.java
@@ -54,7 +54,6 @@ public class ConsumerProcess implements Runnable {
                 consumer.consume(() -> processSignals());
             }
             stop();
-
         } finally {
             logger.info("Releasing consumer process thred of subscription {}", subscriptionName);
             shutdownCallback.accept(subscriptionName);


### PR DESCRIPTION
Since `ScheduledExecutorService` in `ConsumerMessageSender` is never shutdown, it might artificially keep the subscription alive, sending messages etc when there are some messages trapped in retry circle (up to TTL).

I suspect this could have caused some zombie subscriptions and hanging threads we were seeing on prod. Thanks to @samuel-beniamin for pinpointing the issue. 