### PR TITLE
#780 Fixed problem with topic removal due to metrics

### DIFF
--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/common/metric/counter/zookeeper/ZookeeperCounterStorage.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/common/metric/counter/zookeeper/ZookeeperCounterStorage.java
@@ -89,10 +89,15 @@ public class ZookeeperCounterStorage implements CounterStorage {
 
     @Override
     public void setInflightCounter(TopicName topicName, String subscriptionName, long count) {
-        distributedCounter.setCounterValue(
-                pathsCompiler.compile(appendRootPath(SUBSCRIPTION_INFLIGHT_FULL_PATH),
-                        subscriptionPathContext(topicName, subscriptionName)),
-                        count);
+        try {
+            subscriptionRepository.ensureSubscriptionExists(topicName, subscriptionName);
+            distributedCounter.setCounterValue(
+                    pathsCompiler.compile(appendRootPath(SUBSCRIPTION_INFLIGHT_FULL_PATH),
+                            subscriptionPathContext(topicName, subscriptionName)),
+                            count);
+        } catch (SubscriptionNotExistsException e) {
+            LOGGER.debug("Trying to report metric on not existing subscription {} {}", topicName, subscriptionName);
+        }
     }
 
     @Override

--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/infrastructure/zookeeper/ZookeeperBasedRepository.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/infrastructure/zookeeper/ZookeeperBasedRepository.java
@@ -131,6 +131,15 @@ public abstract class ZookeeperBasedRepository {
         }
     }
 
+    protected boolean isEmpty(String path) {
+        try {
+            byte[] data = zookeeper.getData().forPath(path);
+            return data.length == 0;
+        } catch (Exception e) {
+            throw new InternalProcessingException(e);
+        }
+    }
+
     private interface ThrowingReader<T> {
         T read(byte[] data) throws IOException;
     }

--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/infrastructure/zookeeper/ZookeeperTopicRepository.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/infrastructure/zookeeper/ZookeeperTopicRepository.java
@@ -91,7 +91,10 @@ public class ZookeeperTopicRepository extends ZookeeperBasedRepository implement
     }
 
     private void ensureTopicIsEmpty(TopicName topicName) {
-        if (!childrenOf(paths.subscriptionsPath(topicName)).isEmpty()) {
+        List<String> children = childrenOf(paths.subscriptionsPath(topicName));
+        boolean anyNodeNotEmpty = children.stream()
+                .anyMatch(sub -> !isEmpty(paths.subscriptionsPath(topicName) + "/" + sub));
+        if (!children.isEmpty() && anyNodeNotEmpty) {
             throw new TopicNotEmptyException(topicName);
         }
     }

--- a/hermes-common/src/test/groovy/pl/allegro/tech/hermes/test/IntegrationTest.groovy
+++ b/hermes-common/src/test/groovy/pl/allegro/tech/hermes/test/IntegrationTest.groovy
@@ -9,6 +9,7 @@ import pl.allegro.tech.hermes.infrastructure.zookeeper.ZookeeperGroupRepository
 import pl.allegro.tech.hermes.infrastructure.zookeeper.ZookeeperPaths
 import pl.allegro.tech.hermes.infrastructure.zookeeper.ZookeeperSubscriptionRepository
 import pl.allegro.tech.hermes.infrastructure.zookeeper.ZookeeperTopicRepository
+import pl.allegro.tech.hermes.metrics.PathsCompiler
 import pl.allegro.tech.hermes.test.helper.zookeeper.ZookeeperResource
 import spock.lang.Shared
 import spock.lang.Specification
@@ -23,7 +24,9 @@ abstract class IntegrationTest extends Specification {
         starter.curator().create().creatingParentsIfNeeded().forPath("/hermes/groups")
     } as Consumer)
 
-    protected ZookeeperPaths paths = new ZookeeperPaths("/hermes")
+    static final String BASE_ZOOKEEPER_PATH = "/hermes"
+
+    protected ZookeeperPaths paths = new ZookeeperPaths(BASE_ZOOKEEPER_PATH)
 
     protected RepositoryWaiter wait = new RepositoryWaiter(zookeeperResource.curator(), paths)
 
@@ -36,6 +39,8 @@ abstract class IntegrationTest extends Specification {
     protected ZookeeperSubscriptionRepository subscriptionRepository = new ZookeeperSubscriptionRepository(zookeeper(), mapper, paths, topicRepository)
 
     protected KafkaNamesMapper kafkaNamesMapper = new NamespaceKafkaNamesMapper("")
+
+    protected PathsCompiler pathsCompiler = new PathsCompiler("")
 
     protected CuratorFramework zookeeper() {
         return zookeeperResource.curator()

--- a/hermes-common/src/test/java/pl/allegro/tech/hermes/common/metric/counter/zookeeper/ZookeeperCounterStorageTest.java
+++ b/hermes-common/src/test/java/pl/allegro/tech/hermes/common/metric/counter/zookeeper/ZookeeperCounterStorageTest.java
@@ -137,4 +137,19 @@ public class ZookeeperCounterStorageTest {
         //then
         verifyZeroInteractions(sharedCounter);
     }
+
+    @Test
+    public void shouldNotIncrementInflightCounterForNonExistingSubscription() {
+        //given
+        TopicName topicName = TopicName.fromQualifiedName("test.topic");
+        String subscriptionName = "sub";
+        doThrow(new SubscriptionNotExistsException(topicName, subscriptionName))
+                .when(subscriptionRepository).ensureSubscriptionExists(topicName, subscriptionName);
+
+        //when
+        storage.setInflightCounter(topicName, subscriptionName, 1L);
+
+        //then
+        verifyZeroInteractions(sharedCounter);
+    }
 }


### PR DESCRIPTION
There is validation on topic removal that there are no subscriptions on
that topic. But in the same time the metric which has subpath same as
subscription path is stored (e.g. subscription path is
/groups/{group}/topics/{topic}/subscriptions/{sub} and metric path is
/groups/{group}/topics/{topic}/subscriptions/{sub}/metrics/delivered
Validation checks only if path exists.

The situation when there were no subscription but metric was stored
may be caused by missing subscription check while storing inflight
counter or because of the race condition (removing topic and storing
metric at the same time).

The solution is to check if data for subscription path is actually
present and also to add missing check.