### PR TITLE
Schema versions cache fix

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -97,7 +97,11 @@
         <module name="ParenPad"/>
         <module name="TypecastParenPad"/>
         <module name="WhitespaceAfter"/>
-        <module name="WhitespaceAround"/>
+        <module name="WhitespaceAround">
+            <property name="allowEmptyMethods" value="true" />
+            <property name="allowEmptyConstructors" value="true" />
+            <property name="allowEmptyTypes" value="true" />
+        </module>
 
         <!-- Modifier Checks                                    -->
         <!-- See http://checkstyle.sf.net/config_modifiers.html -->

--- a/hermes-schema/src/main/java/pl/allegro/tech/hermes/schema/CachedSchemaVersionsRepository.java
+++ b/hermes-schema/src/main/java/pl/allegro/tech/hermes/schema/CachedSchemaVersionsRepository.java
@@ -73,8 +73,8 @@ public class CachedSchemaVersionsRepository implements SchemaVersionsRepository 
                 try {
                     return rawSchemaClient.getVersions(topic.getName());
                 } catch (Exception e) {
-                    logger.warn("Could not reload schema versions for topic {}", topic.getQualifiedName(), e);
-                    throw e;
+                    logger.error("Could not reload schema versions for topic {}, will use stale data", topic.getQualifiedName(), e);
+                    return oldVersions;
                 }
             });
             versionsReloader.execute(task);

--- a/hermes-schema/src/main/java/pl/allegro/tech/hermes/schema/CouldNotFetchSchemaVersionException.java
+++ b/hermes-schema/src/main/java/pl/allegro/tech/hermes/schema/CouldNotFetchSchemaVersionException.java
@@ -1,0 +1,18 @@
+package pl.allegro.tech.hermes.schema;
+
+import pl.allegro.tech.hermes.api.ErrorCode;
+
+import javax.ws.rs.core.Response;
+
+public class CouldNotFetchSchemaVersionException extends SchemaException {
+
+    public CouldNotFetchSchemaVersionException(String subject, String version, Response response) {
+        super(String.format("Could not fetch schema for subject %s at version %s, reason: %d %s",
+                subject, version, response.getStatus(), response.readEntity(String.class)));
+    }
+
+    @Override
+    public ErrorCode getCode() {
+        return ErrorCode.SCHEMA_COULD_NOT_BE_LOADED;
+    }
+}

--- a/hermes-schema/src/main/java/pl/allegro/tech/hermes/schema/CouldNotFetchSchemaVersionsException.java
+++ b/hermes-schema/src/main/java/pl/allegro/tech/hermes/schema/CouldNotFetchSchemaVersionsException.java
@@ -1,0 +1,18 @@
+package pl.allegro.tech.hermes.schema;
+
+import pl.allegro.tech.hermes.api.ErrorCode;
+
+import javax.ws.rs.core.Response;
+
+public class CouldNotFetchSchemaVersionsException extends SchemaException {
+
+    public CouldNotFetchSchemaVersionsException(String subject, Response response) {
+        super(String.format("Could not fetch schema versions for subject %s, reason: %d %s",
+                subject, response.getStatus(), response.readEntity(String.class)));
+    }
+
+    @Override
+    public ErrorCode getCode() {
+        return ErrorCode.SCHEMA_COULD_NOT_BE_LOADED;
+    }
+}

--- a/hermes-schema/src/main/java/pl/allegro/tech/hermes/schema/CouldNotRegisterSchemaException.java
+++ b/hermes-schema/src/main/java/pl/allegro/tech/hermes/schema/CouldNotRegisterSchemaException.java
@@ -1,0 +1,18 @@
+package pl.allegro.tech.hermes.schema;
+
+import pl.allegro.tech.hermes.api.ErrorCode;
+
+import javax.ws.rs.core.Response;
+
+public class CouldNotRegisterSchemaException extends SchemaException {
+
+    public CouldNotRegisterSchemaException(String subject, Response response) {
+        super(String.format("Could not register schema for subject %s, reason: %d %s",
+                subject, response.getStatus(), response.readEntity(String.class)));
+    }
+
+    @Override
+    public ErrorCode getCode() {
+        return ErrorCode.SCHEMA_COULD_NOT_BE_SAVED;
+    }
+}

--- a/hermes-schema/src/main/java/pl/allegro/tech/hermes/schema/CouldNotRegisterSchemaSubjectException.java
+++ b/hermes-schema/src/main/java/pl/allegro/tech/hermes/schema/CouldNotRegisterSchemaSubjectException.java
@@ -1,0 +1,18 @@
+package pl.allegro.tech.hermes.schema;
+
+import pl.allegro.tech.hermes.api.ErrorCode;
+
+import javax.ws.rs.core.Response;
+
+public class CouldNotRegisterSchemaSubjectException extends SchemaException {
+
+    public CouldNotRegisterSchemaSubjectException(String subject, Response response) {
+        super(String.format("Could not register subject %s in schema repository, reason: %d %s",
+                subject, response.getStatus(), response.readEntity(String.class)));
+    }
+
+    @Override
+    public ErrorCode getCode() {
+        return ErrorCode.SCHEMA_COULD_NOT_BE_SAVED;
+    }
+}

