### PR TITLE
Message receiver reinitialization after schemaVersionAwareSerialization update

### DIFF
--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/SerialConsumer.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/SerialConsumer.java
@@ -159,8 +159,10 @@ public class SerialConsumer implements Consumer {
 
     @Override
     public void updateTopic(Topic newTopic) {
-        if (this.topic.getContentType() != newTopic.getContentType() || messageSizeChanged(newTopic)) {
-            logger.info("Reinitializing message receiver, contentType or messageSize changed.");
+        if (this.topic.getContentType() != newTopic.getContentType()
+                || messageSizeChanged(newTopic)
+                || this.topic.isSchemaVersionAwareSerializationEnabled() != newTopic.isSchemaVersionAwareSerializationEnabled()) {
+            logger.info("Reinitializing message receiver, contentType, messageSize or schemaVersionAwareSerialization changed.");
             this.topic = newTopic;
 
             messageReceiver.stop();


### PR DESCRIPTION
Reinitialize message receiver when schemaVersionAwareSerialization flag on topic is updated. Without this feature subscription had to be suspended and activated manually. 

This is an additional fix to #779 