### PR TITLE
Limit size of messages in preview #710

### DIFF
--- a/hermes-api/src/main/java/pl/allegro/tech/hermes/api/MessageTextPreview.java
+++ b/hermes-api/src/main/java/pl/allegro/tech/hermes/api/MessageTextPreview.java
@@ -1,0 +1,21 @@
+package pl.allegro.tech.hermes.api;
+
+public class MessageTextPreview {
+
+    private final String content;
+
+    private final boolean truncated;
+
+    public MessageTextPreview(String content, boolean truncated) {
+        this.content = content;
+        this.truncated = truncated;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public boolean isTruncated() {
+        return truncated;
+    }
+}

--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/common/config/Configs.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/common/config/Configs.java
@@ -126,6 +126,7 @@ public enum Configs {
     FRONTEND_AUTHENTICATION_MODE("frontend.authentication.mode", "constraint_driven"),
 
     FRONTEND_MESSAGE_PREVIEW_ENABLED("frontend.message.preview.enabled", false),
+    FRONTEND_MESSAGE_PREVIEW_MAX_SIZE_KB("frontend.message.preview.max.size.kb", 10),
     FRONTEND_MESSAGE_PREVIEW_SIZE("frontend.message.preview.size", 3),
     FRONTEND_MESSAGE_PREVIEW_LOG_PERSIST_PERIOD("frontend.message.preview.log.persist.period.seconds", 30),
 

--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/domain/topic/preview/MessagePreview.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/domain/topic/preview/MessagePreview.java
@@ -1,0 +1,29 @@
+package pl.allegro.tech.hermes.domain.topic.preview;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class MessagePreview {
+
+    private final byte[] content;
+
+    private final boolean truncated;
+
+    @JsonCreator
+    public MessagePreview(@JsonProperty("content") byte[] content, @JsonProperty("truncated") boolean truncated) {
+        this.content = content;
+        this.truncated = truncated;
+    }
+
+    public MessagePreview(byte[] content) {
+        this(content, false);
+    }
+
+    public byte[] getContent() {
+        return content;
+    }
+
+    public boolean isTruncated() {
+        return truncated;
+    }
+}

--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/domain/topic/preview/MessagePreviewRepository.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/domain/topic/preview/MessagePreviewRepository.java
@@ -2,12 +2,11 @@ package pl.allegro.tech.hermes.domain.topic.preview;
 
 import pl.allegro.tech.hermes.api.TopicName;
 
-import java.util.Collection;
 import java.util.List;
 
 public interface MessagePreviewRepository {
 
-    List<byte[]> loadPreview(TopicName topicName);
+    List<MessagePreview> loadPreview(TopicName topicName);
 
     void persist(TopicsMessagesPreview topicsMessagesPreview);
 

--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/domain/topic/preview/TopicsMessagesPreview.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/domain/topic/preview/TopicsMessagesPreview.java
@@ -2,18 +2,14 @@ package pl.allegro.tech.hermes.domain.topic.preview;
 
 import pl.allegro.tech.hermes.api.TopicName;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 public class TopicsMessagesPreview {
 
-    private final Map<TopicName, List<byte[]>> messages = new HashMap<>();
+    private final Map<TopicName, List<MessagePreview>> messages = new HashMap<>();
 
-    public void add(TopicName topicName, byte[] message) {
-        List<byte[]> messageList = messages.computeIfAbsent(topicName, k -> new ArrayList<byte[]>());
+    public void add(TopicName topicName, MessagePreview message) {
+        List<MessagePreview> messageList = messages.computeIfAbsent(topicName, k -> new ArrayList<>());
         messageList.add(message);
     }
 
@@ -21,7 +17,7 @@ public class TopicsMessagesPreview {
         return messages.keySet();
     }
 
-    public List<byte[]> previewOf(TopicName topic) {
+    public List<MessagePreview> previewOf(TopicName topic) {
         return messages.getOrDefault(topic, new ArrayList<>());
     }
 }

--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/infrastructure/zookeeper/ZookeeperBasedRepository.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/infrastructure/zookeeper/ZookeeperBasedRepository.java
@@ -82,8 +82,8 @@ public abstract class ZookeeperBasedRepository {
     }
 
     @SuppressWarnings("unchecked")
-    protected <T> T readFrom(String path, TypeReference<T> type) {
-        return readFrom(path, b -> (T) mapper.readValue(b, type), false).get();
+    protected <T> Optional<T> readFrom(String path, TypeReference<T> type, boolean quiet) {
+        return readFrom(path, b -> (T) mapper.readValue(b, type), quiet);
     }
 
     private <T> Optional<T> readFrom(String path, ThrowingReader<T> supplier, boolean quiet) {
@@ -129,10 +129,6 @@ public abstract class ZookeeperBasedRepository {
         } catch (Exception ex) {
             throw new InternalProcessingException(ex);
         }
-    }
-
-    interface PostProcessor {
-        Object invoke(byte[] data, Object value);
     }
 
     private interface ThrowingReader<T> {

--- a/hermes-common/src/test/groovy/pl/allegro/tech/hermes/infrastructure/zookeeper/ZookeeperMessagePreviewRepositoryTest.groovy
+++ b/hermes-common/src/test/groovy/pl/allegro/tech/hermes/infrastructure/zookeeper/ZookeeperMessagePreviewRepositoryTest.groovy
@@ -1,6 +1,8 @@
 package pl.allegro.tech.hermes.infrastructure.zookeeper
 
+import org.apache.curator.framework.CuratorFramework
 import pl.allegro.tech.hermes.api.Group
+import pl.allegro.tech.hermes.domain.topic.preview.MessagePreview
 import pl.allegro.tech.hermes.domain.topic.preview.TopicsMessagesPreview
 import pl.allegro.tech.hermes.test.IntegrationTest
 
@@ -9,10 +11,12 @@ import static pl.allegro.tech.hermes.test.helper.builder.TopicBuilder.topic
 
 class ZookeeperMessagePreviewRepositoryTest extends IntegrationTest {
 
-    private ZookeeperMessagePreviewRepository repository = new ZookeeperMessagePreviewRepository(zookeeper(), mapper, paths)
+    private CuratorFramework zookeeper = zookeeper()
+
+    private ZookeeperMessagePreviewRepository repository = new ZookeeperMessagePreviewRepository(zookeeper, mapper, paths)
 
     def setup() {
-        if(!groupRepository.groupExists('messagePreviewGroup')) {
+        if (!groupRepository.groupExists('messagePreviewGroup')) {
             groupRepository.createGroup(Group.from('messagePreviewGroup'))
             topicRepository.createTopic(topic('messagePreviewGroup.topic-1').build())
             topicRepository.createTopic(topic('messagePreviewGroup.topic-2').build())
@@ -21,32 +25,45 @@ class ZookeeperMessagePreviewRepositoryTest extends IntegrationTest {
 
     def "should save and load messages"() {
         given:
-        TopicsMessagesPreview preview = new TopicsMessagesPreview()
-        preview.add(fromQualifiedName('messagePreviewGroup.topic-1'), 'topic-1-1'.bytes)
-        preview.add(fromQualifiedName('messagePreviewGroup.topic-1'), 'topic-1-2'.bytes)
-        preview.add(fromQualifiedName('messagePreviewGroup.topic-2'), 'topic-2-1'.bytes)
+            TopicsMessagesPreview preview = new TopicsMessagesPreview()
+            preview.add(fromQualifiedName('messagePreviewGroup.topic-1'), new MessagePreview('topic-1-1'.bytes))
+            preview.add(fromQualifiedName('messagePreviewGroup.topic-1'), new MessagePreview('topic-1-2'.bytes))
+            preview.add(fromQualifiedName('messagePreviewGroup.topic-2'), new MessagePreview('topic-2-1'.bytes))
 
         when:
-        repository.persist(preview)
+            repository.persist(preview)
 
         then:
-        repository.loadPreview(fromQualifiedName('messagePreviewGroup.topic-1')) == ['topic-1-1'.bytes, 'topic-1-2'.bytes]
-        repository.loadPreview(fromQualifiedName('messagePreviewGroup.topic-2')) == ['topic-2-1'.bytes]
+            repository.loadPreview(fromQualifiedName('messagePreviewGroup.topic-1'))*.content == ['topic-1-1'.bytes, 'topic-1-2'.bytes]
+            repository.loadPreview(fromQualifiedName('messagePreviewGroup.topic-2'))*.content == ['topic-2-1'.bytes]
     }
 
     def "should overwrite existing messages with new ones"() {
         given:
         TopicsMessagesPreview preview = new TopicsMessagesPreview()
-        preview.add(fromQualifiedName('messagePreviewGroup.topic-2'), 'topic-2-1'.bytes)
+        preview.add(fromQualifiedName('messagePreviewGroup.topic-2'), new MessagePreview('topic-2-1'.bytes))
         repository.persist(preview)
 
         TopicsMessagesPreview newPreview = new TopicsMessagesPreview()
-        newPreview.add(fromQualifiedName('messagePreviewGroup.topic-2'), 'topic-2-2'.bytes)
+        newPreview.add(fromQualifiedName('messagePreviewGroup.topic-2'), new MessagePreview('topic-2-2'.bytes))
 
         when:
         repository.persist(newPreview)
 
         then:
-        repository.loadPreview(fromQualifiedName('messagePreviewGroup.topic-2')) == ['topic-2-2'.bytes]
+        repository.loadPreview(fromQualifiedName('messagePreviewGroup.topic-2'))*.content == ['topic-2-2'.bytes]
+    }
+
+    def "should return empty list if message preview cannot be deserialized"() {
+        given:
+            List storedPreviews = [ new MessagePreview('valid-message'.bytes), 'message-in-invalid-format'.bytes ]
+
+            String previewPath = paths.topicPath(fromQualifiedName('messagePreviewGroup.topic-1'), ZookeeperPaths.PREVIEW_PATH)
+            repository.ensurePathExists(previewPath)
+            zookeeper.setData().forPath(previewPath, mapper.writeValueAsBytes(storedPreviews))
+        when:
+            List<MessagePreview> result = repository.loadPreview(fromQualifiedName('messagePreviewGroup.topic-1'))
+        then:
+            result == []
     }
 }

--- a/hermes-console/static/css/main.css
+++ b/hermes-console/static/css/main.css
@@ -53,3 +53,11 @@ span.helpme {
 a.navbar-brand.console-title {
     color: #2a6496;
 }
+
+.message-preview > .content {
+    margin: 10px 0 0 0;
+}
+
+.message-preview > .truncated-info {
+    font-style: italic;
+}

--- a/hermes-console/static/partials/topic.html
+++ b/hermes-console/static/partials/topic.html
@@ -91,9 +91,10 @@
                     <h3 class="panel-title">Topic messages preview</h3>
                 </div>
                 <div class="panel-body" uib-collapse="!showPreview">
-                    <pre class="pre-scrollable" ng-repeat="message in preview track by $index">
-{{message}}
-                    </pre>
+                    <div class="pre-scrollable message-preview" ng-repeat="message in preview track by $index">
+                        <pre class="content">{{message.content}}</pre>
+                        <span class="truncated-info" ng-if="::(message.truncated)">(preview was too large and has been truncated)</span>
+                    </div>
                 </div>
             </div>
         </div>

--- a/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/di/FrontendBinder.java
+++ b/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/di/FrontendBinder.java
@@ -20,6 +20,7 @@ import pl.allegro.tech.hermes.frontend.publishing.message.MessageContentTypeEnfo
 import pl.allegro.tech.hermes.frontend.publishing.message.MessageFactory;
 import pl.allegro.tech.hermes.frontend.publishing.metadata.DefaultHeadersPropagator;
 import pl.allegro.tech.hermes.frontend.publishing.metadata.HeadersPropagator;
+import pl.allegro.tech.hermes.frontend.publishing.preview.MessagePreviewFactory;
 import pl.allegro.tech.hermes.frontend.publishing.preview.MessagePreviewLog;
 import pl.allegro.tech.hermes.frontend.publishing.preview.MessagePreviewPersister;
 import pl.allegro.tech.hermes.frontend.server.SslContextFactoryProvider;
@@ -80,6 +81,7 @@ public class FrontendBinder extends AbstractBinder {
         bindSingleton(PersistentBufferExtension.class);
         bindSingleton(MessagePreviewPersister.class);
         bindSingleton(MessagePreviewLog.class);
+        bindSingleton(MessagePreviewFactory.class);
         bindSingletonFactory(BlacklistZookeeperNotifyingCacheFactory.class);
     }
 

--- a/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/publishing/preview/MessagePreviewFactory.java
+++ b/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/publishing/preview/MessagePreviewFactory.java
@@ -1,0 +1,32 @@
+package pl.allegro.tech.hermes.frontend.publishing.preview;
+
+import org.apache.commons.lang.ArrayUtils;
+import pl.allegro.tech.hermes.common.config.ConfigFactory;
+import pl.allegro.tech.hermes.common.config.Configs;
+import pl.allegro.tech.hermes.domain.topic.preview.MessagePreview;
+
+import javax.inject.Inject;
+
+public class MessagePreviewFactory {
+
+    private final int maxMessagePreviewLength;
+
+    @Inject
+    public MessagePreviewFactory(ConfigFactory configFactory) {
+        this(configFactory.getIntProperty(Configs.FRONTEND_MESSAGE_PREVIEW_MAX_SIZE_KB) * 1024);
+    }
+
+    MessagePreviewFactory(int maxMessagePreviewSize) {
+        this.maxMessagePreviewLength = maxMessagePreviewSize;
+    }
+
+    public MessagePreview create(byte[] content) {
+        final boolean truncated = (content.length > maxMessagePreviewLength);
+
+        if (truncated) {
+            return new MessagePreview(ArrayUtils.subarray(content, 0, maxMessagePreviewLength), true);
+        } else {
+            return new MessagePreview(content);
+        }
+    }
+}

--- a/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/publishing/preview/MessagePreviewLog.java
+++ b/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/publishing/preview/MessagePreviewLog.java
@@ -4,6 +4,7 @@ import com.google.common.util.concurrent.AtomicLongMap;
 import pl.allegro.tech.hermes.api.TopicName;
 import pl.allegro.tech.hermes.common.config.ConfigFactory;
 import pl.allegro.tech.hermes.common.config.Configs;
+import pl.allegro.tech.hermes.domain.topic.preview.MessagePreview;
 import pl.allegro.tech.hermes.domain.topic.preview.TopicsMessagesPreview;
 
 import javax.inject.Inject;
@@ -13,47 +14,50 @@ import java.util.concurrent.ConcurrentLinkedDeque;
 
 public class MessagePreviewLog {
 
+    private final MessagePreviewFactory messagePreviewFactory;
+
     private final int previewSizePerTopic;
 
     private final AtomicLongMap<TopicName> limiter = AtomicLongMap.create();
 
-    private final ConcurrentLinkedDeque<MessagePreview> messages = new ConcurrentLinkedDeque<>();
+    private final ConcurrentLinkedDeque<MessagePreviewSnapshot> messages = new ConcurrentLinkedDeque<>();
 
     @Inject
-    public MessagePreviewLog(ConfigFactory configFactory) {
-        this(configFactory.getIntProperty(Configs.FRONTEND_MESSAGE_PREVIEW_SIZE));
+    public MessagePreviewLog(MessagePreviewFactory messagePreviewFactory, ConfigFactory configFactory) {
+        this(messagePreviewFactory, configFactory.getIntProperty(Configs.FRONTEND_MESSAGE_PREVIEW_SIZE));
     }
 
-    public MessagePreviewLog(int previewSizePerTopic) {
+    MessagePreviewLog(MessagePreviewFactory messagePreviewFactory, int previewSizePerTopic) {
+        this.messagePreviewFactory = messagePreviewFactory;
         this.previewSizePerTopic = previewSizePerTopic;
     }
 
     public void add(TopicName topicName, byte[] messageContent) {
         long counter = limiter.getAndIncrement(topicName);
         if (counter < previewSizePerTopic) {
-            messages.add(new MessagePreview(topicName, messageContent));
+            messages.add(new MessagePreviewSnapshot(topicName, messagePreviewFactory.create(messageContent)));
         }
     }
 
     public TopicsMessagesPreview snapshotAndClean() {
-        List<MessagePreview> snapshot = new ArrayList<>(messages);
+        List<MessagePreviewSnapshot> snapshot = new ArrayList<>(messages);
         messages.clear();
         limiter.clear();
 
         TopicsMessagesPreview preview = new TopicsMessagesPreview();
-        for (MessagePreview message : snapshot) {
+        for (MessagePreviewSnapshot message : snapshot) {
             preview.add(message.topicName, message.content);
         }
         return preview;
     }
 
-    private static class MessagePreview {
+    private static class MessagePreviewSnapshot {
 
         final TopicName topicName;
 
-        final byte[] content;
+        final MessagePreview content;
 
-        MessagePreview(TopicName topicName, byte[] content) {
+        MessagePreviewSnapshot(TopicName topicName, MessagePreview content) {
             this.topicName = topicName;
             this.content = content;
         }

--- a/hermes-frontend/src/test/groovy/pl/allegro/tech/hermes/frontend/publishing/preview/MessagePreviewFactoryTest.groovy
+++ b/hermes-frontend/src/test/groovy/pl/allegro/tech/hermes/frontend/publishing/preview/MessagePreviewFactoryTest.groovy
@@ -1,0 +1,27 @@
+package pl.allegro.tech.hermes.frontend.publishing.preview
+
+import pl.allegro.tech.hermes.domain.topic.preview.MessagePreview
+import spock.lang.Specification
+import spock.lang.Subject
+
+class MessagePreviewFactoryTest extends Specification {
+
+    @Subject
+    MessagePreviewFactory factory
+
+    def "should truncate message preview if it is too large"() {
+        given:
+            factory = new MessagePreviewFactory(maxContentSize)
+        when:
+            MessagePreview preview = factory.create(new byte[messageSize])
+        then:
+            preview.truncated == shouldTruncate
+        where:
+            messageSize | maxContentSize || shouldTruncate
+            50          | 100            || false
+            99          | 100            || false
+            100         | 100            || false
+            101         | 100            || true
+            150         | 100            || true
+    }
+}

--- a/hermes-frontend/src/test/groovy/pl/allegro/tech/hermes/frontend/publishing/preview/MessagePreviewLogTest.groovy
+++ b/hermes-frontend/src/test/groovy/pl/allegro/tech/hermes/frontend/publishing/preview/MessagePreviewLogTest.groovy
@@ -1,5 +1,6 @@
 package pl.allegro.tech.hermes.frontend.publishing.preview
 
+import pl.allegro.tech.hermes.domain.topic.preview.MessagePreview
 import spock.lang.Specification
 
 import java.util.concurrent.CountDownLatch
@@ -11,7 +12,11 @@ import static pl.allegro.tech.hermes.api.TopicName.fromQualifiedName
 
 class MessagePreviewLogTest extends Specification {
 
-    private MessagePreviewLog log = new MessagePreviewLog(2);
+    private MessagePreviewFactory factory = Stub(MessagePreviewFactory) {
+        create(_ as byte[]) >> { args -> new MessagePreview(args[0]) }
+    }
+
+    private MessagePreviewLog log = new MessagePreviewLog(factory, 2)
 
     def "should persist messages for topics"() {
         given:
@@ -35,7 +40,7 @@ class MessagePreviewLogTest extends Specification {
         def messages = log.snapshotAndClean()
 
         then:
-        messages.previewOf(fromQualifiedName('group.topic-1')) == [[1] as byte[], [2] as byte[]]
+        messages.previewOf(fromQualifiedName('group.topic-1'))*.content == [[1] as byte[], [2] as byte[]]
     }
 
     def "should be thread safe when adding messages for same topic from multiple threads"() {

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/api/TopicsEndpoint.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/api/TopicsEndpoint.java
@@ -119,7 +119,7 @@ public class TopicsEndpoint {
     @Produces(APPLICATION_JSON)
     @Path("/{topicName}/preview")
     @ApiOperation(value = "Topic publisher preview", httpMethod = HttpMethod.GET)
-    public List<String> getPreview(@PathParam("topicName") String qualifiedTopicName) {
+    public List<MessageTextPreview> getPreview(@PathParam("topicName") String qualifiedTopicName) {
         return topicService.previewText(TopicName.fromQualifiedName(qualifiedTopicName));
     }
 


### PR DESCRIPTION
Message preview will be truncated in `MessagePreviewLog#add` if its size exceeds limit defined in `Configs.FRONTEND_MESSAGE_PREVIEW_MAX_SIZE_KB` (10 by default). Additionally to preview content, a `truncated` flag will be stored in Zookeeper for later display in "Topic message preview" panel:

![image](https://cloud.githubusercontent.com/assets/8194995/24744656/0f879b1c-1ab3-11e7-83c1-51c3ee7c4aa7.png)

Previews already stored in ZK (flat structure, only preview content) are not supported, meaning that they won't be displayed. Once new messages arrive, they will be stored in new format and older ones should be discarded. 