### PR TITLE
655 max message size per topic

### DIFF
--- a/hermes-api/src/main/java/pl/allegro/tech/hermes/api/Topic.java
+++ b/hermes-api/src/main/java/pl/allegro/tech/hermes/api/Topic.java
@@ -5,6 +5,8 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import javax.validation.Valid;
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 import java.util.Objects;
 
@@ -25,6 +27,14 @@ public class Topic {
     @NotNull
     private ContentType contentType;
 
+    @Min(MIN_MESSAGE_SIZE)
+    @Max(MAX_MESSAGE_SIZE)
+    private int maxMessageSize;
+
+    public static final int MIN_MESSAGE_SIZE = 1024;
+    public static final int MAX_MESSAGE_SIZE = 2 * 1024 * 1024;
+    private static final int DEFAULT_MAX_MESSAGE_SIZE = 50 * 1024;
+
     public enum Ack {
         NONE, LEADER, ALL
     }
@@ -41,7 +51,8 @@ public class Topic {
 
     public Topic(TopicName name, String description, RetentionTime retentionTime,
                  boolean migratedFromJsonType, Ack ack, boolean trackingEnabled, ContentType contentType,
-                 boolean jsonToAvroDryRunEnabled, boolean schemaVersionAwareSerializationEnabled) {
+                 boolean jsonToAvroDryRunEnabled, boolean schemaVersionAwareSerializationEnabled,
+                 int maxMessageSize) {
         this.name = name;
         this.description = description;
         this.retentionTime = retentionTime;
@@ -51,6 +62,7 @@ public class Topic {
         this.contentType = contentType;
         this.jsonToAvroDryRunEnabled = jsonToAvroDryRunEnabled;
         this.schemaVersionAwareSerializationEnabled = schemaVersionAwareSerializationEnabled;
+        this.maxMessageSize = maxMessageSize;
     }
 
     @JsonCreator
@@ -63,9 +75,11 @@ public class Topic {
             @JsonProperty("trackingEnabled") boolean trackingEnabled,
             @JsonProperty("migratedFromJsonType") boolean migratedFromJsonType,
             @JsonProperty("schemaVersionAwareSerializationEnabled") boolean schemaVersionAwareSerializationEnabled,
-            @JsonProperty("contentType") ContentType contentType) {
+            @JsonProperty("contentType") ContentType contentType,
+            @JsonProperty("maxMessageSize") Integer maxMessageSize) {
         this(TopicName.fromQualifiedName(qualifiedName), description, retentionTime, migratedFromJsonType, ack,
-                trackingEnabled, contentType, jsonToAvroDryRunEnabled, schemaVersionAwareSerializationEnabled);
+                trackingEnabled, contentType, jsonToAvroDryRunEnabled, schemaVersionAwareSerializationEnabled,
+                maxMessageSize == null ? DEFAULT_MAX_MESSAGE_SIZE : maxMessageSize);
     }
 
     public RetentionTime getRetentionTime() {
@@ -150,5 +164,9 @@ public class Topic {
 
     public boolean isSchemaVersionAwareSerializationEnabled() {
         return schemaVersionAwareSerializationEnabled;
+    }
+
+    public int getMaxMessageSize() {
+        return maxMessageSize;
     }
 }

--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/common/config/ConfigFactory.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/common/config/ConfigFactory.java
@@ -40,4 +40,5 @@ public class ConfigFactory {
     private String getProperty(Configs opt) {
         return propertyFactory.getContextualProperty(opt.getName(), opt.getDefaultValue()).getValue().toString();
     }
+
 }

--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/common/config/Configs.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/common/config/Configs.java
@@ -1,6 +1,7 @@
 package pl.allegro.tech.hermes.common.config;
 
 import com.google.common.io.Files;
+import pl.allegro.tech.hermes.api.Topic;
 import pl.allegro.tech.hermes.common.util.InetAddressHostnameResolver;
 
 import static java.lang.Math.abs;
@@ -38,7 +39,9 @@ public enum Configs {
     KAFKA_CONSUMER_SESSION_TIMEOUT_MS_CONFIG("kafka.consumer.session.timeout.ms", 200_000),
     KAFKA_CONSUMER_HEARTBEAT_INTERVAL_MS_CONFIG("kafka.consumer.heartbeat.interval.ms", 3000),
     KAFKA_CONSUMER_METADATA_MAX_AGE_CONFIG("kafka.consumer.metadata.max.age.ms", 5 * 60 * 1000),
-    KAFKA_CONSUMER_MAX_PARTITION_FETCH_BYTES_CONFIG("kafka.consumer.max.partition.fetch.bytes", 10 * 1024 * 1024),
+    KAFKA_CONSUMER_MAX_PARTITION_FETCH_MIN_BYTES_CONFIG("kafka.consumer.max.partition.fetch.min", Topic.MIN_MESSAGE_SIZE),
+    KAFKA_CONSUMER_MAX_PARTITION_FETCH_MAX_BYTES_CONFIG("kafka.consumer.max.partition.fetch.max", Topic.MAX_MESSAGE_SIZE),
+
     KAFKA_CONSUMER_SEND_BUFFER_CONFIG("kafka.consumer.send.buffer.bytes", 256 * 1024),
     KAFKA_CONSUMER_RECEIVE_BUFFER_CONFIG("kafka.consumer.receive.buffer.bytes", 256 * 1024),
     KAFKA_CONSUMER_FETCH_MIN_BYTES_CONFIG("kafka.consumer.fetch.min.bytes", 1),
@@ -50,7 +53,7 @@ public enum Configs {
     KAFKA_CONSUMER_METRICS_NUM_SAMPLES_CONFIG("kafka.consumer.metrics.num.samples", 2),
     KAFKA_CONSUMER_REQUEST_TIMEOUT_MS_CONFIG("kafka.consumer.request.timeout.ms", 250_000),
     KAFKA_CONSUMER_CONNECTIONS_MAX_IDLE_MS_CONFIG("kafka.consumer.connections.max.idle.ms", 9 * 60 * 1000),
-    KAFKA_CONSUMER_MAX_POLL_RECORDS_CONFIG("kafka.consumer.max.poll.records", 10),
+    KAFKA_CONSUMER_MAX_POLL_RECORDS_CONFIG("kafka.consumer.max.poll.records", 1),
 
     KAFKA_SIMPLE_CONSUMER_TIMEOUT_MS("kafka.simple.consumer.timeout.ms", 5000),
     KAFKA_SIMPLE_CONSUMER_BUFFER_SIZE("kafka.simple.consumer.buffer.size", 64 * 1024),
@@ -98,6 +101,7 @@ public enum Configs {
     FRONTEND_GRACEFUL_SHUTDOWN_ENABLED("frontend.graceful.shutdown.enabled", true),
     FRONTEND_GRACEFUL_SHUTDOWN_INITIAL_WAIT_MS("frontend.graceful.shutdown.initial.wait.ms", 10000),
     FRONTEND_HTTP2_ENABLED("frontend.http2.enabled", false),
+    FRONTEND_FORCE_TOPIC_MAX_MESSAGE_SIZE("frontend.force.topic.max.message.size", false),
 
     FRONTEND_SSL_ENABLED("frontend.ssl.enabled", false),
     FRONTEND_SSL_PORT("frontend.ssl.port", 8443),
@@ -165,6 +169,8 @@ public enum Configs {
     CONSUMER_BACKGROUND_SUPERVISOR_KILL_AFTER("consumer.supervisor.background.kill.after", 300_000),
     CONSUMER_SIGNAL_PROCESSING_INTERVAL("consumer.supervisor.signal.processing.interval.ms", 5_000),
     CONSUMER_SIGNAL_PROCESSING_QUEUE_SIZE("consumer.supervisor.signal.queue.size", 5_000),
+
+    CONSUMER_USE_TOPIC_MESSAGE_SIZE("consumer.use.topic.message.size", false),
 
     CONSUMER_CLIENT_ID("consumer.clientId", new InetAddressHostnameResolver().resolve()),
 

--- a/hermes-console/static/index.html
+++ b/hermes-console/static/index.html
@@ -32,6 +32,7 @@
         <script src="js/directives/endpoint.js"></script>
         <script src="js/directives/hoverDelay.js"></script>
         <script src="js/directives/emptyToNull.js"></script>
+        <script src="js/filters/readableSize.js"></script>
         <script src="js/console/Discovery.js"></script>
         <script src="js/console/Home.js"></script>
         <script src="js/console/PasswordService.js"></script>

--- a/hermes-console/static/js/console/topic/TopicController.js
+++ b/hermes-console/static/js/console/topic/TopicController.js
@@ -5,7 +5,8 @@ var topics = angular.module('hermes.topic', [
     'hermes.topic.repository',
     'hermes.topic.metrics',
     'hermes.topic.factory',
-    'hermes.services'
+    'hermes.services',
+    'hermes.filters'
 ]);
 
 topics.controller('TopicController', ['TOPIC_CONFIG', 'TopicRepository', 'TopicMetrics', '$scope', '$location', '$stateParams', '$uibModal',

--- a/hermes-console/static/js/console/topic/TopicFactory.js
+++ b/hermes-console/static/js/console/topic/TopicFactory.js
@@ -4,7 +4,7 @@ topics.factory('TopicFactory', ['TOPIC_CONFIG',
     function(topicConfig) {
         return {
             create: function() {
-                var defaults = {retentionTime: {duration: 1}, contentType: 'JSON', ack: 'LEADER'};
+                var defaults = {retentionTime: {duration: 1}, contentType: 'JSON', ack: 'LEADER', maxMessageSize: 10240};
                 _.merge(defaults, topicConfig.defaults);
 
                 return defaults;

--- a/hermes-console/static/js/filters/readableSize.js
+++ b/hermes-console/static/js/filters/readableSize.js
@@ -1,0 +1,11 @@
+var filters = angular.module('hermes.filters', []);
+
+filters.filter('readableSize', function () {
+    return function (size) {
+        if (size) {
+            var i = Math.floor(Math.log(size)/Math.log(1024));
+            return (size / Math.pow(1024, i)).toFixed(2) * 1 + ' ' + ['B', 'kB', 'MB', 'GB', 'TB'][i];
+        }
+        return ""
+    }
+});

--- a/hermes-console/static/partials/modal/editTopic.html
+++ b/hermes-console/static/partials/modal/editTopic.html
@@ -57,6 +57,15 @@
                     </select>
                 </div>
             </div>
+            <div class="form-group {{topicForm.topicMaxMessageSize.$valid ? '' : 'has-error'}}">
+                <label for="topicMaxMessageSize" class="col-md-3 control-label">Max message size</label>
+                <div class="col-md-9">
+                    <div class="input-group">
+                        <input type="number" required class="form-control" id="topicMaxMessageSize" name="topicMaxMessageSize" ng-model="topic.maxMessageSize" placeholder="what is the message size limit for this topic?"/>
+                        <span class="input-group-addon">bytes</span>
+                    </div>
+                </div>
+            </div>
             <div class="form-group {{topicForm.messageSchema.$valid ? '' : 'has-error'}}" ng-show="topic.contentType === 'AVRO'">
                 <label for="messageSchema" class="col-md-3 control-label">
                     <a href="http://hermes-pubsub.rtfd.org/en/latest/user/publishing-avro/" target="_blank">AVRO schema</a>

--- a/hermes-console/static/partials/topic.html
+++ b/hermes-console/static/partials/topic.html
@@ -55,6 +55,7 @@
                         <span uib-popover='For how many days message is available for subscribers after being published.' popover-trigger="mouseenter" class="fa helpme pull-right">&#xf128;</span>
                     </p>
                     <p><strong>Tracking enabled:</strong> {{topic.trackingEnabled}}</p>
+                    <p><strong>Max message size:</strong> {{topic.maxMessageSize | readableSize}}</p>
                 </div>
             </div>
         </div>

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/receiver/kafka/KafkaMessageReceiverFactory.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/receiver/kafka/KafkaMessageReceiverFactory.java
@@ -15,7 +15,6 @@ import pl.allegro.tech.hermes.consumers.consumer.offset.OffsetQueue;
 import pl.allegro.tech.hermes.consumers.consumer.rate.ConsumerRateLimiter;
 import pl.allegro.tech.hermes.consumers.consumer.receiver.MessageReceiver;
 import pl.allegro.tech.hermes.consumers.consumer.receiver.ReceiverFactory;
-import pl.allegro.tech.hermes.schema.SchemaRepository;
 import pl.allegro.tech.hermes.tracker.consumers.Trackers;
 
 import javax.inject.Inject;
@@ -32,7 +31,6 @@ public class KafkaMessageReceiverFactory implements ReceiverFactory {
     private OffsetQueue offsetQueue;
     private final Clock clock;
     private final KafkaNamesMapper kafkaNamesMapper;
-    private final SchemaRepository schemaRepository;
     private final FilterChainFactory filterChainFactory;
     private final Trackers trackers;
 
@@ -43,7 +41,6 @@ public class KafkaMessageReceiverFactory implements ReceiverFactory {
                                        OffsetQueue offsetQueue,
                                        Clock clock,
                                        KafkaNamesMapper kafkaNamesMapper,
-                                       SchemaRepository schemaRepository,
                                        FilterChainFactory filterChainFactory,
                                        Trackers trackers) {
         this.configs = configs;
@@ -52,7 +49,6 @@ public class KafkaMessageReceiverFactory implements ReceiverFactory {
         this.offsetQueue = offsetQueue;
         this.clock = clock;
         this.kafkaNamesMapper = kafkaNamesMapper;
-        this.schemaRepository = schemaRepository;
         this.filterChainFactory = filterChainFactory;
         this.trackers = trackers;
     }
@@ -63,10 +59,9 @@ public class KafkaMessageReceiverFactory implements ReceiverFactory {
                                                  ConsumerRateLimiter consumerRateLimiter) {
 
         MessageReceiver receiver = new KafkaSingleThreadedMessageReceiver(
-                createKafkaConsumer(kafkaNamesMapper.toConsumerGroupId(subscription.getQualifiedName())),
+                createKafkaConsumer(topic, subscription),
                 messageContentWrapper,
                 hermesMetrics,
-                schemaRepository,
                 kafkaNamesMapper,
                 topic,
                 subscription,
@@ -85,7 +80,8 @@ public class KafkaMessageReceiverFactory implements ReceiverFactory {
         return receiver;
     }
 
-    private KafkaConsumer<byte[], byte[]> createKafkaConsumer(ConsumerGroupId groupId) {
+    private KafkaConsumer<byte[], byte[]> createKafkaConsumer(Topic topic, Subscription subscription) {
+        ConsumerGroupId groupId = kafkaNamesMapper.toConsumerGroupId(subscription.getQualifiedName());
         Properties props = new Properties();
         props.put(GROUP_ID_CONFIG, groupId.asString());
         props.put(ENABLE_AUTO_COMMIT_CONFIG, "false");
@@ -98,7 +94,7 @@ public class KafkaMessageReceiverFactory implements ReceiverFactory {
         props.put(SESSION_TIMEOUT_MS_CONFIG, configs.getIntProperty(Configs.KAFKA_CONSUMER_SESSION_TIMEOUT_MS_CONFIG));
         props.put(HEARTBEAT_INTERVAL_MS_CONFIG, configs.getIntProperty(Configs.KAFKA_CONSUMER_HEARTBEAT_INTERVAL_MS_CONFIG));
         props.put(METADATA_MAX_AGE_CONFIG, configs.getIntProperty(Configs.KAFKA_CONSUMER_METADATA_MAX_AGE_CONFIG));
-        props.put(MAX_PARTITION_FETCH_BYTES_CONFIG, configs.getIntProperty(Configs.KAFKA_CONSUMER_MAX_PARTITION_FETCH_BYTES_CONFIG));
+        props.put(MAX_PARTITION_FETCH_BYTES_CONFIG, getMaxPartitionFetch(topic, configs));
         props.put(SEND_BUFFER_CONFIG, configs.getIntProperty(Configs.KAFKA_CONSUMER_SEND_BUFFER_CONFIG));
         props.put(RECEIVE_BUFFER_CONFIG, configs.getIntProperty(Configs.KAFKA_CONSUMER_RECEIVE_BUFFER_CONFIG));
         props.put(FETCH_MIN_BYTES_CONFIG, configs.getIntProperty(Configs.KAFKA_CONSUMER_FETCH_MIN_BYTES_CONFIG));
@@ -111,6 +107,17 @@ public class KafkaMessageReceiverFactory implements ReceiverFactory {
         props.put(REQUEST_TIMEOUT_MS_CONFIG, configs.getIntProperty(Configs.KAFKA_CONSUMER_REQUEST_TIMEOUT_MS_CONFIG));
         props.put(CONNECTIONS_MAX_IDLE_MS_CONFIG, configs.getIntProperty(Configs.KAFKA_CONSUMER_CONNECTIONS_MAX_IDLE_MS_CONFIG));
         props.put(MAX_POLL_RECORDS_CONFIG, configs.getIntProperty(Configs.KAFKA_CONSUMER_MAX_POLL_RECORDS_CONFIG));
-        return new KafkaConsumer<byte[], byte[]>(props);
+        return new KafkaConsumer<>(props);
+    }
+
+    private int getMaxPartitionFetch(Topic topic, ConfigFactory configs) {
+        if (configs.getBooleanProperty(Configs.CONSUMER_USE_TOPIC_MESSAGE_SIZE)) {
+            int topicMessageSize = topic.getMaxMessageSize();
+            int min = configs.getIntProperty(Configs.KAFKA_CONSUMER_MAX_PARTITION_FETCH_MIN_BYTES_CONFIG);
+            int max = configs.getIntProperty(Configs.KAFKA_CONSUMER_MAX_PARTITION_FETCH_MAX_BYTES_CONFIG);
+            return Math.max(Math.min(topicMessageSize, max), min);
+        } else {
+            return configs.getIntProperty(Configs.KAFKA_CONSUMER_MAX_PARTITION_FETCH_MAX_BYTES_CONFIG);
+        }
     }
 }

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/receiver/kafka/KafkaSingleThreadedMessageReceiver.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/receiver/kafka/KafkaSingleThreadedMessageReceiver.java
@@ -41,7 +41,6 @@ public class KafkaSingleThreadedMessageReceiver implements MessageReceiver {
 
     private KafkaConsumer<byte[], byte[]> consumer;
     private final MessageContentWrapper messageContentWrapper;
-    private final SchemaRepository schemaRepository;
     private final Clock clock;
 
     private final BlockingQueue<Message> readQueue;
@@ -57,7 +56,6 @@ public class KafkaSingleThreadedMessageReceiver implements MessageReceiver {
     public KafkaSingleThreadedMessageReceiver(KafkaConsumer<byte[], byte[]> consumer,
                                               MessageContentWrapper messageContentWrapper,
                                               HermesMetrics metrics,
-                                              SchemaRepository schemaRepository,
                                               KafkaNamesMapper kafkaNamesMapper,
                                               Topic topic,
                                               Subscription subscription,
@@ -72,7 +70,6 @@ public class KafkaSingleThreadedMessageReceiver implements MessageReceiver {
                 .collect(Collectors.toMap(t -> t.name().asString(), Function.identity()));
         this.consumer = consumer;
         this.messageContentWrapper = messageContentWrapper;
-        this.schemaRepository = schemaRepository;
         this.clock = clock;
         this.readQueue = new ArrayBlockingQueue<Message>(readQueueCapacity);
         this.consumer.subscribe(topics.keySet());

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/ConsumerFactory.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/ConsumerFactory.java
@@ -84,7 +84,8 @@ public class ConsumerFactory {
                     hermesMetrics,
                     trackers,
                     subscription,
-                    topic);
+                    topic,
+                    configFactory);
         } else {
             SerialConsumerRateLimiter consumerRateLimiter = new SerialConsumerRateLimiter(subscription, outputRateCalculator, hermesMetrics,
                     consumerRateLimitSupervisor);

--- a/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/publishing/handlers/ContentLengthChecker.java
+++ b/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/publishing/handlers/ContentLengthChecker.java
@@ -4,29 +4,57 @@ import io.undertow.server.HttpServerExchange;
 import io.undertow.util.HeaderMap;
 import io.undertow.util.HeaderValues;
 import io.undertow.util.Headers;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import pl.allegro.tech.hermes.common.config.ConfigFactory;
+import pl.allegro.tech.hermes.common.config.Configs;
 
 import java.io.IOException;
 
 import static java.lang.String.format;
 
 final class ContentLengthChecker {
+    private static final Logger logger = LoggerFactory.getLogger(ContentLengthChecker.class);
 
-    static void checkContentLength(HttpServerExchange exchange, int contentLength) throws InvalidContentLengthException {
+    private boolean forceMaxMessageSizePerTopic;
+
+    ContentLengthChecker(ConfigFactory configs) {
+        this.forceMaxMessageSizePerTopic = configs.getBooleanProperty(Configs.FRONTEND_FORCE_TOPIC_MAX_MESSAGE_SIZE);
+    }
+
+    void check(HttpServerExchange exchange, int contentLength, AttachmentContent attachment)
+            throws InvalidContentLengthException, ContentTooLargeException {
+
+        int max = attachment.getCachedTopic().getTopic().getMaxMessageSize();
         long expected = exchange.getRequestContentLength();
         if (expected != contentLength && !isChunked(exchange.getRequestHeaders(), expected)) {
             throw new InvalidContentLengthException(expected, contentLength);
+        } else if (contentLength > max) {
+            if (forceMaxMessageSizePerTopic) {
+                throw new ContentTooLargeException(contentLength, max);
+            } else {
+                logger.warn("Content-Length is larger than max on this topic [length:{}, max:{}, topic: {}]",
+                                           contentLength, max, attachment.getCachedTopic().getQualifiedName());
+            }
         }
     }
 
     private static boolean isChunked(HeaderMap headerMap, long requestContentLength) {
         HeaderValues headerValue = headerMap.get(Headers.TRANSFER_ENCODING);
-        return headerValue == null ? false : "chunked".equals(headerValue.getFirst()) && requestContentLength < 0;
+        return headerValue != null && ("chunked".equals(headerValue.getFirst()) && requestContentLength < 0);
     }
 
     public static final class InvalidContentLengthException extends IOException {
         InvalidContentLengthException(long expected, int contentLength) {
             super(format("Content-Length does not match the header [header:%s, actual:%s].",
                     expected, contentLength));
+        }
+    }
+
+    public static final class ContentTooLargeException extends IOException {
+        ContentTooLargeException(long contentLength, int max) {
+            super(format("Content-Length is larger than max on this topic [length:%s, max:%s].",
+                    contentLength, max));
         }
     }
 }

--- a/hermes-test-helper/src/main/java/pl/allegro/tech/hermes/test/helper/builder/TopicBuilder.java
+++ b/hermes-test-helper/src/main/java/pl/allegro/tech/hermes/test/helper/builder/TopicBuilder.java
@@ -25,6 +25,8 @@ public class TopicBuilder {
 
     private boolean schemaVersionAwareSerialization = false;
 
+    private int maxMessageSize = 1024 * 1024;
+
     private TopicBuilder(TopicName topicName) {
         this.name = topicName;
     }
@@ -44,7 +46,7 @@ public class TopicBuilder {
     public Topic build() {
         return new Topic(
                 name, description, retentionTime, migratedFromJsonType, ack, trackingEnabled, contentType,
-                jsonToAvroDryRunEnabled, schemaVersionAwareSerialization
+                jsonToAvroDryRunEnabled, schemaVersionAwareSerialization, maxMessageSize
         );
     }
 
@@ -90,6 +92,11 @@ public class TopicBuilder {
 
     public TopicBuilder withSchemaVersionAwareSerialization() {
         this.schemaVersionAwareSerialization = true;
+        return this;
+    }
+
+    public TopicBuilder withMaxMessageSize(int size) {
+        this.maxMessageSize = size;
         return this;
     }
 }

--- a/integration/src/integration/java/pl/allegro/tech/hermes/integration/PublishingTest.java
+++ b/integration/src/integration/java/pl/allegro/tech/hermes/integration/PublishingTest.java
@@ -1,5 +1,6 @@
 package pl.allegro.tech.hermes.integration;
 
+import org.apache.commons.lang.StringUtils;
 import org.glassfish.jersey.client.ClientConfig;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -30,12 +31,14 @@ import java.net.SocketTimeoutException;
 import java.util.UUID;
 
 import static javax.ws.rs.client.ClientBuilder.newClient;
+import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
 import static javax.ws.rs.core.Response.Status.CREATED;
 import static org.glassfish.jersey.client.ClientProperties.REQUEST_ENTITY_PROCESSING;
 import static org.glassfish.jersey.client.RequestEntityProcessing.CHUNKED;
 import static pl.allegro.tech.hermes.integration.helper.ClientBuilderHelper.createRequestWithTraceHeaders;
 import static pl.allegro.tech.hermes.integration.test.HermesAssertions.assertThat;
 import static pl.allegro.tech.hermes.test.helper.builder.SubscriptionBuilder.subscription;
+import static pl.allegro.tech.hermes.test.helper.builder.TopicBuilder.topic;
 
 public class PublishingTest extends IntegrationTest {
 
@@ -61,6 +64,18 @@ public class PublishingTest extends IntegrationTest {
         // then
         assertThat(response).hasStatus(CREATED);
         remoteService.waitUntilReceived();
+    }
+
+    @Test
+    public void shouldReturn4xxForTooLargeContent() {
+        // given
+        Topic topic = operations.buildTopic(topic("largeContent", "topic").withMaxMessageSize(2048).build());
+
+        // when
+        Response response = publisher.publish(topic.getQualifiedName(), StringUtils.repeat("X", 2555));
+
+        // then
+        assertThat(response).hasStatus(BAD_REQUEST);
     }
 
     @Test

--- a/integration/src/integration/java/pl/allegro/tech/hermes/integration/env/ConsumersStarter.java
+++ b/integration/src/integration/java/pl/allegro/tech/hermes/integration/env/ConsumersStarter.java
@@ -13,6 +13,7 @@ import pl.allegro.tech.hermes.test.helper.endpoint.MultiUrlEndpointAddressResolv
 import pl.allegro.tech.hermes.test.helper.environment.Starter;
 import pl.allegro.tech.hermes.tracker.mongo.consumers.MongoLogRepository;
 
+import static pl.allegro.tech.hermes.common.config.Configs.CONSUMER_USE_TOPIC_MESSAGE_SIZE;
 import static pl.allegro.tech.hermes.common.config.Configs.KAFKA_CONSUMER_AUTO_OFFSET_RESET_CONFIG;
 import static pl.allegro.tech.hermes.common.config.Configs.KAFKA_CONSUMER_HEARTBEAT_INTERVAL_MS_CONFIG;
 import static pl.allegro.tech.hermes.common.config.Configs.KAFKA_CONSUMER_MAX_POLL_RECORDS_CONFIG;
@@ -43,6 +44,7 @@ public class ConsumersStarter implements Starter<HermesConsumers> {
         configFactory.overrideProperty(KAFKA_CONSUMER_REQUEST_TIMEOUT_MS_CONFIG, 11000);
         configFactory.overrideProperty(KAFKA_CONSUMER_SESSION_TIMEOUT_MS_CONFIG, 10000);
         configFactory.overrideProperty(KAFKA_CONSUMER_HEARTBEAT_INTERVAL_MS_CONFIG, 50);
+        configFactory.overrideProperty(CONSUMER_USE_TOPIC_MESSAGE_SIZE, true);
 
         consumers = HermesConsumers.consumers()
             .withKafkaTopicsNamesMapper(

--- a/integration/src/integration/java/pl/allegro/tech/hermes/integration/env/FrontendStarter.java
+++ b/integration/src/integration/java/pl/allegro/tech/hermes/integration/env/FrontendStarter.java
@@ -37,6 +37,7 @@ public class FrontendStarter implements Starter<HermesFrontend> {
         configFactory.overrideProperty(FRONTEND_PORT, port);
         configFactory.overrideProperty(SCHEMA_REPOSITORY_TYPE, SCHEMA_REGISTRY.name());
         configFactory.overrideProperty(SCHEMA_CACHE_ENABLED, false);
+        configFactory.overrideProperty(FRONTEND_FORCE_TOPIC_MAX_MESSAGE_SIZE, true);
     }
 
     public FrontendStarter(int port, boolean sslEnabled) {

--- a/integration/src/integration/java/pl/allegro/tech/hermes/integration/management/TopicManagementTest.java
+++ b/integration/src/integration/java/pl/allegro/tech/hermes/integration/management/TopicManagementTest.java
@@ -3,14 +3,17 @@ package pl.allegro.tech.hermes.integration.management;
 import org.assertj.core.api.Assertions;
 import org.testng.annotations.Test;
 import pl.allegro.tech.hermes.api.ErrorCode;
+import pl.allegro.tech.hermes.api.Group;
 import pl.allegro.tech.hermes.api.Topic;
 import pl.allegro.tech.hermes.integration.IntegrationTest;
 import pl.allegro.tech.hermes.integration.shame.Unreliable;
+import pl.allegro.tech.hermes.test.helper.builder.TopicBuilder;
 
 import javax.ws.rs.core.Response;
 import java.util.List;
 import java.util.stream.Stream;
 
+import static javax.ws.rs.core.Response.Status.CREATED;
 import static pl.allegro.tech.hermes.api.ContentType.AVRO;
 import static pl.allegro.tech.hermes.api.ContentType.JSON;
 import static pl.allegro.tech.hermes.integration.test.HermesAssertions.assertThat;
@@ -227,5 +230,19 @@ public class TopicManagementTest extends IntegrationTest {
         // then
         assertThat(brokerOperations.topicExists(qualifiedTopicName, PRIMARY_KAFKA_CLUSTER_NAME)).isTrue();
         assertThat(brokerOperations.topicExists(qualifiedTopicName, SECONDARY_KAFKA_CLUSTER_NAME)).isFalse();
+    }
+
+    @Test
+    public void shouldCreateTopicWithMaxMessageSize() {
+        // given
+        Topic topic = TopicBuilder.topic("messageSize", "topic").withMaxMessageSize(2048).build();
+        assertThat(management.group().create(new Group(topic.getName().getGroupName(), "a", "a", "a"))).hasStatus(CREATED);
+
+        // when
+        Response response = management.topic().create(topic);
+
+        // then
+        assertThat(response).hasStatus(CREATED);
+        assertThat(management.topic().get(topic.getQualifiedName()).getMaxMessageSize()).isEqualTo(2048);
     }
 }


### PR DESCRIPTION
General idea is that configuring KafkaConsumer the same for every subscription is too inefficient memory wise. This PR introduces way to specify max message size per topic which is needed to correctly configure maxPartitionFetchBytes which basically represents how heavy the buffer is per partition for receiving messages from Kafka. Goal was not to exceed 1 mb by default per subscription.