### PR TITLE
Remove ancient Kafka dependency (not used)

### DIFF
--- a/hermes-frontend/build.gradle
+++ b/hermes-frontend/build.gradle
@@ -5,7 +5,6 @@ dependencies {
     compile project(':hermes-schema')
 
     compile group: 'io.undertow', name: 'undertow-core', version: '1.4.3.Final'
-    compile group: 'org.apache.kafka', name: 'kafka-clients', version: '0.8.2.0'
     compile group: 'org.apache.commons', name: 'commons-lang3', version: '3.0'
     compile group: 'net.openhft', name: 'chronicle-map', version: '2.4.13'
     compile group: 'commons-io', name: 'commons-io', version: '2.4'


### PR DESCRIPTION
This dependency was not used, shadowed by Kafka from `hermes-common`. Still it should not be here.

Connected to #706