### PR TITLE
introduced topic auth

### DIFF
--- a/hermes-api/src/main/java/pl/allegro/tech/hermes/api/PublishingAuth.java
+++ b/hermes-api/src/main/java/pl/allegro/tech/hermes/api/PublishingAuth.java
@@ -1,0 +1,64 @@
+package pl.allegro.tech.hermes.api;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+public class PublishingAuth {
+
+    private final List<String> publishers;
+    private final boolean enabled;
+    private final boolean unauthorisedAccessEnabled;
+
+    @JsonCreator
+    public PublishingAuth(@JsonProperty("publishers") List<String> publishers,
+                          @JsonProperty("enabled") boolean enabled,
+                          @JsonProperty("unauthorisedAccessEnabled") boolean unauthorisedAccessEnabled) {
+
+        this.publishers = publishers;
+        this.enabled = enabled;
+        this.unauthorisedAccessEnabled = unauthorisedAccessEnabled;
+    }
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public boolean isUnauthorisedAccessEnabled() {
+        return unauthorisedAccessEnabled;
+    }
+
+    public boolean hasPermission(String publisher) {
+        return publishers.contains(publisher);
+    }
+
+    public List<String> getPublishers() {
+        return publishers;
+    }
+
+    public static PublishingAuth disabled() {
+        return new PublishingAuth(new ArrayList<>(), false, true);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        PublishingAuth that = (PublishingAuth) o;
+        return enabled == that.enabled
+                && unauthorisedAccessEnabled == that.unauthorisedAccessEnabled
+                && Objects.equals(publishers, that.publishers);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(publishers, enabled, unauthorisedAccessEnabled);
+    }
+}

