### PR TITLE
Correcting issues caused by subscriptions with rate set to too low value

### DIFF
--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/rate/ConsumerRateLimitSupervisor.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/rate/ConsumerRateLimitSupervisor.java
@@ -30,12 +30,12 @@ public class ConsumerRateLimitSupervisor implements Runnable {
 
     @Override
     public void run() {
-        try {
-            for (ConsumerRateLimiter limiter : consumerRateLimiters) {
-                    limiter.adjustConsumerRate();
+        for (ConsumerRateLimiter limiter : consumerRateLimiters) {
+            try {
+                limiter.adjustConsumerRate();
+            } catch (Exception e) {
+                logger.warn("Issue adjusting consumer rate", e);
             }
-        } catch (Exception e) {
-            logger.warn("Issue adjusting consumer rates", e);
         }
     }
 

--- a/hermes-consumers/src/test/groovy/pl/allegro/tech/hermes/consumers/consumer/rate/maxrate/MaxRateBalancerTest.groovy
+++ b/hermes-consumers/src/test/groovy/pl/allegro/tech/hermes/consumers/consumer/rate/maxrate/MaxRateBalancerTest.groovy
@@ -187,4 +187,19 @@ class MaxRateBalancerTest extends Specification {
                 new ConsumerRateInfo("reporting", notBusy)
         ] as Set).isPresent()
     }
+
+    def "should assign min max rate when subscription rate is too low"() {
+        given:
+        def notBusy = RateInfo.withNoMaxRate(RateHistory.create(0.0d));
+        def busy = RateInfo.withNoMaxRate(RateHistory.create(1.0d));
+
+        when:
+        def maxRates = balancer.balance(1d, [
+                new ConsumerRateInfo("notBusy", notBusy),
+                new ConsumerRateInfo("busy", busy)
+        ] as Set).get()
+
+        then:
+        maxRates.values()*.getMaxRate() == [MIN_MAX_RATE, MIN_MAX_RATE]
+    }
 }


### PR DESCRIPTION
In case of negotiated max rate algorithm, if subscription rate is lower than consumer count, the algorithm could calculate a negative max rate value.

This in turn would collapse the whole rate limiting supervisor, as the iteration was stopped by a misconfigured rate limit.