### PR TITLE
Ensuring that consumer process exists for processed signal

### DIFF
--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/SerialConsumer.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/SerialConsumer.java
@@ -135,11 +135,14 @@ public class SerialConsumer implements Consumer {
         this.messageReceiver = messageReceiverFactory.createMessageReceiver(topic, subscription, rateLimiter);
     }
 
+    /**
+     * Try to keep shutdown order the same as initialization so nothing will left to clean up when error occurs during initialization
+     */
     @Override
     public void tearDown() {
         messageReceiver.stop();
-        rateLimiter.shutdown();
         sender.shutdown();
+        rateLimiter.shutdown();
         consumerAuthorizationHandler.removeSubscriptionHandler(subscription.getQualifiedName());
     }
 

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/receiver/kafka/KafkaSingleThreadedMessageReceiver.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/receiver/kafka/KafkaSingleThreadedMessageReceiver.java
@@ -23,7 +23,6 @@ import pl.allegro.tech.hermes.common.metric.HermesMetrics;
 import pl.allegro.tech.hermes.consumers.consumer.Message;
 import pl.allegro.tech.hermes.consumers.consumer.offset.SubscriptionPartitionOffset;
 import pl.allegro.tech.hermes.consumers.consumer.receiver.MessageReceiver;
-import pl.allegro.tech.hermes.schema.SchemaRepository;
 
 import java.time.Clock;
 import java.util.Collection;
@@ -153,7 +152,7 @@ public class KafkaSingleThreadedMessageReceiver implements MessageReceiver {
         try {
             consumer.commitSync(createOffset(offsets));
         } catch (Exception ex) {
-            logger.error("Error while committing offset for subscription {}, {}", subscription.getQualifiedName(), ex);
+            logger.error("Error while committing offset for subscription {}", subscription.getQualifiedName(), ex);
             metrics.counter("offset-committer.failed").inc();
         }
     }

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/process/ConsumerProcess.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/process/ConsumerProcess.java
@@ -116,7 +116,7 @@ public class ConsumerProcess implements Runnable {
             }
             signalTimesheet.put(signal.getType(), clock.millis());
         } catch (Exception ex) {
-            logger.error("Failed to process signal {} for subscription {}", signal.getType(), subscriptionName);
+            logger.error("Failed to process signal {} for subscription {}", signal.getType(), subscriptionName, ex);
         }
     }
 
@@ -154,10 +154,14 @@ public class ConsumerProcess implements Runnable {
 
     private void restart() {
         long startTime = clock.millis();
-        logger.info("Restarting consumer for subscription {}", subscriptionName);
-        stop();
-        start();
-        logger.info("Done restarting consumer for subscription {} in {}ms", subscriptionName, clock.millis() - startTime);
+        try {
+            logger.info("Restarting consumer for subscription {}", subscriptionName);
+            stop();
+            start();
+            logger.info("Done restarting consumer for subscription {} in {}ms", subscriptionName, clock.millis() - startTime);
+        } catch (Exception e) {
+            logger.error("Failed restarting consumer for subscription {} in {}ms", subscriptionName, clock.millis() - startTime, e);
+        }
     }
 
     @Override

--- a/hermes-consumers/src/test/groovy/pl/allegro/tech/hermes/consumers/supervisor/process/ConsumerProcessSupervisorTest.groovy
+++ b/hermes-consumers/src/test/groovy/pl/allegro/tech/hermes/consumers/supervisor/process/ConsumerProcessSupervisorTest.groovy
@@ -1,0 +1,54 @@
+package pl.allegro.tech.hermes.consumers.supervisor.process
+
+import com.codahale.metrics.MetricRegistry
+import pl.allegro.tech.hermes.api.SubscriptionName
+import pl.allegro.tech.hermes.common.config.ConfigFactory
+import pl.allegro.tech.hermes.common.metric.HermesMetrics
+import pl.allegro.tech.hermes.consumers.consumer.Consumer
+import pl.allegro.tech.hermes.consumers.supervisor.ConsumersExecutorService
+import pl.allegro.tech.hermes.metrics.PathsCompiler
+import spock.lang.Specification
+
+import java.time.Clock
+
+class ConsumerProcessSupervisorTest extends Specification {
+
+    ConfigFactory configFactory = new ConfigFactory()
+    Retransmitter retransmitter = Stub(Retransmitter)
+    Consumer consumer = Stub(Consumer)
+
+    SubscriptionName subscription = SubscriptionName.fromString('group.topic$sub')
+
+    ConsumerProcessSupervisor consumerProcessSupervisor
+    HermesMetrics hermesMetrics
+
+    def setup() {
+        hermesMetrics = new HermesMetrics(new MetricRegistry(), new PathsCompiler("localhost"))
+
+        consumerProcessSupervisor = new ConsumerProcessSupervisor(
+                new ConsumersExecutorService(configFactory, hermesMetrics),
+                retransmitter,
+                new Clock.SystemClock(),
+                hermesMetrics,
+                configFactory)
+
+        consumer.consume(_) >> {
+            Runnable signalsInterrupt ->
+                signalsInterrupt.run()
+        }
+    }
+
+    def "should not handle commit for non existing consumer process"() {
+        given:
+        consumerProcessSupervisor.accept(Signal.of(Signal.SignalType.START, subscription, consumer))
+        consumerProcessSupervisor.run()
+
+        when:
+        consumerProcessSupervisor.accept(Signal.of(Signal.SignalType.CLEANUP, subscription))
+        consumerProcessSupervisor.accept(Signal.of(Signal.SignalType.COMMIT, subscription))
+        consumerProcessSupervisor.run()
+
+        then:
+        hermesMetrics.counter("supervisor.signal.dropped." + Signal.SignalType.COMMIT.name()).getCount() == 1
+    }
+}


### PR DESCRIPTION
Signals for `ConsumerProcessSupervisor` are produced from few threads on a single queue. These threads are not synchronized with each other which means that signals can be mixed on the queue.
Next, signals are consumed in batches by a single thread. Single batch can contain mixed sequence of signals like so:

```
1. CLEAN - from some STOP signal
2. COMMIT - from commit thread
``` 

At the moment, `ConsumerProcessSupervisor` verifies whether consumer process exists only at the beginning of a batch process. However, some signals from the batch can remove consumer process and next signals from this batch can end up with NPE as consumer process was not found.

This PR fixes described problem by verifying whether consumer process exists for each processed signal.

This is a first step to solve #773