### PR TITLE
630 fixed bug with retransmission node being removed before consumption

### DIFF
--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/common/admin/zookeeper/ZookeeperAdminCache.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/common/admin/zookeeper/ZookeeperAdminCache.java
@@ -12,6 +12,7 @@ import pl.allegro.tech.hermes.infrastructure.zookeeper.ZookeeperPaths;
 
 import javax.inject.Inject;
 import javax.inject.Named;
+import java.time.Clock;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -22,20 +23,26 @@ public class ZookeeperAdminCache extends PathChildrenCache implements PathChildr
     private final ObjectMapper objectMapper;
     private final List<AdminOperationsCallback> adminCallbacks = new ArrayList<>();
 
+    private long initializationTime;
+
     @Inject
-    public ZookeeperAdminCache(ZookeeperPaths zookeeperPaths, @Named(CuratorType.HERMES) CuratorFramework client, ObjectMapper objectMapper) {
+    public ZookeeperAdminCache(ZookeeperPaths zookeeperPaths,
+                               @Named(CuratorType.HERMES) CuratorFramework client,
+                               ObjectMapper objectMapper,
+                               Clock clock) {
         super(client, zookeeperPaths.adminPath(), true);
         this.objectMapper = objectMapper;
-
+        this.initializationTime = clock.millis();
         getListenable().addListener(this);
     }
 
     @Override
     public void childEvent(CuratorFramework client, PathChildrenCacheEvent event) throws Exception {
         switch (event.getType()) {
+            case CHILD_UPDATED:
             case CHILD_ADDED:
-                if (event.getData().getPath().contains(RETRANSMIT.name())) {
-                    retransmit(client, event);
+                if (event.getData().getPath().contains(RETRANSMIT.name()) && isYoungerThanThisNode(event)) {
+                    retransmit(event);
                 }
                 break;
             default:
@@ -43,14 +50,16 @@ public class ZookeeperAdminCache extends PathChildrenCache implements PathChildr
         }
     }
 
-    private void retransmit(CuratorFramework client, PathChildrenCacheEvent event) throws Exception {
+    private boolean isYoungerThanThisNode(PathChildrenCacheEvent event) {
+        return event.getData().getStat().getMtime() > initializationTime;
+    }
+
+    private void retransmit(PathChildrenCacheEvent event) throws Exception {
         SubscriptionName subscriptionName = objectMapper.readValue(event.getData().getData(), SubscriptionName.class);
 
         for (AdminOperationsCallback adminCallback : adminCallbacks) {
             adminCallback.onRetransmissionStarts(subscriptionName);
         }
-
-        client.delete().forPath(event.getData().getPath());
     }
 
     public void addCallback(AdminOperationsCallback callback) {

--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/common/config/Configs.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/common/config/Configs.java
@@ -183,7 +183,7 @@ public enum Configs {
     METRICS_CONSOLE_REPORTER("metrics.console.reporter", false),
     METRICS_COUNTER_EXPIRE_AFTER_ACCESS("metrics.counter.expire.after.access", 72),
 
-    ADMIN_REAPER_INTERAL_MS("admin.reaper.interval.ms", 30000),
+    ADMIN_REAPER_INTERAL_MS("admin.reaper.interval.ms", 180000),
     GLOBAL_SHUTDOWN_HOOK_REGISTERED("global.shutdown.hook.registered", true),
 
     MESSAGE_CONTENT_ROOT("message.content.root", "message"),

--- a/hermes-common/src/test/groovy/pl/allegro/tech/hermes/infrastructure/zookeeper/ZookeeperAdminCacheTest.groovy
+++ b/hermes-common/src/test/groovy/pl/allegro/tech/hermes/infrastructure/zookeeper/ZookeeperAdminCacheTest.groovy
@@ -2,27 +2,51 @@ package pl.allegro.tech.hermes.infrastructure.zookeeper
 
 import org.apache.curator.framework.recipes.cache.ChildData
 import org.apache.curator.framework.recipes.cache.PathChildrenCacheEvent
+import org.apache.zookeeper.data.Stat
 import pl.allegro.tech.hermes.api.SubscriptionName
 import pl.allegro.tech.hermes.api.TopicName
+import pl.allegro.tech.hermes.common.admin.AdminOperationsCallback
 import pl.allegro.tech.hermes.common.admin.AdminTool
 import pl.allegro.tech.hermes.common.admin.zookeeper.ZookeeperAdminCache
 import pl.allegro.tech.hermes.test.IntegrationTest
 
-class ZookeeperAdminCacheTest extends IntegrationTest {
+import java.time.Clock
+import java.time.ZoneId
 
-    def adminCache = new ZookeeperAdminCache(paths, zookeeper(), mapper)
+import static java.time.Instant.ofEpochMilli
+import static org.apache.curator.framework.recipes.cache.PathChildrenCacheEvent.Type.CHILD_ADDED
+import static org.apache.curator.framework.recipes.cache.PathChildrenCacheEvent.Type.CHILD_UPDATED
+
+class ZookeeperAdminCacheTest extends IntegrationTest {
     def subscriptionBytes =  mapper.writeValueAsBytes(new SubscriptionName("test", new TopicName("group", "name")));
 
-    def "should cleanup RETRANSMIT marker after retransmission"() {
+    def "should run retransmit callback when event is younger than node"() {
         given:
-        def path = zookeeper().create().forPath("/123_$AdminTool.Operations.RETRANSMIT")
-        def event = new PathChildrenCacheEvent(PathChildrenCacheEvent.Type.CHILD_ADDED,
-                                                new ChildData(path, null, subscriptionBytes))
-        when:
-        adminCache.childEvent(zookeeper(), event)
+        def clock = Clock.fixed(ofEpochMilli(1000), ZoneId.systemDefault());
+        def adminCache = new ZookeeperAdminCache(paths, zookeeper(), mapper, clock);
+        def path = "/1_$AdminTool.Operations.RETRANSMIT"
+        boolean executed = false
 
-        then:
-        !zookeeper().checkExists().forPath(path)
+        adminCache.addCallback([
+                onRetransmissionStarts: { SubscriptionName subscription ->
+                    executed = true;
+                },
+                restartConsumer       : { SubscriptionName subscription ->  }
+        ] as AdminOperationsCallback)
+
+        expect:
+        adminCache.childEvent(zookeeper(), new PathChildrenCacheEvent(type, new ChildData(path, getStat(mtime), subscriptionBytes)))
+        executed == result
+
+        where:
+        type          | mtime | result
+        CHILD_ADDED   |  1600 | true
+        CHILD_ADDED   |     1 | false
+        CHILD_UPDATED |  1600 | true
+        CHILD_UPDATED |     1 | false
     }
 
+    Stat getStat(int mtime) {
+        new Stat(1, 1, 1, mtime, 1, 1 , 1, 1, 1, 1, 1)
+    }
 }

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/config/StorageConfiguration.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/config/StorageConfiguration.java
@@ -148,6 +148,7 @@ public class StorageConfiguration {
         if (storageZookeeper().checkExists().forPath(zookeeperPaths().groupsPath()) == null) {
             storageZookeeper().create().creatingParentsIfNeeded().forPath(zookeeperPaths().groupsPath());
         }
+        adminTool().start();
     }
 
 }


### PR DESCRIPTION
* removed deletion of zk node when handling retransmission event (this node should be cleared by reaper process in management)
* added check for not processing retransmission events that are older than java process itself