--- a/hermes-api/src/main/java/pl/allegro/tech/hermes/api/Topic.java
+++ b/hermes-api/src/main/java/pl/allegro/tech/hermes/api/Topic.java
@@ -53,10 +53,12 @@ public class Topic {
 
     private boolean schemaVersionAwareSerializationEnabled = false;
 
+    private PublishingAuth publishingAuth;
+
     public Topic(TopicName name, String description, OwnerId owner, RetentionTime retentionTime,
                  boolean migratedFromJsonType, Ack ack, boolean trackingEnabled, ContentType contentType,
                  boolean jsonToAvroDryRunEnabled, boolean schemaVersionAwareSerializationEnabled,
-                 int maxMessageSize) {
+                 int maxMessageSize, PublishingAuth publishingAuth) {
         this.name = name;
         this.description = description;
         this.owner = owner;
@@ -68,6 +70,7 @@ public class Topic {
         this.jsonToAvroDryRunEnabled = jsonToAvroDryRunEnabled;
         this.schemaVersionAwareSerializationEnabled = schemaVersionAwareSerializationEnabled;
         this.maxMessageSize = maxMessageSize;
+        this.publishingAuth = publishingAuth;
     }
 
     @JsonCreator
@@ -82,10 +85,13 @@ public class Topic {
             @JsonProperty("migratedFromJsonType") boolean migratedFromJsonType,
             @JsonProperty("schemaVersionAwareSerializationEnabled") boolean schemaVersionAwareSerializationEnabled,
             @JsonProperty("contentType") ContentType contentType,
-            @JsonProperty("maxMessageSize") Integer maxMessageSize) {
+            @JsonProperty("maxMessageSize") Integer maxMessageSize,
+            @JsonProperty("auth") PublishingAuth publishingAuth
+            ) {
         this(TopicName.fromQualifiedName(qualifiedName), description, owner, retentionTime, migratedFromJsonType, ack,
                 trackingEnabled, contentType, jsonToAvroDryRunEnabled, schemaVersionAwareSerializationEnabled,
-                maxMessageSize == null ? DEFAULT_MAX_MESSAGE_SIZE : maxMessageSize);
+                maxMessageSize == null ? DEFAULT_MAX_MESSAGE_SIZE : maxMessageSize,
+                publishingAuth == null ? PublishingAuth.disabled() : publishingAuth);
     }
 
     public RetentionTime getRetentionTime() {
@@ -95,7 +101,7 @@ public class Topic {
     @Override
     public int hashCode() {
         return Objects.hash(name, description, owner, retentionTime, migratedFromJsonType, trackingEnabled, ack, contentType,
-                jsonToAvroDryRunEnabled, schemaVersionAwareSerializationEnabled, maxMessageSize);
+                jsonToAvroDryRunEnabled, schemaVersionAwareSerializationEnabled, maxMessageSize, publishingAuth);
     }
 
     @Override
@@ -118,7 +124,8 @@ public class Topic {
                 && Objects.equals(this.schemaVersionAwareSerializationEnabled, other.schemaVersionAwareSerializationEnabled)
                 && Objects.equals(this.ack, other.ack)
                 && Objects.equals(this.contentType, other.contentType)
-                && Objects.equals(this.maxMessageSize, other.maxMessageSize);
+                && Objects.equals(this.maxMessageSize, other.maxMessageSize)
+                && Objects.equals(this.publishingAuth, other.publishingAuth);
     }
 
     @JsonProperty("name")
@@ -172,6 +179,25 @@ public class Topic {
 
     public int getMaxMessageSize() {
         return maxMessageSize;
+    }
+
+    @JsonProperty("auth")
+    public PublishingAuth getPublishingAuth() {
+        return publishingAuth;
+    }
+
+    @JsonIgnore
+    public boolean isAuthEnabled() {
+        return publishingAuth.isEnabled();
+    }
+
+    @JsonIgnore
+    public boolean isUnauthorisedAccessEnabled() {
+        return publishingAuth.isUnauthorisedAccessEnabled();
+    }
+
+    public boolean hasPermission(String publisher) {
+        return publishingAuth.hasPermission(publisher);
     }
 
     @Override

--- a/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/publishing/handlers/HandlersChainFactory.java
+++ b/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/publishing/handlers/HandlersChainFactory.java
@@ -84,7 +84,7 @@ public class HandlersChainFactory implements Factory<HttpHandler> {
     private HttpHandler createAuthenticationHandlersChain(HttpHandler next, AuthenticationConfiguration authConfig) {
         HttpHandler authenticationCallHandler = new AuthenticationCallHandler(next);
         HttpHandler constraintHandler = new AuthenticationPredicateAwareConstraintHandler(
-                authenticationCallHandler, authConfig.getAuthConstraintPredicate());
+                authenticationCallHandler, authConfig.getIsAuthenticationRequiredPredicate());
 
         HttpHandler mechanismsHandler = new AuthenticationMechanismsHandler(constraintHandler,
                 authConfig.getAuthMechanisms());

--- a/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/server/auth/AuthenticationConfiguration.java
+++ b/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/server/auth/AuthenticationConfiguration.java
@@ -10,24 +10,24 @@ import java.util.function.Predicate;
 
 public class AuthenticationConfiguration {
 
-    private final Predicate<HttpServerExchange> authConstraintPredicate;
+    private final Predicate<HttpServerExchange> isAuthenticationRequiredPredicate;
     private final List<AuthenticationMechanism> authMechanisms;
     private final IdentityManager identityManager;
 
-    public AuthenticationConfiguration(Predicate<HttpServerExchange> authConstraintPredicate,
+    public AuthenticationConfiguration(Predicate<HttpServerExchange> isAuthenticationRequiredPredicate,
                                 List<AuthenticationMechanism> authMechanisms,
                                 IdentityManager identityManager) {
-        Preconditions.checkNotNull(authConstraintPredicate, "Authentication constraint predicate has to be provided");
+        Preconditions.checkNotNull(isAuthenticationRequiredPredicate, "IsAuthenticationRequired predicate has to be provided");
         Preconditions.checkArgument(!authMechanisms.isEmpty(), "At least one AuthenticationMechanism has to be provided.");
         Preconditions.checkNotNull(identityManager, "IdentityManager has to be provided");
 
-        this.authConstraintPredicate = authConstraintPredicate;
+        this.isAuthenticationRequiredPredicate = isAuthenticationRequiredPredicate;
         this.authMechanisms = authMechanisms;
         this.identityManager = identityManager;
     }
 
-    public Predicate<HttpServerExchange> getAuthConstraintPredicate() {
-        return authConstraintPredicate;
+    public Predicate<HttpServerExchange> getIsAuthenticationRequiredPredicate() {
+        return isAuthenticationRequiredPredicate;
     }
 
     public List<AuthenticationMechanism> getAuthMechanisms() {

--- a/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/server/auth/Roles.java
+++ b/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/server/auth/Roles.java
@@ -1,0 +1,5 @@
+package pl.allegro.tech.hermes.frontend.server.auth;
+
+public interface Roles {
+    String PUBLISHER = "PUBLISHER";
+}

--- a/hermes-test-helper/src/main/java/pl/allegro/tech/hermes/test/helper/builder/TopicBuilder.java
+++ b/hermes-test-helper/src/main/java/pl/allegro/tech/hermes/test/helper/builder/TopicBuilder.java
@@ -2,6 +2,9 @@ package pl.allegro.tech.hermes.test.helper.builder;
 
 import pl.allegro.tech.hermes.api.*;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public class TopicBuilder {
 
     private final TopicName name;
@@ -26,6 +29,12 @@ public class TopicBuilder {
 
     private int maxMessageSize = 1024 * 1024;
 
+    private List<String> publishers = new ArrayList<>();
+
+    private boolean authEnabled = false;
+
+    private boolean unauthorisedAccessEnabled = true;
+
     private TopicBuilder(TopicName topicName) {
         this.name = topicName;
     }
@@ -45,7 +54,8 @@ public class TopicBuilder {
     public Topic build() {
         return new Topic(
                 name, description, owner, retentionTime, migratedFromJsonType, ack, trackingEnabled, contentType,
-                jsonToAvroDryRunEnabled, schemaVersionAwareSerialization, maxMessageSize
+                jsonToAvroDryRunEnabled, schemaVersionAwareSerialization, maxMessageSize,
+                new PublishingAuth(publishers, authEnabled, unauthorisedAccessEnabled)
         );
     }
 
@@ -101,6 +111,21 @@ public class TopicBuilder {
 
     public TopicBuilder withMaxMessageSize(int size) {
         this.maxMessageSize = size;
+        return this;
+    }
+
+    public TopicBuilder withPublisher(String serviceName) {
+        this.publishers.add(serviceName);
+        return this;
+    }
+
+    public TopicBuilder withAuthEnabled() {
+        this.authEnabled = true;
+        return this;
+    }
+
+    public TopicBuilder withUnauthorisedAccessDisabled() {
+        this.unauthorisedAccessEnabled = false;
         return this;
     }
 }

--- a/integration/src/integration/java/pl/allegro/tech/hermes/integration/auth/SingleUserAwareIdentityManager.java
+++ b/integration/src/integration/java/pl/allegro/tech/hermes/integration/auth/SingleUserAwareIdentityManager.java
@@ -1,0 +1,87 @@
+package pl.allegro.tech.hermes.integration.auth;
+
+import io.undertow.security.idm.Account;
+import io.undertow.security.idm.Credential;
+import io.undertow.security.idm.IdentityManager;
+import io.undertow.security.idm.PasswordCredential;
+import org.apache.commons.codec.binary.Base64;
+import pl.allegro.tech.hermes.frontend.server.auth.Roles;
+
+import java.nio.charset.StandardCharsets;
+import java.security.Principal;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+public class SingleUserAwareIdentityManager implements IdentityManager {
+
+    private final String username;
+    private final String password;
+
+    SingleUserAwareIdentityManager(String username, String password) {
+        this.username = username;
+        this.password = password;
+    }
+
+    @Override
+    public Account verify(Account account) {
+        return null;
+    }
+
+    @Override
+    public Account verify(String username, Credential credential) {
+        String password = new String(((PasswordCredential) credential).getPassword());
+        if (this.username.equals(username) && this.password.equals(password)) {
+            return new SomeUserAccount(username);
+        }
+        return null;
+    }
+
+    @Override
+    public Account verify(Credential credential) {
+        return null;
+    }
+
+    private final class SomeUserAccount implements Account {
+
+        private final Principal principal;
+
+        private SomeUserAccount(String username) {
+            this.principal = new SomeUserPrincipal(username);
+        }
+
+        @Override
+        public Principal getPrincipal() {
+            return principal;
+        }
+
+        @Override
+        public Set<String> getRoles() {
+            return Collections.singleton(Roles.PUBLISHER);
+        }
+    }
+
+    private final class SomeUserPrincipal implements Principal {
+
+        private final String username;
+
+        private SomeUserPrincipal(String username) {
+            this.username = username;
+        }
+
+        @Override
+        public String getName() {
+            return username;
+        }
+    }
+
+    static Map<String, String> getHeadersWithAuthentication(String username, String password) {
+        String credentials = username + ":" + password;
+        String token = "Basic " + Base64.encodeBase64String(credentials.getBytes(StandardCharsets.UTF_8));
+
+        Map<String, String> headers = new HashMap<>();
+        headers.put("Authorization", token);
+        return headers;
+    }
+}

--- a/integration/src/integration/java/pl/allegro/tech/hermes/integration/auth/TopicAuthorisationTest.java
+++ b/integration/src/integration/java/pl/allegro/tech/hermes/integration/auth/TopicAuthorisationTest.java
@@ -1,0 +1,208 @@
+package pl.allegro.tech.hermes.integration.auth;
+
+import avro.shaded.com.google.common.collect.Lists;
+import io.undertow.security.impl.BasicAuthenticationMechanism;
+import io.undertow.util.StatusCodes;
+import org.assertj.core.description.Description;
+import org.assertj.core.description.TextDescription;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import pl.allegro.tech.hermes.api.Topic;
+import pl.allegro.tech.hermes.common.config.ConfigFactory;
+import pl.allegro.tech.hermes.common.config.Configs;
+import pl.allegro.tech.hermes.frontend.HermesFrontend;
+import pl.allegro.tech.hermes.frontend.server.auth.AuthenticationConfiguration;
+import pl.allegro.tech.hermes.integration.IntegrationTest;
+import pl.allegro.tech.hermes.test.helper.builder.TopicBuilder;
+import pl.allegro.tech.hermes.test.helper.config.MutableConfigFactory;
+import pl.allegro.tech.hermes.test.helper.endpoint.HermesPublisher;
+import pl.allegro.tech.hermes.test.helper.message.TestMessage;
+import pl.allegro.tech.hermes.test.helper.util.Ports;
+
+import javax.ws.rs.core.Response;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import static javax.ws.rs.core.Response.Status.Family.SUCCESSFUL;
+import static pl.allegro.tech.hermes.integration.auth.SingleUserAwareIdentityManager.getHeadersWithAuthentication;
+import static pl.allegro.tech.hermes.integration.test.HermesAssertions.assertThat;
+
+public class TopicAuthorisationTest extends IntegrationTest {
+
+    public static final int FRONTEND_PORT = Ports.nextAvailable();
+    public static final String FRONTEND_URL = "http://127.0.0.1:" + FRONTEND_PORT;
+
+    private static final String USERNAME = "someUser";
+    private static final String PASSWORD = "somePassword123";
+    private static final String MESSAGE = TestMessage.of("hello", "world").body();
+
+    private static final String USERNAME2 = "foobar";
+
+    protected HermesPublisher publisher;
+
+    private HermesFrontend hermesFrontend;
+
+    @BeforeClass
+    public void setup() throws Exception {
+        ConfigFactory configFactory = new MutableConfigFactory()
+                .overrideProperty(Configs.FRONTEND_PORT, FRONTEND_PORT)
+                .overrideProperty(Configs.FRONTEND_SSL_ENABLED, false)
+                .overrideProperty(Configs.FRONTEND_AUTHENTICATION_MODE, "pro_active")
+                .overrideProperty(Configs.FRONTEND_AUTHENTICATION_ENABLED, true);
+
+        AuthenticationConfiguration authConfig = new AuthenticationConfiguration(
+                exchange -> false,
+                Lists.newArrayList(new BasicAuthenticationMechanism("basicAuthRealm")),
+                new SingleUserAwareIdentityManager(USERNAME, PASSWORD));
+
+        hermesFrontend = HermesFrontend.frontend()
+                .withBinding(configFactory, ConfigFactory.class)
+                .withAuthenticationConfiguration(authConfig)
+                .build();
+
+        hermesFrontend.start();
+
+        publisher = new HermesPublisher(FRONTEND_URL);
+
+        operations.buildTopic("someGroup", "topicWithAuthorization");
+    }
+
+    @AfterClass
+    public void tearDown() throws InterruptedException {
+        hermesFrontend.stop();
+    }
+
+    @Test
+    public void shouldPublishWhenAuthenticated() {
+        // given
+        List<Topic> topics = Arrays.asList(
+                TopicBuilder.topic("disabled.authenticated")
+                        .build(),
+                TopicBuilder.topic("enabled.authenticated_1Publisher")
+                        .withPublisher(USERNAME)
+                        .withAuthEnabled()
+                        .build(),
+                TopicBuilder.topic("enabled.authenticated_2Publishers")
+                        .withPublisher(USERNAME)
+                        .withPublisher(USERNAME2)
+                        .withAuthEnabled()
+                        .build(),
+                TopicBuilder.topic("required.authenticated_1Publisher")
+                        .withPublisher(USERNAME)
+                        .withAuthEnabled()
+                        .withUnauthorisedAccessDisabled()
+                        .build(),
+                TopicBuilder.topic("required.authenticated_2Publishers")
+                        .withPublisher(USERNAME)
+                        .withPublisher(USERNAME2)
+                        .withAuthEnabled()
+                        .withUnauthorisedAccessDisabled()
+                        .build()
+        );
+
+        topics.forEach(operations::buildTopic);
+
+        Map<String, String> headers = getHeadersWithAuthentication(USERNAME, PASSWORD);
+
+        topics.forEach(topic -> {
+            // when
+            Response response = publisher.publish(topic.getQualifiedName(), MESSAGE, headers);
+
+            // then
+            assertThat(response.getStatusInfo().getFamily()).as(description(topic)).isEqualTo(SUCCESSFUL);
+        });
+    }
+
+    @Test
+    public void shouldPublishAsGuestWhenAuthIsNotRequired() {
+        // given
+        List<Topic> topics = Arrays.asList(
+                TopicBuilder.topic("disabled.guest")
+                        .build(),
+                TopicBuilder.topic("enabled.guest_0Publishers")
+                        .withAuthEnabled()
+                        .build(),
+                TopicBuilder.topic("enabled.guest_1Publisher")
+                        .withPublisher(USERNAME2)
+                        .withAuthEnabled()
+                        .build()
+        );
+
+        topics.forEach(operations::buildTopic);
+
+        topics.forEach(topic -> {
+            // when
+            Response response = publisher.publish(topic.getQualifiedName(), MESSAGE);
+
+            // then
+            assertThat(response.getStatusInfo().getFamily()).as(description(topic)).isEqualTo(SUCCESSFUL);
+        });
+    }
+
+    @Test
+    public void shouldNotPublishAsGuestWhenAuthIsRequired() {
+        // given
+        List<Topic> topics = Arrays.asList(
+                TopicBuilder.topic("required.guest_0Publishers")
+                        .withAuthEnabled()
+                        .withUnauthorisedAccessDisabled()
+                        .build(),
+                TopicBuilder.topic("required.guest_1Publisher")
+                        .withPublisher(USERNAME2)
+                        .withAuthEnabled()
+                        .withUnauthorisedAccessDisabled()
+                        .build()
+        );
+
+        topics.forEach(operations::buildTopic);
+
+        topics.forEach(topic -> {
+            // when
+            Response response = publisher.publish(topic.getQualifiedName(), MESSAGE);
+
+            // then
+            assertThat(response.getStatus()).as(description(topic)).isEqualTo(StatusCodes.FORBIDDEN);
+        });
+    }
+
+    @Test
+    public void shouldNotPublishWithoutPermissionWhenAuthenticated() {
+        // given
+        List<Topic> topics = Arrays.asList(
+                TopicBuilder.topic("enabled.authenticated_no_permission_0Publishers")
+                        .withAuthEnabled()
+                        .build(),
+                TopicBuilder.topic("enabled.authenticated_no_permission_1Publisher")
+                        .withPublisher(USERNAME2)
+                        .withAuthEnabled()
+                        .build(),
+                TopicBuilder.topic("required.authenticated_no_permission_0Publishers")
+                        .withAuthEnabled()
+                        .withUnauthorisedAccessDisabled()
+                        .build(),
+                TopicBuilder.topic("required.authenticated_no_permission_1Publisher")
+                        .withPublisher(USERNAME2)
+                        .withAuthEnabled()
+                        .withUnauthorisedAccessDisabled()
+                        .build()
+        );
+
+        topics.forEach(operations::buildTopic);
+
+        Map<String, String> headers = getHeadersWithAuthentication(USERNAME, PASSWORD);
+
+        topics.forEach(topic -> {
+            // when
+            Response response = publisher.publish(topic.getQualifiedName(), MESSAGE, headers);
+
+            // then
+            assertThat(response.getStatus()).as(description(topic)).isEqualTo(StatusCodes.FORBIDDEN);
+        });
+    }
+
+    private Description description(Topic topic) {
+        return new TextDescription("topic=%s", topic.getQualifiedName());
+    }
+}


### PR DESCRIPTION
Added simple authorisation mechanism for publishing. It is based on service name extracted from SecurityContext. User can configure which service can publish on particular topic via **topic.auth.publishers** field.