### PR TITLE
634 added latency metrics for schema registry

### DIFF
--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/common/metric/HermesMetrics.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/common/metric/HermesMetrics.java
@@ -9,6 +9,7 @@ import com.codahale.metrics.Timer;
 import pl.allegro.tech.hermes.api.Subscription;
 import pl.allegro.tech.hermes.api.TopicName;
 import pl.allegro.tech.hermes.common.metric.timer.ConsumerLatencyTimer;
+import pl.allegro.tech.hermes.common.schema.SchemaRepositoryType;
 import pl.allegro.tech.hermes.metrics.PathContext;
 import pl.allegro.tech.hermes.metrics.PathsCompiler;
 
@@ -177,8 +178,8 @@ public class HermesMetrics {
         return pathCompiler.compile(metricDisplayName);
     }
 
-    public Timer schemaTimer(String schemaMetric, String schemaRepoType) {
-        return metricRegistry.timer(pathCompiler.compile(schemaMetric, pathContext().withSchemaRepoType(schemaRepoType).build()));
+    public Timer schemaTimer(String schemaMetric, SchemaRepositoryType schemaRepoType) {
+        return metricRegistry.timer(pathCompiler.compile(schemaMetric, pathContext().withSchemaRepoType(schemaRepoType.toString()).build()));
     }
 
     public Timer executorDurationTimer(String executorName) {

--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/common/metric/HermesMetrics.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/common/metric/HermesMetrics.java
@@ -177,6 +177,10 @@ public class HermesMetrics {
         return pathCompiler.compile(metricDisplayName);
     }
 
+    public Timer schemaTimer(String schemaMetric, String schemaRepoType) {
+        return metricRegistry.timer(pathCompiler.compile(schemaMetric, pathContext().withSchemaRepoType(schemaRepoType).build()));
+    }
+
     public Timer executorDurationTimer(String executorName) {
         return metricRegistry.timer(pathCompiler.compile(Timers.EXECUTOR_DURATION, pathContext().withExecutorName(executorName).build()));
     }

--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/common/metric/Timers.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/common/metric/Timers.java
@@ -35,8 +35,8 @@ public class Timers {
             READ_LATENCY = "read-latency",
 
             SCHEMA = "schema." + SCHEMA_REPO_TYPE,
-            SCHEMA_READ_LATENCY = SCHEMA + ".read-schema",
-            SCHEMA_VERSIONS_READ_LATENCY = SCHEMA + ".get-schema-versions",
+            GET_SCHEMA_LATENCY = SCHEMA + ".get-schema",
+            GET_SCHEMA_VERSIONS_LATENCY = SCHEMA + ".get-schema-versions",
 
             CONSUMER_WORKLOAD_REBALANCE_DURATION = "consumers-workload." + KAFKA_CLUSTER + ".selective.rebalance-duration",
 

--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/common/metric/Timers.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/common/metric/Timers.java
@@ -6,6 +6,7 @@ import static pl.allegro.tech.hermes.metrics.PathsCompiler.KAFKA_CLUSTER;
 import static pl.allegro.tech.hermes.metrics.PathsCompiler.OAUTH_PROVIDER_NAME;
 import static pl.allegro.tech.hermes.metrics.PathsCompiler.SUBSCRIPTION;
 import static pl.allegro.tech.hermes.metrics.PathsCompiler.TOPIC;
+import static pl.allegro.tech.hermes.metrics.PathsCompiler.SCHEMA_REPO_TYPE;
 
 public class Timers {
 
@@ -32,6 +33,10 @@ public class Timers {
             SUBSCRIPTION_LATENCY = LATENCY + "." + GROUP + "." + TOPIC + "." + SUBSCRIPTION,
 
             READ_LATENCY = "read-latency",
+
+            SCHEMA = "schema." + SCHEMA_REPO_TYPE,
+            SCHEMA_READ_LATENCY = SCHEMA + ".read-schema",
+            SCHEMA_VERSIONS_READ_LATENCY = SCHEMA + ".get-schema-versions",
 
             CONSUMER_WORKLOAD_REBALANCE_DURATION = "consumers-workload." + KAFKA_CLUSTER + ".selective.rebalance-duration",
 

--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/common/metric/timer/StartedTimersPair.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/common/metric/timer/StartedTimersPair.java
@@ -1,4 +1,4 @@
-package pl.allegro.tech.hermes.frontend.metric;
+package pl.allegro.tech.hermes.common.metric.timer;
 
 import com.codahale.metrics.Timer;
 

--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/common/schema/ReadMetricsTrackingRawSchemaClient.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/common/schema/ReadMetricsTrackingRawSchemaClient.java
@@ -1,0 +1,73 @@
+package pl.allegro.tech.hermes.common.schema;
+
+import com.codahale.metrics.Timer;
+import pl.allegro.tech.hermes.api.RawSchema;
+import pl.allegro.tech.hermes.api.TopicName;
+import pl.allegro.tech.hermes.common.metric.HermesMetrics;
+import pl.allegro.tech.hermes.common.metric.Timers;
+import pl.allegro.tech.hermes.schema.RawSchemaClient;
+import pl.allegro.tech.hermes.schema.SchemaVersion;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+public class ReadMetricsTrackingRawSchemaClient implements RawSchemaClient {
+    private final RawSchemaClient rawSchemaClient;
+    private final HermesMetrics hermesMetrics;
+    private SchemaRepositoryType schemaRepoType;
+
+    public ReadMetricsTrackingRawSchemaClient(
+            RawSchemaClient rawSchemaClient,
+            HermesMetrics hermesMetrics,
+            SchemaRepositoryType schemaRepoType) {
+        this.rawSchemaClient = rawSchemaClient;
+        this.hermesMetrics = hermesMetrics;
+        this.schemaRepoType = schemaRepoType;
+    }
+
+    @Override
+    public Optional<RawSchema> getSchema(TopicName topic, SchemaVersion version) {
+        return timedSchema(() -> rawSchemaClient.getSchema(topic, version));
+    }
+
+    @Override
+    public Optional<RawSchema> getLatestSchema(TopicName topic) {
+        return timedSchema(() -> rawSchemaClient.getLatestSchema(topic));
+    }
+
+    @Override
+    public List<SchemaVersion> getVersions(TopicName topic) {
+        return timedVersions(() -> rawSchemaClient.getVersions(topic));
+    }
+
+    @Override
+    public void registerSchema(TopicName topic, RawSchema rawSchema) {
+        rawSchemaClient.registerSchema(topic, rawSchema);
+    }
+
+    @Override
+    public void deleteAllSchemaVersions(TopicName topic) {
+        rawSchemaClient.deleteAllSchemaVersions(topic);
+    }
+
+    private <T> T timedSchema(Supplier<? extends T> callable) {
+        return timed(callable, Timers.SCHEMA_READ_LATENCY);
+    }
+
+    private <T> T timedVersions(Supplier<? extends T> callable) {
+        return timed(callable, Timers.SCHEMA_VERSIONS_READ_LATENCY);
+    }
+
+    private <T> T timed(Supplier<? extends T> callable, String schemaTimer) {
+        Timer.Context time = startLatencyTimer(schemaTimer);
+        T value = callable.get();
+        time.stop();
+        return value;
+    }
+
+    private Timer.Context startLatencyTimer(String schemaReadLatency) {
+        return hermesMetrics.schemaTimer(schemaReadLatency, schemaRepoType.toString()).time();
+    }
+
+}

--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/common/schema/SchemaRepositoryType.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/common/schema/SchemaRepositoryType.java
@@ -1,5 +1,16 @@
 package pl.allegro.tech.hermes.common.schema;
 
 public enum SchemaRepositoryType {
-    SCHEMA_REPO, SCHEMA_REGISTRY
+    SCHEMA_REPO("schema-repo"), SCHEMA_REGISTRY("schema-registry");
+
+    private final String metricName;
+
+    SchemaRepositoryType(String metricName) {
+        this.metricName = metricName;
+    }
+
+    @Override
+    public String toString() {
+        return metricName;
+    }
 }

--- a/hermes-common/src/test/groovy/pl/allegro/tech/hermes/common/schema/ReadMetricsTrackingRawSchemaClientTest.groovy
+++ b/hermes-common/src/test/groovy/pl/allegro/tech/hermes/common/schema/ReadMetricsTrackingRawSchemaClientTest.groovy
@@ -1,0 +1,99 @@
+package pl.allegro.tech.hermes.common.schema
+
+import com.codahale.metrics.Timer
+import pl.allegro.tech.hermes.api.RawSchema
+import pl.allegro.tech.hermes.api.TopicName
+import pl.allegro.tech.hermes.common.metric.HermesMetrics
+import pl.allegro.tech.hermes.common.metric.Timers
+import pl.allegro.tech.hermes.schema.RawSchemaClient
+import pl.allegro.tech.hermes.schema.SchemaVersion
+import spock.lang.Shared
+import spock.lang.Specification
+import spock.lang.Subject
+
+import static pl.allegro.tech.hermes.common.schema.SchemaRepositoryType.SCHEMA_REGISTRY
+
+class ReadMetricsTrackingRawSchemaClientTest extends Specification {
+    @Shared
+    TopicName topicName = TopicName.fromQualifiedName("someGroup.someTopic")
+
+    @Shared
+    SchemaVersion schemaVersion = SchemaVersion.valueOf(1)
+
+    @Shared
+    RawSchema schema = RawSchema.valueOf("some_schema")
+
+    @Shared
+    String REPO_TYPE = SCHEMA_REGISTRY.toString()
+
+    HermesMetrics hermesMetrics = Mock()
+    Timer schemaLatencyTimer = Mock()
+    Timer.Context schemaLatencyTime = Mock()
+    Timer schemaVersionsLatencyTimer = Mock()
+    Timer.Context schemaVersionsLatencyTime = Mock()
+
+    RawSchemaClient rawSchemaClient = Mock()
+
+    @Subject
+    RawSchemaClient readMetricsTrackingClient = new ReadMetricsTrackingRawSchemaClient(rawSchemaClient, hermesMetrics, SCHEMA_REGISTRY)
+
+
+    def "should track latency metrics for schema retrieval"(){
+        when:
+        readMetricsTrackingClient.getSchema(topicName, schemaVersion)
+
+        then:
+        1 * hermesMetrics.schemaTimer(Timers.SCHEMA_READ_LATENCY, REPO_TYPE) >> schemaLatencyTimer
+        1 * schemaLatencyTimer.time() >> schemaLatencyTime
+
+        then:
+        1 * rawSchemaClient.getSchema(topicName, schemaVersion)
+
+        then:
+        1 * schemaLatencyTime.stop()
+    }
+
+    def "should track latency metrics for latest schema retrieval"(){
+        when:
+        readMetricsTrackingClient.getLatestSchema(topicName)
+
+        then:
+        1 * hermesMetrics.schemaTimer(Timers.SCHEMA_READ_LATENCY, REPO_TYPE) >> schemaLatencyTimer
+        1 * schemaLatencyTimer.time() >> schemaLatencyTime
+
+        then:
+        1 * rawSchemaClient.getLatestSchema(topicName)
+
+        then:
+        1 * schemaLatencyTime.stop()
+    }
+
+    def "should track latency metrics for versions retrieval"(){
+        when:
+        readMetricsTrackingClient.getVersions(topicName)
+
+        then:
+        1 * hermesMetrics.schemaTimer(Timers.SCHEMA_VERSIONS_READ_LATENCY, REPO_TYPE) >> schemaVersionsLatencyTimer
+        1 * schemaVersionsLatencyTimer.time() >> schemaVersionsLatencyTime
+
+        then:
+        1 * rawSchemaClient.getVersions(topicName)
+
+        then:
+        1 * schemaVersionsLatencyTime.stop()
+    }
+
+    def "should call inner client for non-read operations"() {
+        when:
+        readMetricsTrackingClient.deleteAllSchemaVersions(topicName)
+
+        then:
+        1 * rawSchemaClient.deleteAllSchemaVersions(topicName)
+
+        when:
+        readMetricsTrackingClient.registerSchema(topicName, schema)
+
+        then:
+        1 * rawSchemaClient.registerSchema(topicName, schema)
+    }
+}

--- a/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/buffer/BackupMessagesLoader.java
+++ b/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/buffer/BackupMessagesLoader.java
@@ -10,7 +10,7 @@ import pl.allegro.tech.hermes.common.config.ConfigFactory;
 import pl.allegro.tech.hermes.frontend.cache.topic.TopicsCache;
 import pl.allegro.tech.hermes.frontend.listeners.BrokerListeners;
 import pl.allegro.tech.hermes.frontend.metric.CachedTopic;
-import pl.allegro.tech.hermes.frontend.metric.StartedTimersPair;
+import pl.allegro.tech.hermes.common.metric.timer.StartedTimersPair;
 import pl.allegro.tech.hermes.frontend.producer.BrokerMessageProducer;
 import pl.allegro.tech.hermes.frontend.publishing.PublishingCallback;
 import pl.allegro.tech.hermes.frontend.publishing.message.JsonMessage;
@@ -26,17 +26,10 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentLinkedQueue;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Executor;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static java.util.concurrent.TimeUnit.SECONDS;
 import static pl.allegro.tech.hermes.common.config.Configs.*;
 
 public class BackupMessagesLoader {

--- a/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/metric/CachedTopic.java
+++ b/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/metric/CachedTopic.java
@@ -12,6 +12,7 @@ import pl.allegro.tech.hermes.common.metric.Counters;
 import pl.allegro.tech.hermes.common.metric.HermesMetrics;
 import pl.allegro.tech.hermes.common.metric.Meters;
 import pl.allegro.tech.hermes.common.metric.Timers;
+import pl.allegro.tech.hermes.common.metric.timer.StartedTimersPair;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;

--- a/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/publishing/handlers/ExchangeMetrics.java
+++ b/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/publishing/handlers/ExchangeMetrics.java
@@ -4,7 +4,7 @@ import io.undertow.server.ExchangeCompletionListener;
 import io.undertow.server.HttpServerExchange;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import pl.allegro.tech.hermes.frontend.metric.StartedTimersPair;
+import pl.allegro.tech.hermes.common.metric.timer.StartedTimersPair;
 import pl.allegro.tech.hermes.frontend.metric.CachedTopic;
 
 class ExchangeMetrics implements ExchangeCompletionListener {

--- a/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/publishing/handlers/MessageReadHandler.java
+++ b/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/publishing/handlers/MessageReadHandler.java
@@ -6,7 +6,7 @@ import io.undertow.server.HttpHandler;
 import io.undertow.server.HttpServerExchange;
 import pl.allegro.tech.hermes.common.config.ConfigFactory;
 import pl.allegro.tech.hermes.common.config.Configs;
-import pl.allegro.tech.hermes.frontend.metric.StartedTimersPair;
+import pl.allegro.tech.hermes.common.metric.timer.StartedTimersPair;
 import pl.allegro.tech.hermes.frontend.publishing.handlers.end.MessageErrorProcessor;
 import pl.allegro.tech.hermes.frontend.publishing.message.MessageState;
 

--- a/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/publishing/handlers/PublishingHandler.java
+++ b/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/publishing/handlers/PublishingHandler.java
@@ -3,7 +3,7 @@ package pl.allegro.tech.hermes.frontend.publishing.handlers;
 import io.undertow.server.HttpHandler;
 import io.undertow.server.HttpServerExchange;
 import pl.allegro.tech.hermes.api.Topic;
-import pl.allegro.tech.hermes.frontend.metric.StartedTimersPair;
+import pl.allegro.tech.hermes.common.metric.timer.StartedTimersPair;
 import pl.allegro.tech.hermes.frontend.producer.BrokerMessageProducer;
 import pl.allegro.tech.hermes.frontend.publishing.PublishingCallback;
 import pl.allegro.tech.hermes.frontend.publishing.handlers.end.MessageEndProcessor;

--- a/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/publishing/message/MessageFactory.java
+++ b/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/publishing/message/MessageFactory.java
@@ -9,7 +9,7 @@ import pl.allegro.tech.hermes.api.Topic;
 import pl.allegro.tech.hermes.common.http.MessageMetadataHeaders;
 import pl.allegro.tech.hermes.common.message.wrapper.MessageContentWrapper;
 import pl.allegro.tech.hermes.common.message.wrapper.UnsupportedContentTypeException;
-import pl.allegro.tech.hermes.frontend.metric.StartedTimersPair;
+import pl.allegro.tech.hermes.common.metric.timer.StartedTimersPair;
 import pl.allegro.tech.hermes.common.message.wrapper.WrappingException;
 import pl.allegro.tech.hermes.schema.SchemaRepository;
 import pl.allegro.tech.hermes.frontend.publishing.avro.AvroMessage;

--- a/hermes-frontend/src/test/java/pl/allegro/tech/hermes/frontend/buffer/BackupMessagesLoaderTest.java
+++ b/hermes-frontend/src/test/java/pl/allegro/tech/hermes/frontend/buffer/BackupMessagesLoaderTest.java
@@ -13,7 +13,7 @@ import pl.allegro.tech.hermes.frontend.buffer.chronicle.ChronicleMapMessageRepos
 import pl.allegro.tech.hermes.frontend.cache.topic.TopicsCache;
 import pl.allegro.tech.hermes.frontend.listeners.BrokerListeners;
 import pl.allegro.tech.hermes.frontend.metric.CachedTopic;
-import pl.allegro.tech.hermes.frontend.metric.StartedTimersPair;
+import pl.allegro.tech.hermes.common.metric.timer.StartedTimersPair;
 import pl.allegro.tech.hermes.frontend.producer.BrokerMessageProducer;
 import pl.allegro.tech.hermes.frontend.publishing.PublishingCallback;
 import pl.allegro.tech.hermes.frontend.publishing.message.JsonMessage;

--- a/hermes-metrics/src/main/java/pl/allegro/tech/hermes/metrics/PathContext.java
+++ b/hermes-metrics/src/main/java/pl/allegro/tech/hermes/metrics/PathContext.java
@@ -14,6 +14,7 @@ public class PathContext {
     private final Optional<String> httpCodeFamily;
     private final Optional<String> executorName;
     private final Optional<String> oAuthProviderName;
+    private final Optional<String> schemaRepoType;
 
     private PathContext(Optional<String> group,
                         Optional<String> topic,
@@ -24,7 +25,8 @@ public class PathContext {
                         Optional<Integer> httpCode,
                         Optional<String> httpCodeFamily,
                         Optional<String> executorName,
-                        Optional<String> oAuthProviderName)  {
+                        Optional<String> oAuthProviderName,
+                        Optional<String> schemaRepoType)  {
         this.group = group;
         this.topic = topic;
         this.subscription = subscription;
@@ -35,6 +37,7 @@ public class PathContext {
         this.httpCodeFamily = httpCodeFamily;
         this.executorName = executorName;
         this.oAuthProviderName = oAuthProviderName;
+        this.schemaRepoType = schemaRepoType;
     }
 
     public Optional<String> getGroup() {
@@ -77,6 +80,10 @@ public class PathContext {
         return oAuthProviderName;
     }
 
+    public Optional<String> getSchemaRepoType() {
+        return schemaRepoType;
+    }
+
     public static Builder pathContext() {
         return new Builder();
     }
@@ -93,6 +100,7 @@ public class PathContext {
         private Optional<String> httpCodeFamily = Optional.empty();
         private Optional<String> executorName = Optional.empty();
         private Optional<String> oAuthProviderName = Optional.empty();
+        private Optional<String> schemaRepoType = Optional.empty();
 
         public Builder withGroup(String group) {
             this.group = Optional.of(group);
@@ -143,10 +151,14 @@ public class PathContext {
             this.oAuthProviderName = Optional.of(oAuthProviderName);
             return this;
         }
+        public Builder withSchemaRepoType(String schemaRepoType) {
+            this.schemaRepoType = Optional.of(schemaRepoType);
+            return this;
+        }
 
         public PathContext build() {
             return new PathContext(group, topic, subscription, kafkaTopic, partition, kafkaCluster,
-                    httpCode, httpCodeFamily, executorName, oAuthProviderName);
+                    httpCode, httpCodeFamily, executorName, oAuthProviderName, schemaRepoType);
         }
     }
 }

--- a/hermes-metrics/src/main/java/pl/allegro/tech/hermes/metrics/PathsCompiler.java
+++ b/hermes-metrics/src/main/java/pl/allegro/tech/hermes/metrics/PathsCompiler.java
@@ -17,6 +17,7 @@ public class PathsCompiler {
     public static final String HTTP_CODE_FAMILY = "$http_family_of_code";
     public static final String EXECUTOR_NAME = "$executor_name";
     public static final String OAUTH_PROVIDER_NAME = "$oauth_provider_name";
+    public static final String SCHEMA_REPO_TYPE = "$schema_repo_type";
 
     private final String hostname;
 
@@ -41,6 +42,7 @@ public class PathsCompiler {
         context.getHttpCodeFamily().ifPresent(cf -> pathBuilder.replaceAll(HTTP_CODE_FAMILY, cf));
         context.getExecutorName().ifPresent(c -> pathBuilder.replaceAll(EXECUTOR_NAME, c));
         context.getoAuthProviderName().ifPresent(c -> pathBuilder.replaceAll(OAUTH_PROVIDER_NAME, c));
+        context.getSchemaRepoType().ifPresent(c -> pathBuilder.replaceAll(SCHEMA_REPO_TYPE, c));
 
         pathBuilder.replaceAll(HOSTNAME, hostname);
 


### PR DESCRIPTION
New metrics:
`<schema-repo-type>.latency.read-schema`
`<schema-repo-type>.latency.read-schema.group.topic`
`<schema-repo-type>.latency.get-schema-versions`

where `<schema-repo-type>` can be: `schema-repo` or `schema-registry`

#634 