### PR TITLE
613 json to avro dry-run fix

### DIFF
--- a/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/publishing/message/MessageFactory.java
+++ b/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/publishing/message/MessageFactory.java
@@ -8,6 +8,7 @@ import pl.allegro.tech.hermes.api.Topic;
 import pl.allegro.tech.hermes.common.http.MessageMetadataHeaders;
 import pl.allegro.tech.hermes.common.message.wrapper.MessageContentWrapper;
 import pl.allegro.tech.hermes.common.message.wrapper.UnsupportedContentTypeException;
+import pl.allegro.tech.hermes.common.message.wrapper.WrappingException;
 import pl.allegro.tech.hermes.schema.SchemaRepository;
 import pl.allegro.tech.hermes.frontend.publishing.MessageContentTypeEnforcer;
 import pl.allegro.tech.hermes.frontend.publishing.avro.AvroMessage;
@@ -61,6 +62,9 @@ public class MessageFactory {
                         createAvroMessage(request, topic, messageId, messageContent, timestamp);
                     } catch (AvroConversionException exception) {
                         logger.warn("Unsuccessful message conversion from JSON to AVRO on topic {} in dry run mode",
+                                topic.getQualifiedName(), exception);
+                    } catch (WrappingException exception) {
+                        logger.warn("Unsuccessful wrapping of AVRO message on topic {} in dry run mode",
                                 topic.getQualifiedName(), exception);
                     }
                 }

--- a/hermes-test-helper/src/main/resources/schema/user_no_metadata.avsc
+++ b/hermes-test-helper/src/main/resources/schema/user_no_metadata.avsc
@@ -1,0 +1,10 @@
+{
+    "namespace": "pl.allegro",
+    "type": "record",
+    "name": "User",
+    "fields": [
+        {"name": "name", "type": "string"},
+        {"name": "age",  "type": "int"},
+        {"name": "favoriteColor", "type": ["null", "string"]}
+    ]
+}


### PR DESCRIPTION
This fixes #613 bug

Now, there should be a 201 response + an exception logged, as expected:
```
2016-11-09 14:55:24.663 WARN  p.a.t.h.f.p.message.MessageFactory - Unsuccessful wrapping of AVRO message on topic jsonToAvroDryRun.topic2 in dry run mode
pl.allegro.tech.hermes.common.message.wrapper.WrappingException: Could not wrap avro message
	at pl.allegro.tech.hermes.common.message.wrapper.AvroMessageContentWrapper.wrapContent(AvroMessageContentWrapper.java:64)
	at pl.allegro.tech.hermes.common.message.wrapper.MessageContentWrapper.wrapAvro(MessageContentWrapper.java:75)
	at pl.allegro.tech.hermes.frontend.publishing.message.MessageFactory.createAvroMessage(MessageFactory.java:97)
	at pl.allegro.tech.hermes.frontend.publishing.message.MessageFactory.create(MessageFactory.java:62)
	at pl.allegro.tech.hermes.frontend.publishing.PublishingServlet.lambda$null$16(PublishingServlet.java:107)
	at pl.allegro.tech.hermes.frontend.publishing.PublishingServlet$$Lambda$181/767536861.run(Unknown Source)
	at io.undertow.servlet.spec.AsyncContextImpl$4.run(AsyncContextImpl.java:339)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
Caused by: org.apache.avro.AvroRuntimeException: Not a valid schema field: __metadata
	at org.apache.avro.generic.GenericData$Record.put(GenericData.java:201)
	at pl.allegro.tech.hermes.commo
```