### PR TITLE
Fixed retransmission bug in hermes-console

### DIFF
--- a/hermes-console/static/js/console/subscription/SubscriptionController.js
+++ b/hermes-console/static/js/console/subscription/SubscriptionController.js
@@ -27,7 +27,7 @@ subscriptions.controller('SubscriptionController', ['SubscriptionRepository', 'S
         $scope.metricsUrls = subscriptionMetrics.metricsUrls(groupName, topicName, subscriptionName);
 
         topicRepository.get(topicName).then(function(topic) {
-            initRetransmissionCalendar(topic.topic.retentionTime.duration);
+            initRetransmissionCalendar(topic.retentionTime.duration);
         });
 
         subscriptionMetrics.metrics(topicName, subscriptionName).then(function(metrics) {


### PR DESCRIPTION
Attempt to select starting date for messages retransmission (subscription management screen) ends up with JS console errors. Bug introduced [here](https://github.com/allegro/hermes/commit/49df75281cfa81c236504dc8ec7e95d1ca5e6e1a#diff-dde55599949256892447ffd2141c45b4L41).