### PR TITLE
Fixing max sleep time for zookeeper connection retries  

### DIFF
--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/common/config/Configs.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/common/config/Configs.java
@@ -12,7 +12,8 @@ public enum Configs {
 
     ZOOKEEPER_CONNECT_STRING("zookeeper.connect.string", "localhost:2181"),
     ZOOKEEPER_BASE_SLEEP_TIME("zookeeper.base.sleep.time", 1000),
-    ZOOKEEPER_MAX_SLEEP_TIME("zookeeper.max.sleep.time.seconds", 30),
+    ZOOKEEPER_MAX_SLEEP_TIME_IN_SECONDS("zookeeper.max.sleep.time.seconds", 30),
+    ZOOKEEPER_MAX_RETRIES("zookeeper.max.retries", 29),
     ZOOKEEPER_CONNECTION_TIMEOUT("zookeeper.connection.timeout", 10000),
     ZOOKEEPER_SESSION_TIMEOUT("zookeeper.session.timeout", 10000),
 
@@ -21,7 +22,6 @@ public enum Configs {
     ZOOKEEPER_AUTHORIZATION_USER("zookeeper.authorization.user", "user"),
     ZOOKEEPER_AUTHORIZATION_PASSWORD("zookeeper.authorization.password", "password"),
 
-    ZOOKEEPER_MAX_RETRIES("zookeeper.max.retries", 100),
     ZOOKEEPER_ROOT("zookeeper.root", "/hermes"),
     ZOOKEEPER_CACHE_THREAD_POOL_SIZE("zookeeper.cache.thread.pool.size", 5),
     ZOOKEEPER_TASK_PROCESSING_THREAD_POOL_SIZE("zookeeper.cache.processing.thread.pool.size", 5),

--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/common/di/factories/CuratorClientFactory.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/common/di/factories/CuratorClientFactory.java
@@ -1,16 +1,19 @@
 package pl.allegro.tech.hermes.common.di.factories;
 
+import com.google.common.primitives.Ints;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.retry.ExponentialBackoffRetry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import pl.allegro.tech.hermes.common.config.ConfigFactory;
-import pl.allegro.tech.hermes.common.config.Configs;
 import pl.allegro.tech.hermes.common.exception.InternalProcessingException;
 
 import javax.inject.Inject;
 import java.util.Optional;
+
+import static java.time.Duration.ofSeconds;
+import static pl.allegro.tech.hermes.common.config.Configs.*;
 
 public class CuratorClientFactory {
 
@@ -43,13 +46,13 @@ public class CuratorClientFactory {
     }
 
     public CuratorFramework provide(String connectString, Optional<ZookeeperAuthorization> zookeeperAuthorization) {
-        int baseSleepTime = configFactory.getIntProperty(Configs.ZOOKEEPER_BASE_SLEEP_TIME);
-        int maxRetries = configFactory.getIntProperty(Configs.ZOOKEEPER_MAX_RETRIES);
-        int maxSleepTime = configFactory.getIntProperty(Configs.ZOOKEEPER_MAX_SLEEP_TIME);
+        int baseSleepTime = configFactory.getIntProperty(ZOOKEEPER_BASE_SLEEP_TIME);
+        int maxRetries = configFactory.getIntProperty(ZOOKEEPER_MAX_RETRIES);
+        int maxSleepTime = Ints.saturatedCast(ofSeconds(configFactory.getIntProperty(ZOOKEEPER_MAX_SLEEP_TIME_IN_SECONDS)).toMillis());
         CuratorFrameworkFactory.Builder builder = CuratorFrameworkFactory.builder()
                 .connectString(connectString)
-                .sessionTimeoutMs(configFactory.getIntProperty(Configs.ZOOKEEPER_SESSION_TIMEOUT))
-                .connectionTimeoutMs(configFactory.getIntProperty(Configs.ZOOKEEPER_CONNECTION_TIMEOUT))
+                .sessionTimeoutMs(configFactory.getIntProperty(ZOOKEEPER_SESSION_TIMEOUT))
+                .connectionTimeoutMs(configFactory.getIntProperty(ZOOKEEPER_CONNECTION_TIMEOUT))
                 .retryPolicy(new ExponentialBackoffRetry(baseSleepTime, maxRetries, maxSleepTime));
 
         zookeeperAuthorization.ifPresent(it -> builder.authorization(it.scheme, it.getAuth()));


### PR DESCRIPTION
This PR adds conversion from seconds to milliseconds which was missing for max sleep time between zookeeper connection retries. Thanks this retries will be done between 30 seconds instead of 30 milliseconds.