--- a/hermes-schema/src/main/java/pl/allegro/tech/hermes/schema/schemarepo/SchemaRepoRawSchemaClient.java
+++ b/hermes-schema/src/main/java/pl/allegro/tech/hermes/schema/schemarepo/SchemaRepoRawSchemaClient.java
@@ -6,8 +6,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import pl.allegro.tech.hermes.api.RawSchema;
 import pl.allegro.tech.hermes.api.TopicName;
-import pl.allegro.tech.hermes.schema.InvalidSchemaException;
-import pl.allegro.tech.hermes.schema.SchemaRepositoryServerException;
+import pl.allegro.tech.hermes.schema.CouldNotFetchSchemaVersionException;
+import pl.allegro.tech.hermes.schema.CouldNotFetchSchemaVersionsException;
+import pl.allegro.tech.hermes.schema.CouldNotRegisterSchemaException;
+import pl.allegro.tech.hermes.schema.CouldNotRegisterSchemaSubjectException;
 import pl.allegro.tech.hermes.schema.RawSchemaClient;
 import pl.allegro.tech.hermes.schema.SchemaVersion;
 
@@ -39,30 +41,66 @@ public class SchemaRepoRawSchemaClient implements RawSchemaClient {
     @Override
     public Optional<RawSchema> getSchema(TopicName topic, SchemaVersion version) {
         String subject = topic.qualifiedName();
-        Response response = target.path(subject).path("id").path(Integer.toString(version.value())).request().get();
-        return extractSchema(subject, response).map(RawSchema::valueOf);
+        String versionString = Integer.toString(version.value());
+        Response response = target.path(subject)
+                .path("id")
+                .path(versionString)
+                .request()
+                .get();
+        return extractSchema(subject, versionString, response).map(RawSchema::valueOf);
     }
 
     @Override
     public Optional<RawSchema> getLatestSchema(TopicName topic) {
         String subject = topic.qualifiedName();
-        Response response = target.path(subject).path("latest").request().get();
-        return extractSchema(subject, response).map(RawSchema::valueOf);
+        final String version = "latest";
+        Response response = target.path(subject)
+                .path(version)
+                .request()
+                .get();
+        return extractSchema(subject, version, response).map(RawSchema::valueOf);
+    }
+
+    private Optional<String> extractSchema(String subject, String version, Response response) {
+        switch (response.getStatusInfo().getFamily()) {
+            case SUCCESSFUL:
+                String schema = parseSchema(response.readEntity(String.class));
+                return Optional.of(schema);
+            case CLIENT_ERROR:
+                logger.error("Could not find schema for subject {}, reason: {}", subject, response.getStatus());
+                return Optional.empty();
+            case SERVER_ERROR:
+            default:
+                throw new CouldNotFetchSchemaVersionException(subject, version, response);
+        }
     }
 
     @Override
     public List<SchemaVersion> getVersions(TopicName topic) {
-        Response response = target.path(topic.qualifiedName()).path("all").request().accept(MediaType.APPLICATION_JSON_TYPE).get();
-        if (response.getStatus() == Response.Status.OK.getStatusCode()) {
-            List<SchemaWithId> schemasWithIds = Optional.ofNullable(response.readEntity(new GenericType<List<SchemaWithId>>() {}))
-                    .orElseGet(Collections::emptyList);
-            return schemasWithIds.stream()
-                    .map(SchemaWithId::getId)
-                    .sorted(Comparator.reverseOrder())
-                    .map(SchemaVersion::valueOf)
-                    .collect(Collectors.toList());
+        Response response = target.path(topic.qualifiedName())
+                .path("all")
+                .request()
+                .accept(MediaType.APPLICATION_JSON_TYPE)
+                .get();
+        return extractSchemaVersions(topic.qualifiedName(), response);
+    }
+
+    private List<SchemaVersion> extractSchemaVersions(String subject, Response response) {
+        switch (response.getStatusInfo().getFamily()) {
+            case SUCCESSFUL:
+                List<SchemaWithId> schemasWithIds = Optional.ofNullable(response.readEntity(new GenericType<List<SchemaWithId>>() {}))
+                        .orElseGet(Collections::emptyList);
+                return schemasWithIds.stream()
+                        .map(SchemaWithId::getId)
+                        .sorted(Comparator.reverseOrder())
+                        .map(SchemaVersion::valueOf)
+                        .collect(Collectors.toList());
+            case CLIENT_ERROR:
+                return Collections.emptyList();
+            case SERVER_ERROR:
+            default:
+                throw new CouldNotFetchSchemaVersionsException(subject, response);
         }
-        return Collections.emptyList();
     }
 
     @Override
@@ -81,48 +119,30 @@ public class SchemaRepoRawSchemaClient implements RawSchemaClient {
     private void registerSubject(String subject) {
         Response response = target.path(subject).request().put(Entity.entity("", MediaType.APPLICATION_FORM_URLENCODED_TYPE));
         if (SUCCESSFUL != response.getStatusInfo().getFamily()) {
-            logger.error("Failure subject registration in schema repo. Subject: {}, response code: {}, details: {}",
-                    subject, response.getStatus(), response.readEntity(String.class));
-            throw new SchemaRepositoryServerException("Failure subject registration in schema-repo.");
+            throw new CouldNotRegisterSchemaSubjectException(subject, response);
         }
     }
 
     public void registerSchema(String subject, String schema) {
         Response response = target.path(subject).path("register").request().put(Entity.entity(schema, MediaType.TEXT_PLAIN));
-        checkSchemaRegistration(response.getStatusInfo(), subject, response.readEntity(String.class));
+        checkSchemaRegistration(subject, response);
     }
 
-    private void checkSchemaRegistration(Response.StatusType statusType, String subject, String response) {
-        switch (statusType.getFamily()) {
+    private void checkSchemaRegistration(String subject, Response response) {
+        switch (response.getStatusInfo().getFamily()) {
             case SUCCESSFUL:
                 logger.info("Successful write to schema repo for subject {}", subject);
                 break;
             case CLIENT_ERROR:
-                logger.warn("Invalid schema for subject {}. Details: {}", subject, response);
-                throw new InvalidSchemaException("Invalid schema. Reason: " + response);
             case SERVER_ERROR:
-                logger.error("Failure write to schema repo for subject {}. Reason: {}", subject, response);
-                throw new SchemaRepositoryServerException("Failure writing to schema-repo. Reason: " + response);
             default:
-                logger.error("Unknown response from schema-repo. Subject {}, http status {}, Details: {}",
-                        subject, statusType.getStatusCode(), response);
-                throw new SchemaRepositoryServerException("Unknown response from schema-repo. Reason: " + response);
+                throw new CouldNotRegisterSchemaException(subject, response);
         }
     }
 
     @Override
     public void deleteAllSchemaVersions(TopicName topic) {
         throw new UnsupportedOperationException("Deleting schemas is not supported by this repository type");
-    }
-
-    private Optional<String> extractSchema(String subject, Response response) {
-        if (response.getStatus() == Response.Status.OK.getStatusCode()) {
-            String schema = parseSchema(response.readEntity(String.class));
-            return Optional.of(schema);
-        } else {
-            logger.error("Could not find schema for subject {}, reason: {}", subject, response.getStatus());
-            return Optional.empty();
-        }
     }
 
     private String parseSchema(String schemaResponse) {

--- a/hermes-schema/src/test/groovy/pl/allegro/tech/hermes/schema/CachedSchemaVersionsRepositoryTest.groovy
+++ b/hermes-schema/src/test/groovy/pl/allegro/tech/hermes/schema/CachedSchemaVersionsRepositoryTest.groovy
@@ -5,6 +5,7 @@ import pl.allegro.tech.hermes.api.TopicName
 import pl.allegro.tech.hermes.test.helper.cache.FakeTicker
 import spock.lang.Specification
 
+import javax.ws.rs.core.Response
 import java.time.Duration
 
 import static pl.allegro.tech.hermes.test.helper.builder.TopicBuilder.topic
@@ -89,7 +90,7 @@ class CachedSchemaVersionsRepositoryTest extends Specification {
         def failing = false
         rawSchemaClient.getVersions(topic.getName()) >> {
             if (failing) {
-                throw new RuntimeException("failing mode on")
+                throw new CouldNotFetchSchemaVersionsException(topic.qualifiedName, Response.serverError().build())
             }
             return [v1, v0]
         }
@@ -102,5 +103,4 @@ class CachedSchemaVersionsRepositoryTest extends Specification {
         versionsRepository.schemaVersionExists(topic, v1)
         versionsRepository.latestSchemaVersion(topic).get() == v1
     }
-
 }

--- a/hermes-schema/src/test/groovy/pl/allegro/tech/hermes/schema/DirectCompiledSchemaRepositoryTest.groovy
+++ b/hermes-schema/src/test/groovy/pl/allegro/tech/hermes/schema/DirectCompiledSchemaRepositoryTest.groovy
@@ -3,6 +3,8 @@ package pl.allegro.tech.hermes.schema
 import pl.allegro.tech.hermes.api.RawSchema
 import spock.lang.Specification
 
+import javax.ws.rs.core.Response
+
 import static pl.allegro.tech.hermes.test.helper.builder.TopicBuilder.topic
 
 class DirectCompiledSchemaRepositoryTest extends Specification {
@@ -36,7 +38,10 @@ class DirectCompiledSchemaRepositoryTest extends Specification {
 
     def "should fail to provide schema if loading schema source failed"() {
         given:
-        rawSchemaClient.getSchema(topic.getName(), v1) >> { throw new RuntimeException("loading failed") }
+        rawSchemaClient.getSchema(topic.getName(), v1) >> {
+            throw new CouldNotFetchSchemaVersionException(topic.qualifiedName,
+                    Integer.toString(v1.value()), Response.serverError().build())
+        }
 
         when:
         repository.getSchema(topic, v1)


### PR DESCRIPTION
This fix changes the behaviour of schema repository clients, as they previously didn't throw proper exceptions when schema repository underneath returned server errors etc.
Cache itself works properly.

fixes #607 
