### PR TITLE
Handling conversion of JSON with standard Avro encoding

### DIFF
--- a/hermes-api/src/main/java/pl/allegro/tech/hermes/api/AvroMediaType.java
+++ b/hermes-api/src/main/java/pl/allegro/tech/hermes/api/AvroMediaType.java
@@ -3,4 +3,6 @@ package pl.allegro.tech.hermes.api;
 public class AvroMediaType {
 
     public final static String AVRO_BINARY = "avro/binary";
+
+    public final static String AVRO_JSON = "avro/json";
 }

--- a/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/publishing/message/AvroEncodedJsonAvroConverter.java
+++ b/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/publishing/message/AvroEncodedJsonAvroConverter.java
@@ -1,5 +1,6 @@
 package pl.allegro.tech.hermes.frontend.publishing.message;
 
+import org.apache.avro.AvroRuntimeException;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericDatumReader;
@@ -17,7 +18,7 @@ class AvroEncodedJsonAvroConverter {
     byte[] convertToAvro(byte[] bytes, Schema schema) {
         try {
             return convertToAvro(readJson(bytes, schema), schema);
-        } catch (IOException e) {
+        } catch (IOException | AvroRuntimeException e) {
             throw new AvroConversionException("Failed to convert to AVRO.", e);
         }
     }

--- a/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/publishing/message/AvroEncodedJsonAvroConverter.java
+++ b/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/publishing/message/AvroEncodedJsonAvroConverter.java
@@ -1,0 +1,39 @@
+package pl.allegro.tech.hermes.frontend.publishing.message;
+
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericDatumReader;
+import org.apache.avro.generic.GenericDatumWriter;
+import org.apache.avro.io.*;
+import tech.allegro.schema.json2avro.converter.AvroConversionException;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+class AvroEncodedJsonAvroConverter {
+
+    byte[] convertToAvro(byte[] bytes, Schema schema) {
+        try {
+            return convertToAvro(readJson(bytes, schema), schema);
+        } catch (IOException e) {
+            throw new AvroConversionException("Failed to convert to AVRO.", e);
+        }
+    }
+
+    private GenericData.Record readJson(byte[] bytes, Schema schema) throws IOException {
+        InputStream input = new ByteArrayInputStream(bytes);
+        Decoder decoder = DecoderFactory.get().jsonDecoder(schema, input);
+        return new GenericDatumReader<GenericData.Record>(schema).read(null, decoder);
+    }
+
+    private byte[] convertToAvro(GenericData.Record jsonData, Schema schema) throws IOException {
+        GenericDatumWriter<GenericData.Record> writer = new GenericDatumWriter<>(schema);
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        Encoder encoder = EncoderFactory.get().binaryEncoder(outputStream, null);
+        writer.write(jsonData, encoder);
+        encoder.flush();
+        return outputStream.toByteArray();
+    }
+}

--- a/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/publishing/message/MessageContentTypeEnforcer.java
+++ b/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/publishing/message/MessageContentTypeEnforcer.java
@@ -8,19 +8,24 @@ import tech.allegro.schema.json2avro.converter.JsonAvroConverter;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static pl.allegro.tech.hermes.api.AvroMediaType.AVRO_BINARY;
+import static pl.allegro.tech.hermes.api.AvroMediaType.AVRO_JSON;
 
 public class MessageContentTypeEnforcer {
 
-    private final JsonAvroConverter converter = new JsonAvroConverter();
+    private final JsonAvroConverter defaultJsonAvroconverter = new JsonAvroConverter();
+    private final AvroEncodedJsonAvroConverter avroEncodedJsonAvroConverter = new AvroEncodedJsonAvroConverter();
 
     private static final String APPLICATION_JSON_WITH_DELIM = APPLICATION_JSON + ";";
+    private static final String AVRO_JSON_WITH_DELIM = AVRO_JSON + ";";
     private static final String AVRO_BINARY_WITH_DELIM = AVRO_BINARY + ";";
 
     public byte[] enforceAvro(String payloadContentType, byte[] data, Schema schema, Topic topic) {
         String contentTypeLowerCase = StringUtils.lowerCase(payloadContentType);
         if (isJSON(contentTypeLowerCase)) {
-            return converter.convertToAvro(data, schema);
-        } else if (isAvro(contentTypeLowerCase)) {
+            return defaultJsonAvroconverter.convertToAvro(data, schema);
+        } else if (isAvroJSON(contentTypeLowerCase)) {
+            return avroEncodedJsonAvroConverter.convertToAvro(data, schema);
+        } else if (isAvroBinary(contentTypeLowerCase)) {
             return data;
         } else {
             throw new UnsupportedContentTypeException(payloadContentType, topic);
@@ -31,7 +36,11 @@ public class MessageContentTypeEnforcer {
         return isOfType(contentType, APPLICATION_JSON, APPLICATION_JSON_WITH_DELIM);
     }
 
-    private boolean isAvro(String contentType) {
+    private boolean isAvroJSON(String contentType) {
+        return isOfType(contentType, AVRO_JSON, AVRO_JSON_WITH_DELIM);
+    }
+
+    private boolean isAvroBinary(String contentType) {
         return isOfType(contentType, AVRO_BINARY, AVRO_BINARY_WITH_DELIM);
     }
 

--- a/hermes-frontend/src/test/java/pl/allegro/tech/hermes/frontend/publishing/message/MessageContentTypeEnforcerTest.java
+++ b/hermes-frontend/src/test/java/pl/allegro/tech/hermes/frontend/publishing/message/MessageContentTypeEnforcerTest.java
@@ -33,6 +33,15 @@ public class MessageContentTypeEnforcerTest {
     }
 
     @Test
+    public void shouldConvertToAvroWhenReceivedAvroJSONOnAvroTopic() throws IOException {
+        // when
+        byte[] enforcedMessage = enforcer.enforceAvro("avro/json", avroMessage.asAvroEncodedJson().getBytes(), schema.getSchema(), topic);
+
+        // then
+        assertThat(enforcedMessage).isEqualTo(avroMessage.asBytes());
+    }
+
+    @Test
     public void shouldStringContentTypeOfAdditionalOptionsWhenInterpretingIt() throws IOException {
         // when
         byte[] enforcedMessage = enforcer.enforceAvro("application/json;encoding=utf-8", avroMessage.asJson().getBytes(), schema.getSchema(), topic);

--- a/hermes-test-helper/src/main/java/pl/allegro/tech/hermes/test/helper/avro/AvroUser.java
+++ b/hermes-test-helper/src/main/java/pl/allegro/tech/hermes/test/helper/avro/AvroUser.java
@@ -1,5 +1,6 @@
 package pl.allegro.tech.hermes.test.helper.avro;
 
+import com.google.common.collect.ImmutableMap;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
@@ -10,10 +11,12 @@ import pl.allegro.tech.hermes.test.helper.message.TestMessage;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 
+import static java.util.Optional.ofNullable;
 import static pl.allegro.tech.hermes.test.helper.avro.RecordToBytesConverter.recordToBytes;
 
 public class AvroUser {
 
+    private static final String METADATA_FIELD = "__metadata";
     private static final String NAME_FIELD = "name";
     private static final String AGE_FIELD = "age";
     private static final String FAVORITE_COLOR_FIELD = "favoriteColor";
@@ -68,8 +71,17 @@ public class AvroUser {
         return asTestMessage().toString();
     }
 
+    public String asAvroEncodedJson() {
+        return asAvroEncodedTestMessage().toString();
+    }
+
     public TestMessage asTestMessage() {
         return TestMessage.of(NAME_FIELD, getName()).append(AGE_FIELD, getAge()).append(FAVORITE_COLOR_FIELD, getFavoriteColor());
+    }
+
+    public TestMessage asAvroEncodedTestMessage() {
+        Object favoriteColorType = ofNullable(getFavoriteColor()).map(color -> (Object)ImmutableMap.of("string", color)).orElse("null");
+        return TestMessage.of(METADATA_FIELD, null).append(NAME_FIELD, getName()).append(AGE_FIELD, getAge()).append(FAVORITE_COLOR_FIELD, favoriteColorType);
     }
 
     public static AvroUser create(CompiledSchema<Schema> schema, byte[] bytes) {

--- a/hermes-test-helper/src/main/java/pl/allegro/tech/hermes/test/helper/endpoint/HermesPublisher.java
+++ b/hermes-test-helper/src/main/java/pl/allegro/tech/hermes/test/helper/endpoint/HermesPublisher.java
@@ -5,12 +5,10 @@ import pl.allegro.tech.hermes.test.helper.client.Hermes;
 
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.Response;
 import java.util.Map;
-
-import static javax.ws.rs.client.Entity.text;
-
 
 public class HermesPublisher {
 
@@ -28,7 +26,8 @@ public class HermesPublisher {
     }
 
     public Response publish(String qualifiedTopicName, String message, Map<String, String> headers) {
-        return webTarget.path(qualifiedTopicName).request().headers(new MultivaluedHashMap<>(headers)).post(text(message));
+        String contentType = headers.getOrDefault("Content-Type", MediaType.TEXT_PLAIN);
+        return webTarget.path(qualifiedTopicName).request().headers(new MultivaluedHashMap<>(headers)).post(Entity.entity(message, contentType));
     }
 
     public Response publish(String qualifiedTopicName, byte[] message) {

--- a/integration/src/integration/java/pl/allegro/tech/hermes/integration/PublishingAvroTest.java
+++ b/integration/src/integration/java/pl/allegro/tech/hermes/integration/PublishingAvroTest.java
@@ -34,6 +34,7 @@ import static javax.ws.rs.core.Response.Status.CREATED;
 import static javax.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
 import static javax.ws.rs.core.Response.Status.OK;
 import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson;
+import static pl.allegro.tech.hermes.api.AvroMediaType.AVRO_JSON;
 import static pl.allegro.tech.hermes.api.ContentType.AVRO;
 import static pl.allegro.tech.hermes.api.ContentType.JSON;
 import static pl.allegro.tech.hermes.api.PatchData.patchData;
@@ -180,6 +181,22 @@ public class PublishingAvroTest extends IntegrationTest {
 
         // when
         Response response = publisher.publish("avro.topic2", user.asJson());
+
+        // then
+        assertThat(response.getStatus()).isEqualTo(CREATED.getStatusCode());
+    }
+
+    @Test
+    public void shouldPublishAvroEncodedJsonMessageConvertedToAvroForAvroTopics() {
+        // given
+        Topic topic = operations.buildTopic(topic("avro.topic2")
+                .withContentType(AVRO)
+                .build()
+        );
+        operations.saveSchema(topic, user.getSchemaAsString());
+
+        // when
+        Response response = publisher.publish("avro.topic2", user.asAvroEncodedJson(), Collections.singletonMap("Content-Type", AVRO_JSON));
 
         // then
         assertThat(response.getStatus()).isEqualTo(CREATED.getStatusCode());


### PR DESCRIPTION
Added `avro/json` payload content-type and applied standard `JSON->AVRO` conversion mechanism for messages with this type. (based on https://avro.apache.org/docs/1.8.1/spec.html#json_encoding)

This addresses the issue with custom JSON converter (https://github.com/allegro/json-avro-converter/issues/14), where more complex Union types could not be properly matched, since plain JSON does not carry type information.

For given schema:
```json
{
    "namespace": "pl.allegro",
    "type": "record",
    "name": "User",
    "fields": [
        {
              "name": "__metadata",
              "type": ["null", {"type": "map", "values": "string"}],
              "default": null
        },
        {"name": "name", "type": "string"},
        {"name": "age",  "type": "int"},
        {"name": "favoriteColor", "type": ["null", "string"]}
    ]
}
```

proper `avro/json` formatted message is:
```json
{"__metadata":null,"name":"Bob","age":30,"favoriteColor":{"string":"black"}}
```
**NOTE:** when namespace is defined, for custom defined types (records, etc. but not primitives) it must be prepended to type discriminator `{ "<namespace>.<type name>": <value> }`

compared to standard `application/json`:
```json
{"name":"Bob","age":30,"favoriteColor":"black"}
```