### PR TITLE
Verifying configuration for negotiated max rate algorithm

### DIFF
--- a/docs/docs/configuration/rate-limiting.md
+++ b/docs/docs/configuration/rate-limiting.md
@@ -57,6 +57,8 @@ and we always preserve a *MIN_MAX_RATE* for a consumer.
 - Recalculation is done every *BALANCE_INTERVAL* seconds.
 - Consumer updates it's delivery attempt rate history every *UPDATE_INTERVAL*
 if the change from previous recorded value is greater than *MIN_SIGNIFICANT_CHANGE_PERCENT*.
+- *MIN_SIGNIFICANT_CHANGE_PERCENT* / 100 must be lower than *BUSY_TOLERANCE*, as otherwise 
+consumers would (in some cases) not enter busy state
 - At the moment *RATE_HISTORY_SIZE* is ignored, defaulting to 1,
 and might be used in future versions of the algorithm
 
@@ -71,4 +73,4 @@ RATE_HISTORY_SIZE              | consumer.maxrate.history.size                  
 BUSY_TOLERANCE                 | consumer.maxrate.busy.tolerance                 | 0.1
 MIN_MAX_RATE                   | consumer.maxrate.min.value                      | 1.0
 MIN_CHANGE_PERCENT             | consumer.maxrate.min.allowed.change.percent     | 1.0
-MIN_SIGNIFICANT_CHANGE_PERCENT | consumer.maxrate.min.significant.update.percent | 10.0
+MIN_SIGNIFICANT_CHANGE_PERCENT | consumer.maxrate.min.significant.update.percent | 9.0

--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/common/config/Configs.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/common/config/Configs.java
@@ -167,7 +167,7 @@ public enum Configs {
     CONSUMER_MAXRATE_BUSY_TOLERANCE("consumer.maxrate.busy.tolerance", 0.1),
     CONSUMER_MAXRATE_MIN_MAX_RATE("consumer.maxrate.min.value", 1.0),
     CONSUMER_MAXRATE_MIN_ALLOWED_CHANGE_PERCENT("consumer.maxrate.min.allowed.change.percent", 1.0),
-    CONSUMER_MAXRATE_MIN_SIGNIFICANT_UPDATE_PERCENT("consumer.maxrate.min.significant.update.percent", 10.0),
+    CONSUMER_MAXRATE_MIN_SIGNIFICANT_UPDATE_PERCENT("consumer.maxrate.min.significant.update.percent", 9.0),
 
     CONSUMER_HEALTH_CHECK_PORT("consumer.status.health.port", 8000),
     CONSUMER_WORKLOAD_ALGORITHM("consumer.workload.algorithm", "selective"),

--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/infrastructure/zookeeper/cache/HierarchicalCache.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/infrastructure/zookeeper/cache/HierarchicalCache.java
@@ -2,6 +2,7 @@ package pl.allegro.tech.hermes.infrastructure.zookeeper.cache;
 
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.recipes.cache.PathChildrenCacheEvent;
+import org.apache.zookeeper.KeeperException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import pl.allegro.tech.hermes.common.exception.InternalProcessingException;
@@ -82,8 +83,12 @@ public class HierarchicalCache {
 
     private void ensureBasePath() {
         try {
-            if (curatorFramework.checkExists().forPath(basePath) == null) {
-                curatorFramework.create().creatingParentsIfNeeded().forPath(basePath);
+            try {
+                if (curatorFramework.checkExists().forPath(basePath) == null) {
+                    curatorFramework.create().creatingParentsIfNeeded().forPath(basePath);
+                }
+            } catch (KeeperException.NodeExistsException e) {
+                // ignore
             }
         } catch (Exception e) {
             throw new InternalProcessingException(e);


### PR DESCRIPTION
Prevents lost history updates when consumers are nearly busy,
which could happen when
consumer.maxrate.min.significant.update.percent / 100
was higher than consumer.maxrate.busy.tolerance.