### PR TITLE
Console notification box UX improvements

### DIFF
--- a/hermes-console/static/css/main.css
+++ b/hermes-console/static/css/main.css
@@ -61,3 +61,8 @@ a.navbar-brand.console-title {
 .message-preview > .truncated-info {
     font-style: italic;
 }
+
+#toast-container > div {
+    width: auto;
+    max-width: 800px;
+}

--- a/hermes-console/static/index.html
+++ b/hermes-console/static/index.html
@@ -72,7 +72,7 @@
             </div>
         </nav>
 
-    <toaster-container toaster-options="{'time-out': 5000}"></toaster-container>
+    <toaster-container toaster-options="{'time-out': {'toast-error': 0, 'toast-success': 5000, 'toast-info': 5000}, 'close-button': {'toast-error': true}}"></toaster-container>
     <div ui-view class="container">
     </div>
 </body>


### PR DESCRIPTION
This small change is related to #692 and improves the toaster notification widget of the console as follows:
* notification box will resize according to body text (with maximum size of 800px) - currently it was 300px fixed, so longer error messages were hard to read
* error messages require user interaction in order to disappear - close button is shown