### PR TITLE
Explicit CORS allowed domain

### DIFF
--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/HermesManagement.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/HermesManagement.java
@@ -1,32 +1,13 @@
 package pl.allegro.tech.hermes.management;
 
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.context.annotation.Bean;
-import org.springframework.http.client.ClientHttpRequestFactory;
-import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
-import org.springframework.web.client.RestTemplate;
-import pl.allegro.tech.hermes.management.config.SupportTeamServiceProperties;
 
 @SpringBootApplication
-@EnableConfigurationProperties(SupportTeamServiceProperties.class)
 public class HermesManagement {
 
     public static void main(String[] args) {
         SpringApplication.run(HermesManagement.class, args);
     }
 
-    @Bean(name = "managementRequestFactory")
-    @ConfigurationProperties(prefix = "management.restTemplate")
-    public ClientHttpRequestFactory clientHttpRequestFactory() {
-        return new HttpComponentsClientHttpRequestFactory();
-    }
-
-    @Bean
-    public RestTemplate restTemplate(@Qualifier("managementRequestFactory") ClientHttpRequestFactory clientHttpRequestFactory) {
-        return new RestTemplate(clientHttpRequestFactory);
-    }
 }

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/api/CORSFilter.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/api/CORSFilter.java
@@ -1,5 +1,8 @@
 package pl.allegro.tech.hermes.management.api;
 
+import org.springframework.beans.factory.annotation.Autowired;
+import pl.allegro.tech.hermes.management.config.CorsProperties;
+
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerResponseContext;
 import javax.ws.rs.container.ContainerResponseFilter;
@@ -9,11 +12,17 @@ import javax.ws.rs.ext.Provider;
 @Provider
 public class CORSFilter implements ContainerResponseFilter {
 
+    private final CorsProperties corsProperties;
+
+    @Autowired
+    public CORSFilter(CorsProperties corsProperties) {
+        this.corsProperties = corsProperties;
+    }
+
     @Override
     public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext) {
         MultivaluedMap<String, Object> headers = responseContext.getHeaders();
-        headers.add("Access-Control-Allow-Origin", "*");
-        headers.add("Access-Control-Allow-Credentials", "true");
+        headers.add("Access-Control-Allow-Origin", corsProperties.getAllowedOrigin());
         headers.add("Access-Control-Allow-Methods", "POST,PUT,GET,HEAD,DELETE");
         headers.add("Access-Control-Max-Age", "1209600");
         headers.addAll(

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/config/CorsConfiguration.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/config/CorsConfiguration.java
@@ -1,0 +1,10 @@
+package pl.allegro.tech.hermes.management.config;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableConfigurationProperties(CorsProperties.class)
+public class CorsConfiguration {
+
+}

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/config/CorsProperties.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/config/CorsProperties.java
@@ -1,0 +1,18 @@
+package pl.allegro.tech.hermes.management.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties("cors")
+public class CorsProperties {
+
+    private String allowedOrigin = "*";
+
+    public String getAllowedOrigin() {
+        return allowedOrigin;
+    }
+
+    public void setAllowedOrigin(String allowedOrigin) {
+        this.allowedOrigin = allowedOrigin;
+    }
+
+}

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/config/SupportTeamConfiguration.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/config/SupportTeamConfiguration.java
@@ -1,0 +1,27 @@
+package pl.allegro.tech.hermes.management.config;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.ClientHttpRequestFactory;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+@EnableConfigurationProperties(SupportTeamServiceProperties.class)
+public class SupportTeamConfiguration {
+
+    @Bean("managementRequestFactory")
+    @ConfigurationProperties(prefix = "management.restTemplate")
+    public ClientHttpRequestFactory clientHttpRequestFactory() {
+        return new HttpComponentsClientHttpRequestFactory();
+    }
+
+    @Bean
+    public RestTemplate restTemplate(@Qualifier("managementRequestFactory") ClientHttpRequestFactory clientHttpRequestFactory) {
+        return new RestTemplate(clientHttpRequestFactory);
+    }
+
+}


### PR DESCRIPTION
Hermes-management sets `Access-Control-Allow-Origin` header to `*` to allow AJAX requests from hermes-console. This is too broad and enables CSRF attacks on hermes-management API.

This PR makes the allowed origin configurable, so it can be narrowed to a single domain hosting the console. `*` stays as the default for backwards compatibility, we should probably rethink this before 1.0.0 release. Also removed `Access-Control-Allow-Credentials: true` as we don't use cookies in hermes-management.