### PR TITLE
Selective algorithm healing

### DIFF
--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/common/config/Configs.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/common/config/Configs.java
@@ -169,6 +169,7 @@ public enum Configs {
             new InetAddressHostnameResolver().resolve().replaceAll("\\.", "_") + "$" + abs(randomUUID().getMostSignificantBits())),
     CONSUMER_WORKLOAD_MONITOR_SCAN_INTERVAL("consumer.workload.monitor.scan.interval.seconds", 120),
     CONSUMER_WORKLOAD_AUTO_REBALANCE("consumer.workload.rebalance.auto", true),
+    CONSUMER_WORKLOAD_DEAD_AFTER_SECONDS("consumer.workload.dead.after.seconds", 120),
     CONSUMER_BATCH_POOLABLE_SIZE("consumer.batch.poolable.size", 1024),
     CONSUMER_BATCH_MAX_POOL_SIZE("consumer.batch.max.pool.size", 64*1024*1024),
     CONSUMER_BATCH_CONNECTION_TIMEOUT("consumer.batch.connection.timeout", 500),

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/ConsumerFactory.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/ConsumerFactory.java
@@ -72,7 +72,7 @@ public class ConsumerFactory {
         this.consumerAuthorizationHandler = consumerAuthorizationHandler;
     }
 
