### PR TITLE
728 payload content-type check & error handling

### DIFF
--- a/hermes-api/src/main/java/pl/allegro/tech/hermes/api/AvroMediaType.java
+++ b/hermes-api/src/main/java/pl/allegro/tech/hermes/api/AvroMediaType.java
@@ -1,4 +1,4 @@
-package pl.allegro.tech.hermes.consumers.consumer.sender.http;
+package pl.allegro.tech.hermes.api;
 
 public class AvroMediaType {
 

--- a/hermes-api/src/main/java/pl/allegro/tech/hermes/api/endpoints/TopicEndpoint.java
+++ b/hermes-api/src/main/java/pl/allegro/tech/hermes/api/endpoints/TopicEndpoint.java
@@ -14,11 +14,11 @@ import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
-import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.util.List;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+import static pl.allegro.tech.hermes.api.AvroMediaType.AVRO_BINARY;
 
 @Path("topics")
 public interface TopicEndpoint {
@@ -69,7 +69,7 @@ public interface TopicEndpoint {
     Response publishMessage(@PathParam("topicName") String qualifiedTopicName, String message);
 
     @POST
-    @Consumes(MediaType.TEXT_PLAIN)
+    @Consumes(AVRO_BINARY)
     @Produces(APPLICATION_JSON)
     @Path("/{topicName}")
     Response publishMessage(@PathParam("topicName") String qualifiedTopicName, byte[] message);

--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/common/message/wrapper/UnsupportedContentTypeException.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/common/message/wrapper/UnsupportedContentTypeException.java
@@ -1,5 +1,6 @@
 package pl.allegro.tech.hermes.common.message.wrapper;
 
+import org.apache.avro.Schema;
 import pl.allegro.tech.hermes.api.Subscription;
 import pl.allegro.tech.hermes.api.Topic;
 import pl.allegro.tech.hermes.common.exception.InternalProcessingException;
@@ -19,6 +20,14 @@ public class UnsupportedContentTypeException extends InternalProcessingException
                 "Unsupported content type %s for subscription %s",
                 subscription.getContentType(),
                 subscription.getQualifiedName()
+        ));
+    }
+
+    public UnsupportedContentTypeException(String payloadContentType, Schema schema) {
+        super(String.format(
+                "Unsupported payload content type %s for %s",
+                payloadContentType,
+                schema.getFullName()
         ));
     }
 

--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/common/message/wrapper/UnsupportedContentTypeException.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/common/message/wrapper/UnsupportedContentTypeException.java
@@ -1,6 +1,5 @@
 package pl.allegro.tech.hermes.common.message.wrapper;
 
-import org.apache.avro.Schema;
 import pl.allegro.tech.hermes.api.Subscription;
 import pl.allegro.tech.hermes.api.Topic;
 import pl.allegro.tech.hermes.common.exception.InternalProcessingException;
@@ -23,11 +22,11 @@ public class UnsupportedContentTypeException extends InternalProcessingException
         ));
     }
 
