### PR TITLE
Make the docker-compose work with the latest versions

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,48 +1,52 @@
-zookeeper:
-  image: wurstmeister/zookeeper
-  ports:
-    - "2181:2181"
-  volumes:
-    - ./data/zookeeper:/opt/zookeeper-3.4.6/data
+version: '3'
 
-kafka:
-  image: wurstmeister/kafka:0.8.2.1
-  ports:
-    - "9092:9092"
-  links:
-    - zookeeper:zk
-  environment:
-    KAFKA_ADVERTISED_HOST_NAME: 172.17.0.1
-  volumes:
-    - /var/run/docker.sock:/var/run/docker.sock
+services:
+  zk:
+    image: wurstmeister/zookeeper
+    ports:
+      - "2181:2181"
 
-graphite:
-  image: nickstenning/graphite
-  ports:
-    - "80:80"
-    - "2003:2003"
+  kafka:
+    image: wurstmeister/kafka
+    ports:
+      - "9092:9092"
+    depends_on:
+      - zk
+    environment:
+      KAFKA_ADVERTISED_LISTENERS: "PLAINTEXT://kafka:9092"
+      KAFKA_ZOOKEEPER_CONNECT: zk:2181
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
 
-frontend:
-  image: allegro/hermes-frontend
-  ports:
-    - "8080:8080"
-  links:
-    - zookeeper:zk
-    - kafka
-    - graphite
+  graphite:
+    image: nickstenning/graphite
+    ports:
+      - "80:80"
+      - "2003:2003"
 
-consumers:
-  image: allegro/hermes-consumers
-  links:
-    - zookeeper:zk
-    - kafka
-    - graphite
+  frontend:
+    image: allegro/hermes-frontend
+    ports:
+      - "8080:8080"
+    depends_on:
+      - zk
+      - kafka
+      - graphite
+      - consumers
 
-management:
-  image: allegro/hermes-management
-  ports:
-    - "8090:8090"
-  links:
-    - zookeeper:zk
-    - kafka
-    - graphite
+  consumers:
+    image: allegro/hermes-consumers
+    depends_on:
+      - zk
+      - kafka
+      - graphite
+
+  management:
+    image: allegro/hermes-management
+    ports:
+      - "8090:8090"
+    depends_on:
+      - zk
+      - kafka
+      - graphite
+

--- a/docker/latest/consumers/consumers.properties
+++ b/docker/latest/consumers/consumers.properties
@@ -6,6 +6,9 @@ zookeeper.session.timeout=7000
 kafka.zookeeper.connect.string=zk:2181
 kafka.consumer.offsets.storage=kafka
 
+kafka.bootstrap.servers=kafka:9092
+kafka.broker.list=kafka:9092
+
 graphite.host=graphite
 graphite.http.port=80
 metrics.graphite.reporter=true


### PR DESCRIPTION
- Use Kafka advertised.listeners
- Change Bootstrap servers to kafka:9092 (from the default localhost:9092)