-    Consumer createConsumer(Subscription subscription) {
+    public Consumer createConsumer(Subscription subscription) {
         Topic topic = topicRepository.getTopicDetails(subscription.getTopicName());
         if (subscription.isBatchSubscription()) {
             return new BatchConsumer(messageReceiverFactory,

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/monitor/ConsumersRuntimeMonitor.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/monitor/ConsumersRuntimeMonitor.java
@@ -8,6 +8,7 @@ import pl.allegro.tech.hermes.api.SubscriptionName;
 import pl.allegro.tech.hermes.common.config.ConfigFactory;
 import pl.allegro.tech.hermes.common.config.Configs;
 import pl.allegro.tech.hermes.common.metric.HermesMetrics;
+import pl.allegro.tech.hermes.consumers.subscription.cache.SubscriptionsCache;
 import pl.allegro.tech.hermes.consumers.supervisor.ConsumersSupervisor;
 import pl.allegro.tech.hermes.consumers.supervisor.workload.SupervisorController;
 
@@ -30,14 +31,17 @@ public class ConsumersRuntimeMonitor implements Runnable {
 
     private final SupervisorController workloadSupervisor;
 
+    private final SubscriptionsCache subscriptionsCache;
+
     private final MonitorMetrics monitorMetrics = new MonitorMetrics();
 
     public ConsumersRuntimeMonitor(ConsumersSupervisor consumerSupervisor,
                                    SupervisorController workloadSupervisor,
                                    HermesMetrics hermesMetrics,
-                                   ConfigFactory configFactory) {
+                                   SubscriptionsCache subscriptionsCache, ConfigFactory configFactory) {
         this.consumerSupervisor = consumerSupervisor;
         this.workloadSupervisor = workloadSupervisor;
+        this.subscriptionsCache = subscriptionsCache;
         this.scanIntervalSeconds = configFactory.getIntProperty(Configs.CONSUMER_WORKLOAD_MONITOR_SCAN_INTERVAL);
 
         hermesMetrics.registerGauge("consumers-workload.monitor.running", () -> monitorMetrics.running);
@@ -46,42 +50,59 @@ public class ConsumersRuntimeMonitor implements Runnable {
         hermesMetrics.registerGauge("consumers-workload.monitor.oversubscribed", () -> monitorMetrics.oversubscribed);
     }
 
-    public void checkCorrectness() {
-        Set<SubscriptionName> assignedSubscriptions = workloadSupervisor.assignedSubscriptions();
-        Set<SubscriptionName> runningSubscriptions = consumerSupervisor.runningConsumers();
-
-        monitorMetrics.assigned = assignedSubscriptions.size();
-        monitorMetrics.running = runningSubscriptions.size();
-
-        Set<SubscriptionName> missingSubscriptions = missing(assignedSubscriptions, runningSubscriptions);
-        monitorMetrics.missing = missingSubscriptions.size();
-        for (SubscriptionName subscriptionName : missingSubscriptions) {
+    public void log(Set<SubscriptionName> assigned,
+                    Set<SubscriptionName> running,
+                    Set<SubscriptionName> missing,
+                    Set<SubscriptionName> oversubscribed) {
+        for (SubscriptionName subscriptionName : missing) {
             logger.warn("Missing consumer process for subscription: {}", subscriptionName);
         }
 
-
-        Set<SubscriptionName> oversubscribedSubscriptions = oversubscribed(assignedSubscriptions, runningSubscriptions);
-        monitorMetrics.oversubscribed = oversubscribedSubscriptions.size();
-        for (SubscriptionName subscriptionName : oversubscribedSubscriptions) {
+        for (SubscriptionName subscriptionName : oversubscribed) {
             logger.warn("Unwanted consumer process for subscription: {}", subscriptionName);
         }
 
         logger.info(
                 "Subscriptions assigned: {}, existing subscriptions: {}, missing: {}, oversubscribed: {}",
-                assignedSubscriptions.size(),
-                runningSubscriptions.size(),
-                missingSubscriptions.size(),
-                oversubscribedSubscriptions.size()
+                assigned.size(),
+                running.size(),
+                missing.size(),
+                oversubscribed.size()
         );
     }
 
     @Override
     public void run() {
         try {
-            checkCorrectness();
+            Set<SubscriptionName> assigned = workloadSupervisor.assignedSubscriptions();
+            Set<SubscriptionName> running = consumerSupervisor.runningConsumers();
+            Set<SubscriptionName> missing = missing(assigned, running);
+            Set<SubscriptionName> oversubscribed = oversubscribed(assigned, running);
+
+            log(assigned, running, missing, oversubscribed);
+            updateMetrics(assigned, running, missing, oversubscribed);
+
+            ensureCorrectness(missing, oversubscribed);
         } catch (Exception exception) {
             logger.error("Could not check correctness of assignments", exception);
         }
+    }
+
+    private void ensureCorrectness(Set<SubscriptionName> missing, Set<SubscriptionName> oversubscribed) {
+        missing.stream()
+                .map(subscriptionsCache::getSubscription)
+                .forEach(consumerSupervisor::assignConsumerForSubscription);
+        oversubscribed.forEach(consumerSupervisor::deleteConsumerForSubscriptionName);
+    }
+
+    private void updateMetrics(Set<SubscriptionName> assigned,
+                               Set<SubscriptionName> running,
+                               Set<SubscriptionName> missing,
+                               Set<SubscriptionName> oversubscribed) {
+        monitorMetrics.assigned = assigned.size();
+        monitorMetrics.running = running.size();
+        monitorMetrics.missing = missing.size();
+        monitorMetrics.oversubscribed = oversubscribed.size();
     }
 
     private Set<SubscriptionName> missing(Set<SubscriptionName> assignedSubscriptions,

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/monitor/ConsumersRuntimeMonitor.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/monitor/ConsumersRuntimeMonitor.java
@@ -89,6 +89,9 @@ public class ConsumersRuntimeMonitor implements Runnable {
     }
 
     private void ensureCorrectness(Set<SubscriptionName> missing, Set<SubscriptionName> oversubscribed) {
+        if (!missing.isEmpty() || !oversubscribed.isEmpty()) {
+            logger.info("Fixing runtime. Creating {} and killing {} consumers", missing.size(), oversubscribed.size());
+        }
         missing.stream()
                 .map(subscriptionsCache::getSubscription)
                 .forEach(consumerSupervisor::assignConsumerForSubscription);

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/monitor/ConsumersRuntimeMonitor.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/monitor/ConsumersRuntimeMonitor.java
@@ -36,7 +36,7 @@ public class ConsumersRuntimeMonitor implements Runnable {
 
     private final MonitorMetrics monitorMetrics = new MonitorMetrics();
 
-    private ScheduledFuture job;
+    private ScheduledFuture monitoringTask;
 
     public ConsumersRuntimeMonitor(ConsumersSupervisor consumerSupervisor,
                                    SupervisorController workloadSupervisor,
@@ -71,11 +71,11 @@ public class ConsumersRuntimeMonitor implements Runnable {
     }
 
     public void start() {
-        this.job = executor.scheduleWithFixedDelay(this, scanIntervalSeconds, scanIntervalSeconds, TimeUnit.SECONDS);
+        this.monitoringTask = executor.scheduleWithFixedDelay(this, scanIntervalSeconds, scanIntervalSeconds, TimeUnit.SECONDS);
     }
 
     public void shutdown() throws InterruptedException {
-        job.cancel(false);
+        monitoringTask.cancel(false);
         executor.shutdown();
         executor.awaitTermination(1, TimeUnit.MINUTES);
     }

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/monitor/ConsumersRuntimeMonitor.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/monitor/ConsumersRuntimeMonitor.java
@@ -15,6 +15,7 @@ import pl.allegro.tech.hermes.consumers.supervisor.workload.SupervisorController
 import java.util.Set;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
 public class ConsumersRuntimeMonitor implements Runnable {
@@ -34,6 +35,8 @@ public class ConsumersRuntimeMonitor implements Runnable {
     private final SubscriptionsCache subscriptionsCache;
 
     private final MonitorMetrics monitorMetrics = new MonitorMetrics();
+
+    private ScheduledFuture job;
 
     public ConsumersRuntimeMonitor(ConsumersSupervisor consumerSupervisor,
                                    SupervisorController workloadSupervisor,
@@ -68,10 +71,11 @@ public class ConsumersRuntimeMonitor implements Runnable {
     }
 
     public void start() {
-        executor.scheduleWithFixedDelay(this, scanIntervalSeconds, scanIntervalSeconds, TimeUnit.SECONDS);
+        this.job = executor.scheduleWithFixedDelay(this, scanIntervalSeconds, scanIntervalSeconds, TimeUnit.SECONDS);
     }
 
     public void shutdown() throws InterruptedException {
+        job.cancel(false);
         executor.shutdown();
         executor.awaitTermination(1, TimeUnit.MINUTES);
     }

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/monitor/ConsumersRuntimeMonitorFactory.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/monitor/ConsumersRuntimeMonitorFactory.java
@@ -5,6 +5,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import pl.allegro.tech.hermes.common.config.ConfigFactory;
 import pl.allegro.tech.hermes.common.metric.HermesMetrics;
+import pl.allegro.tech.hermes.consumers.subscription.cache.SubscriptionsCache;
 import pl.allegro.tech.hermes.consumers.supervisor.ConsumersSupervisor;
 import pl.allegro.tech.hermes.consumers.supervisor.workload.SupervisorController;
 
@@ -21,9 +22,11 @@ public class ConsumersRuntimeMonitorFactory implements Factory<ConsumersRuntimeM
             ConsumersSupervisor consumerSupervisor,
             SupervisorController workloadSupervisor,
             HermesMetrics hermesMetrics,
+            SubscriptionsCache subscriptionsCache,
             ConfigFactory configFactory
     ) {
-        monitor = new ConsumersRuntimeMonitor(consumerSupervisor, workloadSupervisor, hermesMetrics, configFactory);
+        monitor = new ConsumersRuntimeMonitor(
+                consumerSupervisor, workloadSupervisor, hermesMetrics, subscriptionsCache, configFactory);
     }
 
     @Override

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/process/ConsumerProcessSupervisor.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/process/ConsumerProcessSupervisor.java
@@ -11,9 +11,9 @@ import pl.allegro.tech.hermes.consumers.queue.MonitoredMpscQueue;
 import pl.allegro.tech.hermes.consumers.supervisor.ConsumersExecutorService;
 
 import java.time.Clock;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
-import java.util.ArrayList;
 import java.util.concurrent.Future;
 
 public class ConsumerProcessSupervisor implements Runnable {
@@ -153,6 +153,7 @@ public class ConsumerProcessSupervisor implements Runnable {
                     logger.error("Failed to interrupt consumer process {}, possible stale consumer", subscriptionName);
                 }
             } else {
+                runningProcesses.remove(subscriptionName);
                 logger.info("Consumer was already dead process {}", subscriptionName);
             }
         }

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/process/RunningConsumerProcesses.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/process/RunningConsumerProcesses.java
@@ -1,5 +1,6 @@
 package pl.allegro.tech.hermes.consumers.supervisor.process;
 
+import com.google.common.collect.ImmutableSet;
 import pl.allegro.tech.hermes.api.SubscriptionName;
 
 import java.util.List;
@@ -40,7 +41,7 @@ class RunningConsumerProcesses {
     }
 
     Set<SubscriptionName> existingConsumers() {
-        return processes.keySet();
+        return ImmutableSet.copyOf(processes.keySet());
     }
 
     List<RunningSubscriptionStatus> listRunningSubscriptions() {

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/workload/SubscriptionAssignment.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/workload/SubscriptionAssignment.java
@@ -7,10 +7,16 @@ import java.util.Objects;
 public class SubscriptionAssignment {
     private final String consumerNodeId;
     private final SubscriptionName subscriptionName;
+    private boolean auto = true;
 
     public SubscriptionAssignment(String consumerNodeId, SubscriptionName subscriptionName) {
+        this(consumerNodeId, subscriptionName, true);
+    }
+
+    public SubscriptionAssignment(String consumerNodeId, SubscriptionName subscriptionName, boolean auto) {
         this.consumerNodeId = consumerNodeId;
         this.subscriptionName = subscriptionName;
+        this.auto = auto;
     }
 
     public String getConsumerNodeId() {
@@ -33,5 +39,9 @@ public class SubscriptionAssignment {
     @Override
     public int hashCode() {
         return Objects.hash(consumerNodeId, subscriptionName);
+    }
+
+    public boolean isAuto() {
+        return auto;
     }
 }

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/workload/SubscriptionAssignment.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/workload/SubscriptionAssignment.java
@@ -7,16 +7,16 @@ import java.util.Objects;
 public class SubscriptionAssignment {
     private final String consumerNodeId;
     private final SubscriptionName subscriptionName;
-    private boolean auto = true;
+    private boolean autoAssigned = true;
 
     public SubscriptionAssignment(String consumerNodeId, SubscriptionName subscriptionName) {
         this(consumerNodeId, subscriptionName, true);
     }
 
-    public SubscriptionAssignment(String consumerNodeId, SubscriptionName subscriptionName, boolean auto) {
+    public SubscriptionAssignment(String consumerNodeId, SubscriptionName subscriptionName, boolean autoAssigned) {
         this.consumerNodeId = consumerNodeId;
         this.subscriptionName = subscriptionName;
-        this.auto = auto;
+        this.autoAssigned = autoAssigned;
     }
 
     public String getConsumerNodeId() {
@@ -41,7 +41,7 @@ public class SubscriptionAssignment {
         return Objects.hash(consumerNodeId, subscriptionName);
     }
 
-    public boolean isAuto() {
-        return auto;
+    public boolean isAutoAssigned() {
+        return autoAssigned;
     }
 }

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/workload/SubscriptionAssignmentAware.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/workload/SubscriptionAssignmentAware.java
@@ -1,9 +1,8 @@
 package pl.allegro.tech.hermes.consumers.supervisor.workload;
 
-import pl.allegro.tech.hermes.api.Subscription;
 import pl.allegro.tech.hermes.api.SubscriptionName;
 
 public interface SubscriptionAssignmentAware {
-    default void onSubscriptionAssigned(Subscription subscription) {}
+    default void onSubscriptionAssigned(SubscriptionName subscriptionName) {}
     default void onAssignmentRemoved(SubscriptionName subscriptionName) {}
 }

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/workload/SubscriptionAssignmentPathSerializer.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/workload/SubscriptionAssignmentPathSerializer.java
@@ -3,14 +3,18 @@ package pl.allegro.tech.hermes.consumers.supervisor.workload;
 import com.google.common.base.Joiner;
 import pl.allegro.tech.hermes.api.SubscriptionName;
 
+import java.util.Arrays;
+
 import static com.google.common.base.Preconditions.checkArgument;
 
 public class SubscriptionAssignmentPathSerializer {
 
     private final String prefix;
+    private final byte[] autoMarker;
 
-    public SubscriptionAssignmentPathSerializer(String prefix) {
+    public SubscriptionAssignmentPathSerializer(String prefix, byte[] autoMarker) {
         this.prefix = prefix;
+        this.autoMarker = autoMarker;
     }
 
     public String serialize(SubscriptionName subscriptionName, String supervisorId) {
@@ -21,9 +25,12 @@ public class SubscriptionAssignmentPathSerializer {
         return Joiner.on("/").join(prefix, subscriptionName);
     }
 
-    public SubscriptionAssignment deserialize(String path) {
+    public SubscriptionAssignment deserialize(String path, byte[] data) {
         String[] paths = path.split("/");
         checkArgument(paths.length > 1, "Incorrect path format. Expected:'/base/subscription/supervisorId'. Found:'%s'", path);
-        return new SubscriptionAssignment(paths[paths.length - 1], SubscriptionName.fromString(paths[paths.length - 2]));
+        boolean auto = data != null && Arrays.equals(data, autoMarker);
+        return new SubscriptionAssignment(paths[paths.length - 1],
+                SubscriptionName.fromString(paths[paths.length - 2]),
+                auto);
     }
 }

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/workload/SubscriptionAssignmentPathSerializer.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/workload/SubscriptionAssignmentPathSerializer.java
@@ -10,11 +10,11 @@ import static com.google.common.base.Preconditions.checkArgument;
 public class SubscriptionAssignmentPathSerializer {
 
     private final String prefix;
-    private final byte[] autoMarker;
+    private final byte[] autoAssignedMarker;
 
-    public SubscriptionAssignmentPathSerializer(String prefix, byte[] autoMarker) {
+    public SubscriptionAssignmentPathSerializer(String prefix, byte[] autoAssignedMarker) {
         this.prefix = prefix;
-        this.autoMarker = autoMarker;
+        this.autoAssignedMarker = Arrays.copyOf(autoAssignedMarker, autoAssignedMarker.length);
     }
 
     public String serialize(SubscriptionName subscriptionName, String supervisorId) {
@@ -28,9 +28,9 @@ public class SubscriptionAssignmentPathSerializer {
     public SubscriptionAssignment deserialize(String path, byte[] data) {
         String[] paths = path.split("/");
         checkArgument(paths.length > 1, "Incorrect path format. Expected:'/base/subscription/supervisorId'. Found:'%s'", path);
-        boolean auto = data != null && Arrays.equals(data, autoMarker);
+        boolean autoAssigned = data != null && Arrays.equals(data, autoAssignedMarker);
         return new SubscriptionAssignment(paths[paths.length - 1],
                 SubscriptionName.fromString(paths[paths.length - 2]),
-                auto);
+                autoAssigned);
     }
 }

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/workload/SubscriptionAssignmentRegistry.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/workload/SubscriptionAssignmentRegistry.java
@@ -111,7 +111,7 @@ public class SubscriptionAssignmentRegistry {
         assignments.add(assignment);
         if (consumerNodeId.equals(assignment.getConsumerNodeId())) {
             callbacks.forEach(callback ->
-                callback.onSubscriptionAssigned(subscriptionsCache.getSubscription(assignment.getSubscriptionName()))
+                callback.onSubscriptionAssigned(assignment.getSubscriptionName())
             );
         }
     }

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/workload/SubscriptionAssignmentRegistry.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/workload/SubscriptionAssignmentRegistry.java
@@ -3,6 +3,8 @@ package pl.allegro.tech.hermes.consumers.supervisor.workload;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.KeeperException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import pl.allegro.tech.hermes.api.SubscriptionName;
 import pl.allegro.tech.hermes.common.exception.InternalProcessingException;
 import pl.allegro.tech.hermes.consumers.subscription.cache.SubscriptionsCache;
@@ -17,13 +19,14 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
-import java.util.stream.Collectors;
 
 public class SubscriptionAssignmentRegistry {
 
     private static final int SUBSCRIPTION_LEVEL = 0;
 
     private static final int ASSIGNMENT_LEVEL = 1;
+
+    private static final Logger logger = LoggerFactory.getLogger(SubscriptionAssignmentRegistry.class);
 
     private final Set<SubscriptionAssignment> assignments = Collections.newSetFromMap(new ConcurrentHashMap<>());
 
@@ -103,7 +106,7 @@ public class SubscriptionAssignmentRegistry {
                 List<String> nodes = curator.getChildren().forPath(path);
                 nodes.forEach(node -> assignments.add(new SubscriptionAssignment(node, subscriptionName)));
             } catch (Exception e) {
-                // ignore - should be fixed by the cache
+                logger.info("Exception occurred when initializing cache with subscription {}", subscriptionName, e);
             }
         }
         return assignments;

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/workload/SubscriptionAssignmentRegistry.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/workload/SubscriptionAssignmentRegistry.java
@@ -32,8 +32,6 @@ public class SubscriptionAssignmentRegistry {
 
     private final Set<SubscriptionAssignmentAware> callbacks = Collections.newSetFromMap(new ConcurrentHashMap<>());
 
-    private final Set<Runnable> postInitializationListeners = Collections.newSetFromMap(new ConcurrentHashMap<>());
-
     private final String consumerNodeId;
 
     private final CuratorFramework curator;
@@ -72,13 +70,13 @@ public class SubscriptionAssignmentRegistry {
 
     public void start() throws Exception {
         logger.info("Starting assignment registry");
+
         List<SubscriptionAssignment> currentAssignments = readExistingAssignments();
         currentAssignments.forEach(this::onAssignmentAdded);
-        logger.info("Initialized registry with {} assignments", currentAssignments.size());
-        logger.info("Starting assignment cache");
+
         cache.start();
-        logger.info("Assignment cache started");
-        postInitializationListeners.forEach(Runnable::run);
+
+        logger.info("Started assignment registry. Read {} assignments", currentAssignments.size());
     }
 
     public void stop() throws Exception {
@@ -87,10 +85,6 @@ public class SubscriptionAssignmentRegistry {
 
     public void registerAssignmentCallback(SubscriptionAssignmentAware callback) {
         callbacks.add(callback);
-    }
-
-    public void registerPostInitializationListener(Runnable task) {
-        postInitializationListeners.add(task);
     }
 
     public boolean isAssignedTo(String nodeId, SubscriptionName subscription) {

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/workload/SubscriptionAssignmentRegistryFactory.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/workload/SubscriptionAssignmentRegistryFactory.java
@@ -2,7 +2,6 @@ package pl.allegro.tech.hermes.consumers.supervisor.workload;
 
 import org.apache.curator.framework.CuratorFramework;
 import org.glassfish.hk2.api.Factory;
-import org.glassfish.hk2.api.IterableProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import pl.allegro.tech.hermes.common.config.ConfigFactory;

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/workload/SubscriptionAssignmentRegistryFactory.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/workload/SubscriptionAssignmentRegistryFactory.java
@@ -38,11 +38,15 @@ public class SubscriptionAssignmentRegistryFactory implements Factory<Subscripti
 
     @Override
     public SubscriptionAssignmentRegistry provide() {
+        return provide(configFactory.getStringProperty(CONSUMER_WORKLOAD_NODE_ID));
+    }
+
+    public SubscriptionAssignmentRegistry provide(String consumerId) {
         ZookeeperPaths paths = new ZookeeperPaths(configFactory.getStringProperty(Configs.ZOOKEEPER_ROOT));
         String cluster = configFactory.getStringProperty(KAFKA_CLUSTER_NAME);
 
         SubscriptionAssignmentRegistry registry = new SubscriptionAssignmentRegistry(
-                configFactory.getStringProperty(CONSUMER_WORKLOAD_NODE_ID),
+                consumerId,
                 curatorClient,
                 paths.consumersRuntimePath(cluster),
                 cache,

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/workload/SubscriptionAssignmentRegistryFactory.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/workload/SubscriptionAssignmentRegistryFactory.java
@@ -48,8 +48,7 @@ public class SubscriptionAssignmentRegistryFactory implements Factory<Subscripti
                 consumerId,
                 curatorClient,
                 paths.consumersRuntimePath(cluster),
-                cache,
-                new SubscriptionAssignmentPathSerializer(paths.consumersRuntimePath(cluster))
+                cache
         );
 
         return registry;

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/workload/SubscriptionAssignmentView.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/workload/SubscriptionAssignmentView.java
@@ -95,6 +95,9 @@ public class SubscriptionAssignmentView {
 
     private void addAssignment(SubscriptionAssignment assignment) {
         subscriptionAssignments.get(assignment.getSubscriptionName()).add(assignment);
+        if (!consumerNodeAssignments.containsKey(assignment.getConsumerNodeId())) {
+            addConsumerNode(assignment.getConsumerNodeId());
+        }
         consumerNodeAssignments.get(assignment.getConsumerNodeId()).add(assignment);
     }
 
@@ -163,6 +166,7 @@ public class SubscriptionAssignmentView {
         void addSubscription(SubscriptionName subscriptionName);
         void addConsumerNode(String nodeId);
         void addAssignment(SubscriptionAssignment assignment);
+        void removeAssignment(SubscriptionAssignment assignment);
         void transferAssignment(String from, String to, SubscriptionName subscriptionName);
     }
 
@@ -192,6 +196,11 @@ public class SubscriptionAssignmentView {
             @Override
             public void addAssignment(SubscriptionAssignment assignment) {
                 view.addAssignment(assignment);
+            }
+
+            @Override
+            public void removeAssignment(SubscriptionAssignment assignment) {
+                view.removeAssignment(assignment);
             }
 
             @Override

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/workload/SupervisorControllerFactory.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/workload/SupervisorControllerFactory.java
@@ -32,6 +32,7 @@ import static java.util.concurrent.Executors.newFixedThreadPool;
 import static java.util.concurrent.Executors.newSingleThreadExecutor;
 import static pl.allegro.tech.hermes.common.config.Configs.CONSUMER_WORKLOAD_ALGORITHM;
 import static pl.allegro.tech.hermes.common.config.Configs.CONSUMER_WORKLOAD_ASSIGNMENT_PROCESSING_THREAD_POOL_SIZE;
+import static pl.allegro.tech.hermes.common.config.Configs.CONSUMER_WORKLOAD_DEAD_AFTER_SECONDS;
 import static pl.allegro.tech.hermes.consumers.supervisor.workload.ConsumerWorkloadAlgorithm.MIRROR;
 import static pl.allegro.tech.hermes.consumers.supervisor.workload.ConsumerWorkloadAlgorithm.SELECTIVE;
 
@@ -69,10 +70,13 @@ public class SupervisorControllerFactory implements Factory<SupervisorController
     }
 
     private static ConsumerNodesRegistry createConsumersRegistry(ConfigFactory configs, CuratorFramework curator) {
+        ThreadFactory threadFactory = new ThreadFactoryBuilder()
+                .setNameFormat("ConsumerRegistryExecutor-%d").build();
         return new ConsumerNodesRegistry(curator,
-                newSingleThreadExecutor(),
+                newSingleThreadExecutor(threadFactory),
                 new ZookeeperPaths(configs.getStringProperty(Configs.ZOOKEEPER_ROOT)).consumersRegistryPath(configs.getStringProperty(Configs.KAFKA_CLUSTER_NAME)),
-                configs.getStringProperty(Configs.CONSUMER_WORKLOAD_NODE_ID));
+                configs.getStringProperty(Configs.CONSUMER_WORKLOAD_NODE_ID),
+                configs.getIntProperty(CONSUMER_WORKLOAD_DEAD_AFTER_SECONDS));
     }
 
     @Override

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/workload/SupervisorControllerFactory.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/workload/SupervisorControllerFactory.java
@@ -23,6 +23,7 @@ import pl.allegro.tech.hermes.infrastructure.zookeeper.ZookeeperPaths;
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Provider;
+import java.time.Clock;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ThreadFactory;
@@ -51,12 +52,13 @@ public class SupervisorControllerFactory implements Factory<SupervisorController
                                        ConsumersSupervisor supervisor,
                                        ZookeeperAdminCache adminCache,
                                        HermesMetrics metrics,
-                                       ConfigFactory configs) {
+                                       ConfigFactory configs,
+                                       Clock clock) {
         this.configs = configs;
         this.availableImplementations = ImmutableMap.of(
                 MIRROR, () -> new MirroringSupervisorController(supervisor, notificationsBus, assignmentRegistry, subscriptionsCache, workTracker, adminCache, configs),
                 SELECTIVE, () -> new SelectiveSupervisorController(supervisor, notificationsBus, subscriptionsCache, assignmentRegistry, workTracker,
-                        createConsumersRegistry(configs, curator), adminCache,
+                        createConsumersRegistry(configs, curator, clock), adminCache,
                         getAssignmentExecutor(configs),
                         configs, metrics));
     }
@@ -69,14 +71,15 @@ public class SupervisorControllerFactory implements Factory<SupervisorController
         return newFixedThreadPool(configs.getIntProperty(CONSUMER_WORKLOAD_ASSIGNMENT_PROCESSING_THREAD_POOL_SIZE), threadFactory);
     }
 
-    private static ConsumerNodesRegistry createConsumersRegistry(ConfigFactory configs, CuratorFramework curator) {
+    private static ConsumerNodesRegistry createConsumersRegistry(ConfigFactory configs, CuratorFramework curator, Clock clock) {
         ThreadFactory threadFactory = new ThreadFactoryBuilder()
                 .setNameFormat("ConsumerRegistryExecutor-%d").build();
         return new ConsumerNodesRegistry(curator,
                 newSingleThreadExecutor(threadFactory),
                 new ZookeeperPaths(configs.getStringProperty(Configs.ZOOKEEPER_ROOT)).consumersRegistryPath(configs.getStringProperty(Configs.KAFKA_CLUSTER_NAME)),
                 configs.getStringProperty(Configs.CONSUMER_WORKLOAD_NODE_ID),
-                configs.getIntProperty(CONSUMER_WORKLOAD_DEAD_AFTER_SECONDS));
+                configs.getIntProperty(CONSUMER_WORKLOAD_DEAD_AFTER_SECONDS),
+                clock);
     }
 
     @Override

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/workload/WorkTracker.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/workload/WorkTracker.java
@@ -33,11 +33,10 @@ public class WorkTracker {
         ));
     }
 
-    public WorkDistributionChanges apply(SubscriptionAssignmentView targetView) {
-        SubscriptionAssignmentView currentView = getAssignments();
-
-        List<SubscriptionAssignment> assignmentDeletions = currentView.deletions(targetView).getAllAssignments();
-        List<SubscriptionAssignment> assignmentAdditions = currentView.additions(targetView).getAllAssignments();
+    public WorkDistributionChanges apply(SubscriptionAssignmentView initialState,
+                                         SubscriptionAssignmentView targetView) {
+        List<SubscriptionAssignment> assignmentDeletions = initialState.deletions(targetView).getAllAssignments();
+        List<SubscriptionAssignment> assignmentAdditions = initialState.additions(targetView).getAllAssignments();
 
         assignmentDeletions.forEach(registry::dropAssignment);
         assignmentAdditions.forEach(registry::addPersistentAssignment);

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/workload/mirror/MirroringSupervisorController.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/workload/mirror/MirroringSupervisorController.java
@@ -97,8 +97,9 @@ public class MirroringSupervisorController implements SupervisorController {
     }
 
     @Override
-    public void onSubscriptionAssigned(Subscription subscription) {
-        logger.info("Assigning consumer for {}", subscription.getQualifiedName());
+    public void onSubscriptionAssigned(SubscriptionName subscriptionName) {
+        logger.info("Assigning consumer for {}", subscriptionName.getQualifiedName());
+        Subscription subscription = subscriptionsCache.getSubscription(subscriptionName);
         supervisor.assignConsumerForSubscription(subscription);
     }
 

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/workload/mirror/MirroringSupervisorController.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/workload/mirror/MirroringSupervisorController.java
@@ -11,9 +11,9 @@ import pl.allegro.tech.hermes.common.config.ConfigFactory;
 import pl.allegro.tech.hermes.common.config.Configs;
 import pl.allegro.tech.hermes.consumers.subscription.cache.SubscriptionsCache;
 import pl.allegro.tech.hermes.consumers.supervisor.ConsumersSupervisor;
+import pl.allegro.tech.hermes.consumers.supervisor.workload.SubscriptionAssignmentRegistry;
 import pl.allegro.tech.hermes.consumers.supervisor.workload.SupervisorController;
 import pl.allegro.tech.hermes.consumers.supervisor.workload.WorkTracker;
-import pl.allegro.tech.hermes.consumers.supervisor.workload.SubscriptionAssignmentRegistry;
 import pl.allegro.tech.hermes.domain.notifications.InternalNotificationsBus;
 
 import java.util.Set;
@@ -115,7 +115,7 @@ public class MirroringSupervisorController implements SupervisorController {
 
         notificationsBus.registerSubscriptionCallback(this);
         notificationsBus.registerTopicCallback(this);
-        assignementRegistry.registerAssignementCallback(this);
+        assignementRegistry.registerAssignmentCallback(this);
 
         supervisor.start();
         assignementRegistry.start();

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/workload/selective/BalancingJob.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/workload/selective/BalancingJob.java
@@ -52,22 +52,26 @@ public class BalancingJob implements Runnable {
         this.intervalSeconds = intervalSeconds;
 
         metrics.registerGauge(
-                "consumers-workload." + kafkaCluster + ".selective.all-assignments",
+                gaugeName(kafkaCluster, "selective.all-assignments"),
                 () -> balancingMetrics.allAssignments
         );
 
         metrics.registerGauge(
-                "consumers-workload." + kafkaCluster + ".selective.missing-resources",
+                gaugeName(kafkaCluster, "selective.missing-resources"),
                 () -> balancingMetrics.missingResources
         );
         metrics.registerGauge(
-                "consumers-workload." + kafkaCluster + ".selective.deleted-assignments",
+                gaugeName(kafkaCluster, ".selective.deleted-assignments"),
                 () -> balancingMetrics.deletedAssignments
         );
         metrics.registerGauge(
-                "consumers-workload." + kafkaCluster + ".selective.created-assignments",
+                gaugeName(kafkaCluster, ".selective.created-assignments"),
                 () -> balancingMetrics.createdAssignments
         );
+    }
+
+    private String gaugeName(String kafkaCluster, String name) {
+        return "consumers-workload." + kafkaCluster + "." + name;
     }
 
     @Override

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/workload/selective/ConsumerNodesRegistry.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/workload/selective/ConsumerNodesRegistry.java
@@ -74,8 +74,8 @@ public class ConsumerNodesRegistry extends PathChildrenCache implements PathChil
 
     public void registerLeaderLatchListener(LeaderLatchListener... leaderListener) {
         try {
-            leaderLatch.start();
             Arrays.stream(leaderListener).forEach(leaderLatch::addListener);
+            leaderLatch.start();
         } catch (Exception e) {
             throw new InternalProcessingException(e);
         }

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/workload/selective/ConsumerNodesRegistry.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/workload/selective/ConsumerNodesRegistry.java
@@ -121,6 +121,7 @@ public class ConsumerNodesRegistry extends PathChildrenCache implements PathChil
             curatorClient.create().creatingParentsIfNeeded()
                     .withMode(EPHEMERAL).forPath(getNodePath(consumerNodeId));
             logger.info("Registered in consumer nodes registry as {}", consumerNodeId);
+            refresh();
         } catch (Exception e) {
             throw new InternalProcessingException(e);
         }

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/workload/selective/ConsumerNodesRegistry.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/workload/selective/ConsumerNodesRegistry.java
@@ -62,6 +62,16 @@ public class ConsumerNodesRegistry extends PathChildrenCache implements PathChil
         }
     }
 
+    private boolean ensureRegistered() {
+        if (curatorClient.getZookeeperClient().isConnected()) {
+            if (!isRegistered(consumerNodeId)) {
+                registerConsumerNode();
+            }
+            return true;
+        }
+        return false;
+    }
+
     private void registerConsumerNode() {
         try {
             curatorClient.create().creatingParentsIfNeeded()
@@ -94,7 +104,7 @@ public class ConsumerNodesRegistry extends PathChildrenCache implements PathChil
     }
 
     public boolean isLeader() {
-        return curatorClient.getZookeeperClient().isConnected() && leaderLatch.hasLeadership();
+        return ensureRegistered() && leaderLatch.hasLeadership();
     }
 
     public List<String> list() {

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/workload/selective/SelectiveSupervisorController.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/workload/selective/SelectiveSupervisorController.java
@@ -65,7 +65,8 @@ public class SelectiveSupervisorController implements SupervisorController {
     }
 
     @Override
-    public void onSubscriptionAssigned(Subscription subscription) {
+    public void onSubscriptionAssigned(SubscriptionName subscriptionName) {
+        Subscription subscription = subscriptionsCache.getSubscription(subscriptionName);
         logger.info("Scheduling assignment consumer for {}", subscription.getQualifiedName());
         assignmentExecutor.execute(() -> {
             logger.info("Assigning consumer for {}", subscription.getQualifiedName());

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/workload/selective/SelectiveSupervisorController.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/workload/selective/SelectiveSupervisorController.java
@@ -114,14 +114,16 @@ public class SelectiveSupervisorController implements SupervisorController {
         supervisor.start();
         consumersRegistry.start();
         if (configFactory.getBooleanProperty(CONSUMER_WORKLOAD_AUTO_REBALANCE)) {
-            consumersRegistry.registerLeaderLatchListener(new BalancingJob(
-                    consumersRegistry,
-                    subscriptionsCache,
-                    new SelectiveWorkBalancer(configFactory.getIntProperty(CONSUMER_WORKLOAD_CONSUMERS_PER_SUBSCRIPTION),
-                            configFactory.getIntProperty(CONSUMER_WORKLOAD_MAX_SUBSCRIPTIONS_PER_CONSUMER)),
-                    workTracker, metrics,
-                    configFactory.getIntProperty(CONSUMER_WORKLOAD_REBALANCE_INTERVAL),
-                    configFactory.getStringProperty(KAFKA_CLUSTER_NAME)));
+            registry.registerPostInitializationListener(() ->
+                consumersRegistry.registerLeaderLatchListener(new BalancingJob(
+                        consumersRegistry,
+                        subscriptionsCache,
+                        new SelectiveWorkBalancer(configFactory.getIntProperty(CONSUMER_WORKLOAD_CONSUMERS_PER_SUBSCRIPTION),
+                                configFactory.getIntProperty(CONSUMER_WORKLOAD_MAX_SUBSCRIPTIONS_PER_CONSUMER)),
+                        workTracker, metrics,
+                        configFactory.getIntProperty(CONSUMER_WORKLOAD_REBALANCE_INTERVAL),
+                        configFactory.getStringProperty(KAFKA_CLUSTER_NAME)))
+            );
         } else {
             logger.info("Automatic workload rebalancing is disabled.");
         }

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/workload/selective/SelectiveSupervisorController.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/workload/selective/SelectiveSupervisorController.java
@@ -18,7 +18,13 @@ import pl.allegro.tech.hermes.domain.notifications.InternalNotificationsBus;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
 
-import static pl.allegro.tech.hermes.common.config.Configs.*;
+import static pl.allegro.tech.hermes.common.config.Configs.CONSUMER_WORKLOAD_ALGORITHM;
+import static pl.allegro.tech.hermes.common.config.Configs.CONSUMER_WORKLOAD_AUTO_REBALANCE;
+import static pl.allegro.tech.hermes.common.config.Configs.CONSUMER_WORKLOAD_CONSUMERS_PER_SUBSCRIPTION;
+import static pl.allegro.tech.hermes.common.config.Configs.CONSUMER_WORKLOAD_MAX_SUBSCRIPTIONS_PER_CONSUMER;
+import static pl.allegro.tech.hermes.common.config.Configs.CONSUMER_WORKLOAD_NODE_ID;
+import static pl.allegro.tech.hermes.common.config.Configs.CONSUMER_WORKLOAD_REBALANCE_INTERVAL;
+import static pl.allegro.tech.hermes.common.config.Configs.KAFKA_CLUSTER_NAME;
 
 public class SelectiveSupervisorController implements SupervisorController {
 
@@ -102,7 +108,7 @@ public class SelectiveSupervisorController implements SupervisorController {
 
         notificationsBus.registerSubscriptionCallback(this);
         notificationsBus.registerTopicCallback(this);
-        registry.registerAssignementCallback(this);
+        registry.registerAssignmentCallback(this);
 
         supervisor.start();
         consumersRegistry.start();

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/workload/selective/SelectiveWorkBalancer.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/workload/selective/SelectiveWorkBalancer.java
@@ -32,7 +32,7 @@ public class SelectiveWorkBalancer {
         return new WorkBalancingResult.Builder(balancedState)
                 .withSubscriptionsStats(subscriptions.size(), removedSubscriptions.size(), newSubscriptions.size())
                 .withConsumersStats(activeConsumerNodes.size(), inactiveConsumers.size(), newConsumers.size())
-                .withMissingResources(countMissingResources(balancedState))
+                .withMissingResources(countMissingResources(subscriptions, balancedState))
                 .build();
     }
 
@@ -51,8 +51,8 @@ public class SelectiveWorkBalancer {
         });
     }
 
-    private int countMissingResources(SubscriptionAssignmentView state) {
-        return state.getSubscriptions().stream()
+    private int countMissingResources(List<SubscriptionName> subscriptions, SubscriptionAssignmentView state) {
+        return subscriptions.stream()
                 .mapToInt(s -> consumersPerSubscription - state.getAssignmentsCountForSubscription(s))
                 .sum();
     }

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/workload/selective/SelectiveWorkBalancer.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/workload/selective/SelectiveWorkBalancer.java
@@ -62,7 +62,15 @@ public class SelectiveWorkBalancer {
 
     private int countMissingResources(List<SubscriptionName> subscriptions, SubscriptionAssignmentView state) {
         return subscriptions.stream()
-                .mapToInt(s -> consumersPerSubscription - state.getAssignmentsCountForSubscription(s))
+                .mapToInt(s -> {
+                    int subscriptionAssignments = state.getAssignmentsCountForSubscription(s);
+                    int missing = consumersPerSubscription - subscriptionAssignments;
+                    if (missing != 0) {
+                        logger.info("Subscription {} has {} != {} (default) assignments",
+                                s, subscriptionAssignments, consumersPerSubscription);
+                    }
+                    return missing;
+                })
                 .sum();
     }
 

--- a/hermes-consumers/src/main/resources/logback.xml
+++ b/hermes-consumers/src/main/resources/logback.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
 
-    <turboFilter class="ch.qos.logback.classic.turbo.DuplicateMessageFilter"/>
-
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
             <Pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level %logger{36} - %msg%n</Pattern>

--- a/hermes-consumers/src/test/java/pl/allegro/tech/hermes/consumers/supervisor/workload/ConsumerTestRuntimeEnvironment.java
+++ b/hermes-consumers/src/test/java/pl/allegro/tech/hermes/consumers/supervisor/workload/ConsumerTestRuntimeEnvironment.java
@@ -11,9 +11,17 @@ import pl.allegro.tech.hermes.common.admin.zookeeper.ZookeeperAdminCache;
 import pl.allegro.tech.hermes.common.di.factories.ModelAwareZookeeperNotifyingCacheFactory;
 import pl.allegro.tech.hermes.common.exception.InternalProcessingException;
 import pl.allegro.tech.hermes.common.metric.HermesMetrics;
+import pl.allegro.tech.hermes.consumers.consumer.offset.OffsetQueue;
+import pl.allegro.tech.hermes.consumers.health.ConsumerMonitor;
+import pl.allegro.tech.hermes.consumers.message.undelivered.UndeliveredMessageLogPersister;
 import pl.allegro.tech.hermes.consumers.subscription.cache.NotificationsBasedSubscriptionCache;
 import pl.allegro.tech.hermes.consumers.subscription.cache.SubscriptionsCache;
+import pl.allegro.tech.hermes.consumers.supervisor.ConsumerFactory;
+import pl.allegro.tech.hermes.consumers.supervisor.ConsumersExecutorService;
 import pl.allegro.tech.hermes.consumers.supervisor.ConsumersSupervisor;
+import pl.allegro.tech.hermes.consumers.supervisor.NonblockingConsumersSupervisor;
+import pl.allegro.tech.hermes.consumers.supervisor.monitor.ConsumersRuntimeMonitor;
+import pl.allegro.tech.hermes.consumers.supervisor.process.Retransmitter;
 import pl.allegro.tech.hermes.consumers.supervisor.workload.selective.ConsumerNodesRegistry;
 import pl.allegro.tech.hermes.consumers.supervisor.workload.selective.SelectiveSupervisorController;
 import pl.allegro.tech.hermes.domain.group.GroupRepository;
@@ -29,6 +37,7 @@ import pl.allegro.tech.hermes.infrastructure.zookeeper.notifications.ZookeeperIn
 import pl.allegro.tech.hermes.metrics.PathsCompiler;
 import pl.allegro.tech.hermes.test.helper.config.MutableConfigFactory;
 
+import java.time.Clock;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
@@ -61,9 +70,8 @@ class ConsumerTestRuntimeEnvironment {
     private SubscriptionRepository subscriptionRepository;
     private MutableConfigFactory configFactory;
     private ObjectMapper objectMapper = new ObjectMapper();
-    private ConsumersSupervisor supervisor = mock(ConsumersSupervisor.class);
     private ExecutorService executorService = Executors.newSingleThreadExecutor();
-    private HermesMetrics metrics;
+    private Supplier<HermesMetrics> metricsSupplier;
     private ConsumerNodesRegistry consumersRegistry;
     private CuratorFramework curator;
 
@@ -85,7 +93,7 @@ class ConsumerTestRuntimeEnvironment {
                 curator, executorService, paths.consumersRegistryPath(CLUSTER_NAME), "id"
         );
 
-        this.metrics = new HermesMetrics(new MetricRegistry(), new PathsCompiler("localhost"));
+        this.metricsSupplier = () -> new HermesMetrics(new MetricRegistry(), new PathsCompiler("localhost"));
 
         try {
             consumersRegistry.start();
@@ -99,6 +107,11 @@ class ConsumerTestRuntimeEnvironment {
     }
 
     private SelectiveSupervisorController createConsumer(String consumerId) {
+        return createConsumer(consumerId, consumersSupervisor(mock(ConsumerFactory.class)));
+    }
+
+    private SelectiveSupervisorController createConsumer(String consumerId,
+                                                         ConsumersSupervisor consumersSupervisor) {
         CuratorFramework curator = curatorSupplier.get();
         consumerZookeeperConnections.put(consumerId, curator);
         ConsumerNodesRegistry registry = new ConsumerNodesRegistry(
@@ -111,20 +124,57 @@ class ConsumerTestRuntimeEnvironment {
         ModelAwareZookeeperNotifyingCache modelAwareCache = new ModelAwareZookeeperNotifyingCacheFactory(
                 curator, configFactory
         ).provide();
-        InternalNotificationsBus notificationsBus = new ZookeeperInternalNotificationBus(objectMapper, modelAwareCache);
+        InternalNotificationsBus notificationsBus =
+                new ZookeeperInternalNotificationBus(objectMapper, modelAwareCache);
         SubscriptionsCache subscriptionsCache = new NotificationsBasedSubscriptionCache(
                 notificationsBus, groupRepository, topicRepository, subscriptionRepository
         );
         SubscriptionAssignmentRegistry assignmentRegistry = new SubscriptionAssignmentRegistryFactory(
-                curator, configFactory, subscriptionsCache
-        ).provide();
+                curator, configFactory, subscriptionsCache).provide(consumerId);
 
         WorkTracker workTracker = new WorkTracker(consumerId, assignmentRegistry);
 
         return new SelectiveSupervisorController(
-                supervisor, notificationsBus, subscriptionsCache, assignmentRegistry, workTracker, registry,
-                mock(ZookeeperAdminCache.class), executorService, configFactory, metrics
+                consumersSupervisor, notificationsBus, subscriptionsCache, assignmentRegistry, workTracker, registry,
+                mock(ZookeeperAdminCache.class), executorService, configFactory, metricsSupplier.get()
         );
+    }
+
+    SelectiveSupervisorController spawnConsumer(String consumerId, ConsumersSupervisor consumersSupervisor) {
+        return startNode(createConsumer(consumerId, consumersSupervisor));
+    }
+
+    ConsumersSupervisor consumersSupervisor(ConsumerFactory consumerFactory) {
+        HermesMetrics metrics = metricsSupplier.get();
+        return new NonblockingConsumersSupervisor(configFactory,
+                new ConsumersExecutorService(configFactory, metrics),
+                consumerFactory,
+                mock(OffsetQueue.class),
+                mock(Retransmitter.class),
+                mock(UndeliveredMessageLogPersister.class),
+                subscriptionRepository,
+                metrics,
+                mock(ConsumerMonitor.class),
+                Clock.systemDefaultZone());
+    }
+
+    ConsumersRuntimeMonitor monitor(String consumerId,
+                                    ConsumersSupervisor consumersSupervisor,
+                                    SupervisorController supervisorController) {
+        CuratorFramework curator = consumerZookeeperConnections.get(consumerId);
+        ModelAwareZookeeperNotifyingCache modelAwareCache =
+                new ModelAwareZookeeperNotifyingCacheFactory(curator, configFactory).provide();
+        InternalNotificationsBus notificationsBus =
+                new ZookeeperInternalNotificationBus(objectMapper, modelAwareCache);
+        SubscriptionsCache subscriptionsCache = new NotificationsBasedSubscriptionCache(
+                notificationsBus, groupRepository, topicRepository, subscriptionRepository);
+        subscriptionsCache.start();
+        return new ConsumersRuntimeMonitor(
+                consumersSupervisor,
+                supervisorController,
+                metricsSupplier.get(),
+                subscriptionsCache,
+                configFactory);
     }
 
     private List<SelectiveSupervisorController> createConsumers(int howMany) {

--- a/hermes-consumers/src/test/java/pl/allegro/tech/hermes/consumers/supervisor/workload/ConsumerTestRuntimeEnvironment.java
+++ b/hermes-consumers/src/test/java/pl/allegro/tech/hermes/consumers/supervisor/workload/ConsumerTestRuntimeEnvironment.java
@@ -97,7 +97,7 @@ class ConsumerTestRuntimeEnvironment {
 
         this.consumersRegistry = new ConsumerNodesRegistry(
                 curator, executorService, paths.consumersRegistryPath(CLUSTER_NAME), "id",
-                DEATH_OF_CONSUMER_AFTER_SECONDS);
+                DEATH_OF_CONSUMER_AFTER_SECONDS, Clock.systemDefaultZone());
 
         this.metricsSupplier = () -> new HermesMetrics(new MetricRegistry(), new PathsCompiler("localhost"));
 
@@ -125,7 +125,8 @@ class ConsumerTestRuntimeEnvironment {
                 executorService,
                 paths.consumersRegistryPath(CLUSTER_NAME),
                 consumerId,
-                DEATH_OF_CONSUMER_AFTER_SECONDS);
+                DEATH_OF_CONSUMER_AFTER_SECONDS,
+                Clock.systemDefaultZone());
 
         ModelAwareZookeeperNotifyingCache modelAwareCache = new ModelAwareZookeeperNotifyingCacheFactory(
                 curator, configFactory
@@ -263,7 +264,8 @@ class ConsumerTestRuntimeEnvironment {
         await().atMost(adjust(ONE_SECOND)).until(
                 () -> {
                     subscriptionRepository.subscriptionExists(subscription.getTopicName(), subscription.getName());
-                    subscriptionsCaches.forEach(subscriptionsCache -> subscriptionsCache.listActiveSubscriptionNames().contains(subscriptionName));
+                    subscriptionsCaches.forEach(subscriptionsCache ->
+                            subscriptionsCache.listActiveSubscriptionNames().contains(subscriptionName));
                 }
         );
         return subscription.getQualifiedName();

--- a/hermes-consumers/src/test/java/pl/allegro/tech/hermes/consumers/supervisor/workload/SelectiveSupervisorControllersIntegrationTest.java
+++ b/hermes-consumers/src/test/java/pl/allegro/tech/hermes/consumers/supervisor/workload/SelectiveSupervisorControllersIntegrationTest.java
@@ -3,7 +3,12 @@ package pl.allegro.tech.hermes.consumers.supervisor.workload;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import pl.allegro.tech.hermes.api.Subscription;
 import pl.allegro.tech.hermes.api.SubscriptionName;
+import pl.allegro.tech.hermes.common.exception.InternalProcessingException;
+import pl.allegro.tech.hermes.consumers.consumer.SerialConsumer;
+import pl.allegro.tech.hermes.consumers.supervisor.ConsumerFactory;
+import pl.allegro.tech.hermes.consumers.supervisor.ConsumersSupervisor;
 import pl.allegro.tech.hermes.consumers.supervisor.workload.selective.SelectiveSupervisorController;
 import pl.allegro.tech.hermes.test.helper.zookeeper.ZookeeperBaseTest;
 
@@ -12,6 +17,11 @@ import java.util.List;
 import static com.jayway.awaitility.Awaitility.await;
 import static com.jayway.awaitility.Duration.FIVE_SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import static pl.allegro.tech.hermes.test.helper.endpoint.TimeoutAdjuster.adjust;
 
 public class SelectiveSupervisorControllersIntegrationTest extends ZookeeperBaseTest {
@@ -96,5 +106,28 @@ public class SelectiveSupervisorControllersIntegrationTest extends ZookeeperBase
 
         // then
         subscriptions.forEach(subscription -> runtime.awaitUntilAssignmentExists(subscription, node));
+    }
+
+    @Test
+    public void shouldRecreateMissingConsumer() {
+        // given
+        ConsumerFactory consumerFactory = mock(ConsumerFactory.class);
+
+        when(consumerFactory.createConsumer(any(Subscription.class)))
+                .thenThrow(
+                        new InternalProcessingException("failed to create consumer"))
+                .thenReturn(
+                        mock(SerialConsumer.class));
+
+        ConsumersSupervisor supervisor = runtime.consumersSupervisor(consumerFactory);
+        SelectiveSupervisorController node = runtime.spawnConsumer("consumer", supervisor);
+
+        runtime.awaitUntilAssignmentExists(runtime.createSubscription(), node);
+
+        // when
+        runtime.monitor("consumer", supervisor, node).run();
+
+        // then
+        verify(consumerFactory, times(2)).createConsumer(any());
     }
 }

--- a/hermes-consumers/src/test/java/pl/allegro/tech/hermes/consumers/supervisor/workload/SelectiveWorkBalancerTest.java
+++ b/hermes-consumers/src/test/java/pl/allegro/tech/hermes/consumers/supervisor/workload/SelectiveWorkBalancerTest.java
@@ -7,7 +7,6 @@ import pl.allegro.tech.hermes.api.SubscriptionName;
 import pl.allegro.tech.hermes.consumers.supervisor.workload.selective.SelectiveWorkBalancer;
 import pl.allegro.tech.hermes.consumers.supervisor.workload.selective.WorkBalancingResult;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.IntStream;

--- a/hermes-consumers/src/test/java/pl/allegro/tech/hermes/consumers/supervisor/workload/WorkTrackerTest.java
+++ b/hermes-consumers/src/test/java/pl/allegro/tech/hermes/consumers/supervisor/workload/WorkTrackerTest.java
@@ -42,7 +42,7 @@ public class WorkTrackerTest extends ZookeeperBaseTest {
     );
 
     private final SubscriptionAssignmentRegistry subscriptionAssignmentRegistry = new SubscriptionAssignmentRegistry(
-            supervisorId, zookeeperClient, basePath, cache, new SubscriptionAssignmentPathSerializer(basePath));
+            supervisorId, zookeeperClient, basePath, cache);
 
     private final WorkTracker workTracker = new WorkTracker(supervisorId, subscriptionAssignmentRegistry);
 

--- a/hermes-consumers/src/test/java/pl/allegro/tech/hermes/consumers/supervisor/workload/WorkTrackerTest.java
+++ b/hermes-consumers/src/test/java/pl/allegro/tech/hermes/consumers/supervisor/workload/WorkTrackerTest.java
@@ -106,7 +106,7 @@ public class WorkTrackerTest extends ZookeeperBaseTest {
         SubscriptionAssignmentView view = stateWithSingleAssignment(s1);
 
         // when
-        workTracker.apply(view);
+        workTracker.apply(subscriptionAssignmentRegistry.createSnapshot(), view);
 
         // then
         wait.untilZookeeperPathIsCreated(basePath, s1.getQualifiedName().toString(), supervisorId);
@@ -118,7 +118,7 @@ public class WorkTrackerTest extends ZookeeperBaseTest {
         Subscription s1 = forceAssignment(anySubscription());
 
         // when
-        workTracker.apply(stateWithNoAssignments());
+        workTracker.apply(subscriptionAssignmentRegistry.createSnapshot(), stateWithNoAssignments());
 
         // then
         wait.untilZookeeperPathNotExists(basePath, s1.getQualifiedName().toString(), supervisorId);
@@ -130,7 +130,7 @@ public class WorkTrackerTest extends ZookeeperBaseTest {
         Subscription s1 = dropAssignment(forceAssignment(anySubscription()));
 
         // when
-        workTracker.apply(stateWithNoAssignments());
+        workTracker.apply(subscriptionAssignmentRegistry.createSnapshot(), stateWithNoAssignments());
 
         // then
         wait.untilZookeeperPathNotExists(basePath, s1.getQualifiedName().toString());
@@ -141,11 +141,11 @@ public class WorkTrackerTest extends ZookeeperBaseTest {
         // given
         Subscription s1 = anySubscription();
         SubscriptionAssignmentView view = stateWithSingleAssignment(s1);
-        workTracker.apply(view);
+        workTracker.apply(subscriptionAssignmentRegistry.createSnapshot(), view);
         wait.untilZookeeperPathIsCreated(basePath, s1.getQualifiedName().toString(), supervisorId);
 
         // when
-        workTracker.apply(stateWithNoAssignments());
+        workTracker.apply(subscriptionAssignmentRegistry.createSnapshot(), stateWithNoAssignments());
 
         // then
         wait.untilZookeeperPathNotExists(basePath, s1.getQualifiedName().toString());
@@ -162,7 +162,7 @@ public class WorkTrackerTest extends ZookeeperBaseTest {
                         s2.getQualifiedName(), ImmutableSet.of(assignment(supervisorId, s2.getQualifiedName()))));
 
         // when
-        workTracker.apply(view);
+        workTracker.apply(subscriptionAssignmentRegistry.createSnapshot(), view);
 
         // then
         wait.untilZookeeperPathIsCreated(basePath, s1.getQualifiedName().toString(), supervisorId);

--- a/integration/build.gradle
+++ b/integration/build.gradle
@@ -42,8 +42,12 @@ def getAlpnVersion() {
                 return '8.1.7.v20160121'
             case 78..101:
                 return '8.1.8.v20160420'
-            case 102..112:
+            case 102..111:
                 return '8.1.9.v20160720'
+            case 112..120:
+                return '8.1.10.v20161026'
+            case 121:
+                return '8.1.11.v20170118'
             default:
                 throw new IllegalStateException("ALPN version not defined for Java version: ${javaVersion}; extracted minor version: ${version}")
         }


### PR DESCRIPTION
This PR solves two issues:

- inconsistent distribution of assignments could happen when assignment cache was not built completely when workload balancing took place
- failed creations of consumers resulted in those consumer processes being missing and never re-created

In the first case, initializing the cache with existing assignments has been introduced.
The latter utilizes the running consumers monitor to issue signals for re-assigning consumers.

Edit:

During development more issues have been solved:

- inconsistent reporting by `ConsumersRuntimeMonitor` has been fixed to take a snapshot at the beginning of a run - it used the underlying structure of running processes before, which would change during the run
- when zookeeper is down, consumer would never come back to life, as it wouldn't re-register itself with the `ConsumerNodesRegistry` - this has been fixed
- it could happen that a consumer would restart and never register itself with the registry, as the ephemeral node from previous session would be still present and the consumer would not overwrite that node. This was solved by continuously checking the state of registration and enforcing it if necessary
- any restart of a node triggered the balancing job to take away it's assignments, which should not happen, especially in case of zookeeper flaps. Fixing this is based on checking last seen timestamp of a node in the registry and removing it's assignments only after specified timeout
- killing a consumer process would never remove it from the running processes list if the process has not yet started - this also has been fixed