-    public UnsupportedContentTypeException(String payloadContentType, Schema schema) {
+    public UnsupportedContentTypeException(String payloadContentType, Topic topic) {
         super(String.format(
-                "Unsupported payload content type %s for %s",
+                "Unsupported payload content type header %s for topic %s",
                 payloadContentType,
-                schema.getFullName()
+                topic.getQualifiedName()
         ));
     }
 

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/sender/http/ApacheHttpClientMessageBatchSender.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/sender/http/ApacheHttpClientMessageBatchSender.java
@@ -20,7 +20,7 @@ import java.net.URI;
 import static pl.allegro.tech.hermes.api.ContentType.AVRO;
 import static pl.allegro.tech.hermes.common.http.MessageMetadataHeaders.BATCH_ID;
 import static pl.allegro.tech.hermes.common.http.MessageMetadataHeaders.RETRY_COUNT;
-import static pl.allegro.tech.hermes.consumers.consumer.sender.http.AvroMediaType.AVRO_BINARY;
+import static pl.allegro.tech.hermes.api.AvroMediaType.AVRO_BINARY;
 
 public class ApacheHttpClientMessageBatchSender implements MessageBatchSender {
 

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/sender/http/HttpRequestFactory.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/sender/http/HttpRequestFactory.java
@@ -21,7 +21,7 @@ import static pl.allegro.tech.hermes.api.ContentType.AVRO;
 import static pl.allegro.tech.hermes.common.http.MessageMetadataHeaders.MESSAGE_ID;
 import static pl.allegro.tech.hermes.common.http.MessageMetadataHeaders.RETRY_COUNT;
 import static pl.allegro.tech.hermes.common.http.MessageMetadataHeaders.SCHEMA_VERSION;
-import static pl.allegro.tech.hermes.consumers.consumer.sender.http.AvroMediaType.AVRO_BINARY;
+import static pl.allegro.tech.hermes.api.AvroMediaType.AVRO_BINARY;
 
 class HttpRequestFactory {
 

--- a/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/publishing/message/MessageContentTypeEnforcer.java
+++ b/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/publishing/message/MessageContentTypeEnforcer.java
@@ -1,25 +1,39 @@
 package pl.allegro.tech.hermes.frontend.publishing.message;
 
 import org.apache.avro.Schema;
+import pl.allegro.tech.hermes.common.message.wrapper.UnsupportedContentTypeException;
 import tech.allegro.schema.json2avro.converter.JsonAvroConverter;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+import static pl.allegro.tech.hermes.api.AvroMediaType.AVRO_BINARY;
 
 public class MessageContentTypeEnforcer {
 
     private final JsonAvroConverter converter = new JsonAvroConverter();
 
     private static final String APPLICATION_JSON_WITH_DELIM = APPLICATION_JSON + ";";
+    private static final String AVRO_BINARY_WITH_DELIM = AVRO_BINARY + ";";
 
     public byte[] enforceAvro(String payloadContentType, byte[] data, Schema schema) {
         if (isJSON(payloadContentType)) {
             return converter.convertToAvro(data, schema);
+        } else if (isAvro(payloadContentType)) {
+            return data;
+        } else {
+            throw new UnsupportedContentTypeException(payloadContentType, schema);
         }
-        return data;
     }
 
     private boolean isJSON(String contentType) {
-        return contentType != null && (contentType.length() > APPLICATION_JSON.length() ?
-                contentType.startsWith(APPLICATION_JSON_WITH_DELIM) : contentType.equals(APPLICATION_JSON));
+        return isOfType(contentType, APPLICATION_JSON, APPLICATION_JSON_WITH_DELIM);
+    }
+
+    private boolean isAvro(String contentType) {
+        return isOfType(contentType, AVRO_BINARY, AVRO_BINARY_WITH_DELIM);
+    }
+
+    private boolean isOfType(String contentType, String expectedContentType, String expectedWithDelim) {
+        return contentType != null && (contentType.length() > expectedContentType.length() ?
+                contentType.startsWith(expectedWithDelim) : contentType.equals(expectedContentType));
     }
 }

--- a/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/publishing/message/MessageContentTypeEnforcer.java
+++ b/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/publishing/message/MessageContentTypeEnforcer.java
@@ -1,6 +1,7 @@
 package pl.allegro.tech.hermes.frontend.publishing.message;
 
 import org.apache.avro.Schema;
+import org.apache.commons.lang.StringUtils;
 import pl.allegro.tech.hermes.common.message.wrapper.UnsupportedContentTypeException;
 import tech.allegro.schema.json2avro.converter.JsonAvroConverter;
 
@@ -15,9 +16,10 @@ public class MessageContentTypeEnforcer {
     private static final String AVRO_BINARY_WITH_DELIM = AVRO_BINARY + ";";
 
     public byte[] enforceAvro(String payloadContentType, byte[] data, Schema schema) {
-        if (isJSON(payloadContentType)) {
+        String contentTypeLowerCase = StringUtils.lowerCase(payloadContentType);
+        if (isJSON(contentTypeLowerCase)) {
             return converter.convertToAvro(data, schema);
-        } else if (isAvro(payloadContentType)) {
+        } else if (isAvro(contentTypeLowerCase)) {
             return data;
         } else {
             throw new UnsupportedContentTypeException(payloadContentType, schema);

--- a/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/publishing/message/MessageContentTypeEnforcer.java
+++ b/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/publishing/message/MessageContentTypeEnforcer.java
@@ -2,6 +2,7 @@ package pl.allegro.tech.hermes.frontend.publishing.message;
 
 import org.apache.avro.Schema;
 import org.apache.commons.lang.StringUtils;
+import pl.allegro.tech.hermes.api.Topic;
 import pl.allegro.tech.hermes.common.message.wrapper.UnsupportedContentTypeException;
 import tech.allegro.schema.json2avro.converter.JsonAvroConverter;
 
@@ -15,14 +16,14 @@ public class MessageContentTypeEnforcer {
     private static final String APPLICATION_JSON_WITH_DELIM = APPLICATION_JSON + ";";
     private static final String AVRO_BINARY_WITH_DELIM = AVRO_BINARY + ";";
 
-    public byte[] enforceAvro(String payloadContentType, byte[] data, Schema schema) {
+    public byte[] enforceAvro(String payloadContentType, byte[] data, Schema schema, Topic topic) {
         String contentTypeLowerCase = StringUtils.lowerCase(payloadContentType);
         if (isJSON(contentTypeLowerCase)) {
             return converter.convertToAvro(data, schema);
         } else if (isAvro(contentTypeLowerCase)) {
             return data;
         } else {
-            throw new UnsupportedContentTypeException(payloadContentType, schema);
+            throw new UnsupportedContentTypeException(payloadContentType, topic);
         }
     }
 
@@ -35,7 +36,6 @@ public class MessageContentTypeEnforcer {
     }
 
     private boolean isOfType(String contentType, String expectedContentType, String expectedWithDelim) {
-        return contentType != null && (contentType.length() > expectedContentType.length() ?
-                contentType.startsWith(expectedWithDelim) : contentType.equals(expectedContentType));
+        return contentType != null && (contentType.equals(expectedContentType) || contentType.startsWith(expectedWithDelim));
     }
 }

--- a/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/publishing/message/MessageFactory.java
+++ b/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/publishing/message/MessageFactory.java
@@ -101,7 +101,7 @@ public class MessageFactory {
 
         AvroMessage message = new AvroMessage(
                 messageId,
-                enforcer.enforceAvro(headerMap.getFirst(Headers.CONTENT_TYPE_STRING), messageContent, schema.getSchema()),
+                enforcer.enforceAvro(headerMap.getFirst(Headers.CONTENT_TYPE_STRING), messageContent, schema.getSchema(), topic),
                 timestamp,
                 schema);
 

--- a/hermes-frontend/src/test/java/pl/allegro/tech/hermes/frontend/publishing/message/MessageContentTypeEnforcerTest.java
+++ b/hermes-frontend/src/test/java/pl/allegro/tech/hermes/frontend/publishing/message/MessageContentTypeEnforcerTest.java
@@ -2,10 +2,13 @@ package pl.allegro.tech.hermes.frontend.publishing.message;
 
 import org.apache.avro.Schema;
 import org.junit.Test;
+import pl.allegro.tech.hermes.api.ContentType;
+import pl.allegro.tech.hermes.api.Topic;
 import pl.allegro.tech.hermes.common.message.wrapper.UnsupportedContentTypeException;
 import pl.allegro.tech.hermes.schema.CompiledSchema;
 import pl.allegro.tech.hermes.schema.SchemaVersion;
 import pl.allegro.tech.hermes.test.helper.avro.AvroUser;
+import pl.allegro.tech.hermes.test.helper.builder.TopicBuilder;
 
 import javax.ws.rs.core.MediaType;
 import java.io.IOException;
@@ -16,13 +19,14 @@ public class MessageContentTypeEnforcerTest {
 
     private MessageContentTypeEnforcer enforcer = new MessageContentTypeEnforcer();
 
+    private Topic topic = TopicBuilder.topic("test.Topic").withContentType(ContentType.AVRO).build();
     private AvroUser avroMessage = new AvroUser("Bob", 30, "black");
     private CompiledSchema<Schema> schema = new CompiledSchema<>(avroMessage.getSchema(), SchemaVersion.valueOf(0));
 
     @Test
     public void shouldConvertToAvroWhenReceivedJSONOnAvroTopic() throws IOException {
         // when
-        byte[] enforcedMessage = enforcer.enforceAvro("application/json", avroMessage.asJson().getBytes(), schema.getSchema());
+        byte[] enforcedMessage = enforcer.enforceAvro("application/json", avroMessage.asJson().getBytes(), schema.getSchema(), topic);
 
         // then
         assertThat(enforcedMessage).isEqualTo(avroMessage.asBytes());
@@ -31,7 +35,7 @@ public class MessageContentTypeEnforcerTest {
     @Test
     public void shouldStringContentTypeOfAdditionalOptionsWhenInterpretingIt() throws IOException {
         // when
-        byte[] enforcedMessage = enforcer.enforceAvro("application/json;encoding=utf-8", avroMessage.asJson().getBytes(), schema.getSchema());
+        byte[] enforcedMessage = enforcer.enforceAvro("application/json;encoding=utf-8", avroMessage.asJson().getBytes(), schema.getSchema(), topic);
 
         // then
         assertThat(enforcedMessage).isEqualTo(avroMessage.asBytes());
@@ -40,7 +44,7 @@ public class MessageContentTypeEnforcerTest {
     @Test
     public void shouldNotConvertWhenReceivingAvroOnAvroTopic() throws IOException {
         // when
-        byte[] enforcedMessage = enforcer.enforceAvro("avro/binary", avroMessage.asBytes(), schema.getSchema());
+        byte[] enforcedMessage = enforcer.enforceAvro("avro/binary", avroMessage.asBytes(), schema.getSchema(), topic);
 
         // then
         assertThat(enforcedMessage).isEqualTo(avroMessage.asBytes());
@@ -49,7 +53,7 @@ public class MessageContentTypeEnforcerTest {
     @Test
     public void shouldBeCaseInsensitiveForPayloadContentType() throws IOException {
         // when
-        byte[] enforcedMessage = enforcer.enforceAvro("AVRO/Binary", avroMessage.asBytes(), schema.getSchema());
+        byte[] enforcedMessage = enforcer.enforceAvro("AVRO/Binary", avroMessage.asBytes(), schema.getSchema(), topic);
 
         // then
         assertThat(enforcedMessage).isEqualTo(avroMessage.asBytes());
@@ -58,7 +62,7 @@ public class MessageContentTypeEnforcerTest {
     @Test(expected = UnsupportedContentTypeException.class)
     public void shouldThrowUnsupportedContentTypeExceptionWhenReceivedWrongContentType() throws IOException {
         // when
-        enforcer.enforceAvro(MediaType.TEXT_PLAIN, avroMessage.asBytes(), schema.getSchema());
+        enforcer.enforceAvro(MediaType.TEXT_PLAIN, avroMessage.asBytes(), schema.getSchema(), topic);
     }
 
 }

--- a/hermes-frontend/src/test/java/pl/allegro/tech/hermes/frontend/publishing/message/MessageContentTypeEnforcerTest.java
+++ b/hermes-frontend/src/test/java/pl/allegro/tech/hermes/frontend/publishing/message/MessageContentTypeEnforcerTest.java
@@ -2,10 +2,12 @@ package pl.allegro.tech.hermes.frontend.publishing.message;
 
 import org.apache.avro.Schema;
 import org.junit.Test;
+import pl.allegro.tech.hermes.common.message.wrapper.UnsupportedContentTypeException;
 import pl.allegro.tech.hermes.schema.CompiledSchema;
 import pl.allegro.tech.hermes.schema.SchemaVersion;
 import pl.allegro.tech.hermes.test.helper.avro.AvroUser;
 
+import javax.ws.rs.core.MediaType;
 import java.io.IOException;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -42,6 +44,12 @@ public class MessageContentTypeEnforcerTest {
 
         // then
         assertThat(enforcedMessage).isEqualTo(avroMessage.asBytes());
+    }
+
+    @Test(expected = UnsupportedContentTypeException.class)
+    public void shouldThrowUnsupportedContentTypeExceptionWhenReceivedWrongContentType() throws IOException {
+        // when
+        enforcer.enforceAvro(MediaType.TEXT_PLAIN, avroMessage.asBytes(), schema.getSchema());
     }
 
 }

--- a/hermes-frontend/src/test/java/pl/allegro/tech/hermes/frontend/publishing/message/MessageContentTypeEnforcerTest.java
+++ b/hermes-frontend/src/test/java/pl/allegro/tech/hermes/frontend/publishing/message/MessageContentTypeEnforcerTest.java
@@ -46,6 +46,15 @@ public class MessageContentTypeEnforcerTest {
         assertThat(enforcedMessage).isEqualTo(avroMessage.asBytes());
     }
 
+    @Test
+    public void shouldBeCaseInsensitiveForPayloadContentType() throws IOException {
+        // when
+        byte[] enforcedMessage = enforcer.enforceAvro("AVRO/Binary", avroMessage.asBytes(), schema.getSchema());
+
+        // then
+        assertThat(enforcedMessage).isEqualTo(avroMessage.asBytes());
+    }
+
     @Test(expected = UnsupportedContentTypeException.class)
     public void shouldThrowUnsupportedContentTypeExceptionWhenReceivedWrongContentType() throws IOException {
         // when


### PR DESCRIPTION
Added check which accepts only "binary/avro" or "application/json" message content-type.
In other cases,  http status 400 and proper error message will be returned.

#728