### PR TITLE
Fixes flaky owner migration integration test

### DIFF
--- a/integration/src/integration/java/pl/allegro/tech/hermes/integration/management/SupportTeamToOwnerMigratorIntegrationTest.java
+++ b/integration/src/integration/java/pl/allegro/tech/hermes/integration/management/SupportTeamToOwnerMigratorIntegrationTest.java
@@ -6,7 +6,6 @@ import pl.allegro.tech.hermes.api.OwnerId;
 import pl.allegro.tech.hermes.api.Subscription;
 import pl.allegro.tech.hermes.api.Topic;
 import pl.allegro.tech.hermes.integration.IntegrationTest;
-import pl.allegro.tech.hermes.management.migration.owner.SupportTeamToOwnerMigrator;
 
 import javax.ws.rs.core.Response;
 
@@ -54,9 +53,6 @@ public class SupportTeamToOwnerMigratorIntegrationTest extends IntegrationTest {
 
         // then
         assertThat(response.getStatus()).isEqualTo(200);
-        SupportTeamToOwnerMigrator.ExecutionStats stats = response.readEntity(SupportTeamToOwnerMigrator.ExecutionStats.class);
-        assertThat(stats.topics().migrated()).isEqualTo(4);
-        assertThat(stats.subscriptions().migrated()).isEqualTo(3);
 
         assertTopicLoadedFromApiHasOwner(firstSingleTeamTopic, new OwnerId("Plaintext", "Team A"));
         assertSubscriptionLoadedFromApiHasOwner(firstSingleTeamTopicSubAlpha, new OwnerId("Plaintext", "Team Alpha"));


### PR DESCRIPTION
Removes stats check in owner migration integration test. We sometimes migrate more topics than expected, because of a shared Zookeeper and Kafka containing topics from the other tests. Removing all topics before the test doesn't help, probably there is sometimes a race with previous tests adding some topics. Stats are verified in a separate unit test anyway.