### PR TITLE
Move Zookeeper cache logs to debug to decrease log noise

### DIFF
--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/infrastructure/zookeeper/cache/HierarchicalCacheLevel.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/infrastructure/zookeeper/cache/HierarchicalCacheLevel.java
@@ -52,7 +52,7 @@ class HierarchicalCacheLevel extends PathChildrenCache implements PathChildrenCa
 
         String path = event.getData().getPath();
         String cacheName = cacheNameFromPath(path);
-        logger.info("Got {} event for path {}", event.getType(), path);
+        logger.debug("Got {} event for path {}", event.getType(), path);
 
         switch (event.getType()) {
             case CHILD_ADDED:
@@ -87,7 +87,7 @@ class HierarchicalCacheLevel extends PathChildrenCache implements PathChildrenCa
         writeLock.lock();
         try {
             if (subcacheMap.containsKey(cacheName)) {
-                logger.info("Possible duplicate of new entry for {}, ignoring", cacheName);
+                logger.debug("Possible duplicate of new entry for {}, ignoring", cacheName);
                 return;
             }
             nextLevelFactory.ifPresent(f -> subcacheMap.put(cacheName, f.apply(currentDepth + 1, path)));
@@ -103,7 +103,7 @@ class HierarchicalCacheLevel extends PathChildrenCache implements PathChildrenCa
         try {
             HierarchicalCacheLevel subcache = subcacheMap.remove(cacheName);
             if (subcache == null) {
-                logger.info("Possible duplicate of removed entry for {}, ignoring", cacheName);
+                logger.debug("Possible duplicate of removed entry for {}, ignoring", cacheName);
                 return;
             }
             subcache.close();


### PR DESCRIPTION
By moving Zookeeper cache logs and SchemaRegistry logs (#750) to debug, we can reduce number of log messages by almost 100x. I think those logs are of little value for us and only make it harder to actually debug issues with Hermes.

Before:
<img width="441" alt="screen shot 2017-03-25 at 10 35 01" src="https://cloud.githubusercontent.com/assets/5269406/24321231/a27f458e-1147-11e7-8e5d-c2e60de32d38.png">

After: 
<img width="335" alt="screen shot 2017-03-25 at 10 35 49" src="https://cloud.githubusercontent.com/assets/5269406/24321234/a6944b06-1147-11e7-9e30-a3ec5403cd18.png">
