### PR TITLE
Don't match when queried nested field doesn't exist instead of failing

### DIFF
--- a/hermes-api/src/main/java/pl/allegro/tech/hermes/api/Group.java
+++ b/hermes-api/src/main/java/pl/allegro/tech/hermes/api/Group.java
@@ -74,4 +74,9 @@ public class Group {
     public int hashCode() {
         return Objects.hash(groupName, technicalOwner, supportTeam);
     }
+
+    @Override
+    public String toString() {
+        return "Group(" + groupName + ")";
+    }
 }

--- a/hermes-api/src/main/java/pl/allegro/tech/hermes/api/Subscription.java
+++ b/hermes-api/src/main/java/pl/allegro/tech/hermes/api/Subscription.java
@@ -373,4 +373,9 @@ public class Subscription implements Anonymizable {
         }
         return this;
     }
+
+    @Override
+    public String toString() {
+        return "Subscription(" + getQualifiedName() + ")";
+    }
 }

--- a/hermes-api/src/main/java/pl/allegro/tech/hermes/api/Topic.java
+++ b/hermes-api/src/main/java/pl/allegro/tech/hermes/api/Topic.java
@@ -170,4 +170,9 @@ public class Topic {
     public int getMaxMessageSize() {
         return maxMessageSize;
     }
+
+    @Override
+    public String toString() {
+        return "Topic(" + getQualifiedName() + ")";
+    }
 }

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/infrastructure/query/MatcherQuery.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/infrastructure/query/MatcherQuery.java
@@ -1,14 +1,19 @@
 package pl.allegro.tech.hermes.management.infrastructure.query;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import pl.allegro.tech.hermes.api.Query;
 import pl.allegro.tech.hermes.management.infrastructure.query.matcher.Matcher;
+import pl.allegro.tech.hermes.management.infrastructure.query.matcher.MatcherException;
 
 import java.util.Map;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 
 public class MatcherQuery<T> implements Query<T> {
+
+    private static final Logger logger = LoggerFactory.getLogger(MatcherQuery.class);
 
     private final Matcher matcher;
     private final ObjectMapper objectMapper;
@@ -24,7 +29,14 @@ public class MatcherQuery<T> implements Query<T> {
     }
 
     public Predicate<T> getPredicate() {
-        return (value) -> matcher.match(convertToMap(value));
+        return (value) -> {
+            try {
+                return matcher.match(convertToMap(value));
+            } catch (MatcherException e) {
+                logger.info("Failed to match {}, skipping", value, e);
+                return false;
+            }
+        };
     }
 
     @SuppressWarnings("unchecked")

--- a/integration/src/integration/java/pl/allegro/tech/hermes/integration/management/QueryEndpointTest.java
+++ b/integration/src/integration/java/pl/allegro/tech/hermes/integration/management/QueryEndpointTest.java
@@ -54,7 +54,6 @@ public class QueryEndpointTest extends IntegrationTest {
         assertListMatches(groups, found, positions);
     }
 
-
     @DataProvider(name = "topicData")
     public static Object[][] topicData() {
         return new Object[][] {
@@ -115,6 +114,30 @@ public class QueryEndpointTest extends IntegrationTest {
 
         // then
         assertListMatches(subscriptions, found, positions);
+    }
+
+    @Test
+    public void shouldSkipEntitiesNotContainingQueriedField() {
+        // given
+        management.group().create(new Group("group", "owner", "team", "contact"));
+
+        // when
+        List<Group> found = management.query().queryGroups("{\"query\": {\"missingField\": \"xxx\"}}");
+
+        // then
+        assertThat(found).isEmpty();
+    }
+
+    @Test
+    public void shouldSkipEntitiesNotContainingQueriedNestedField() {
+        // given
+        management.group().create(new Group("group", "owner", "team", "contact"));
+
+        // when
+        List<Group> found = management.query().queryGroups("{\"query\": {\"missing.nested.field\": \"xxx\"}}");
+
+        // then
+        assertThat(found).isEmpty();
     }
 
     private Subscription enrichSubscription(SubscriptionBuilder subscription, String endpoint) {


### PR DESCRIPTION
Currently we don't match groups / topics / subscriptions when querying by a field that doesn't exist in a given instance. E.g. querying topics with `{"query": {"endpoint": "xxx"}}` (no topic has a field called `endpoint`) always gives an empty result.

This doesn't hold when querying by a missing nested field, e.g. `{"query": {"endpoint.nested": "xxx"}}`. In such case an exception is thrown, the query stops and the result is a 500 error response.

This PR introduces not matching entities that don't have a queried nested fields instead of failing the query with a 500 response.