### PR TITLE
Add offline store information

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ hermes-console/build
 hermes-console/out
 hermes-console/coverage
 hermes-console/test_out
+hermes-console/package-lock.json
 
 hermes-console/static/components
 

--- a/hermes-api/src/main/java/pl/allegro/tech/hermes/api/OfflineRetentionTime.java
+++ b/hermes-api/src/main/java/pl/allegro/tech/hermes/api/OfflineRetentionTime.java
@@ -1,0 +1,49 @@
+package pl.allegro.tech.hermes.api;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import javax.validation.constraints.Min;
+import java.util.Objects;
+
+public class OfflineRetentionTime {
+
+    @Min(1)
+    private final Integer duration;
+
+    private final boolean infinite;
+
+    public OfflineRetentionTime(@JsonProperty("duration") Integer duration, @JsonProperty("infinite") boolean infinite) {
+        this.infinite = infinite;
+        this.duration = infinite ? null : duration;
+    }
+
+    public static OfflineRetentionTime of(int duration) {
+        return new OfflineRetentionTime(duration, false);
+    }
+
+    public static OfflineRetentionTime infinite() {
+        return new OfflineRetentionTime(null, false);
+    }
+
+    public int getDuration() {
+        return duration;
+    }
+
+    public boolean isInfinite() {
+        return infinite;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof OfflineRetentionTime)) return false;
+        OfflineRetentionTime that = (OfflineRetentionTime) o;
+        return infinite == that.infinite &&
+                Objects.equals(duration, that.duration);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(duration, infinite);
+    }
+}

--- a/hermes-api/src/main/java/pl/allegro/tech/hermes/api/PublishingAuth.java
+++ b/hermes-api/src/main/java/pl/allegro/tech/hermes/api/PublishingAuth.java
@@ -15,13 +15,13 @@ public class PublishingAuth {
 
     @JsonCreator
     public PublishingAuth(@JsonProperty("publishers") List<String> publishers,
-                          @JsonProperty("enabled") boolean enabled,
-                          @JsonProperty("unauthenticatedAccessEnabled") boolean unauthenticatedAccessEnabled) {
+        @JsonProperty("enabled") boolean enabled,
+        @JsonProperty("unauthenticatedAccessEnabled") boolean unauthenticatedAccessEnabled) {
 
-        this.publishers = publishers;
-        this.enabled = enabled;
-        this.unauthenticatedAccessEnabled = unauthenticatedAccessEnabled;
-    }
+            this.publishers = publishers;
+            this.enabled = enabled;
+            this.unauthenticatedAccessEnabled = unauthenticatedAccessEnabled;
+        }
 
     public boolean isEnabled() {
         return enabled;

--- a/hermes-api/src/main/java/pl/allegro/tech/hermes/api/Topic.java
+++ b/hermes-api/src/main/java/pl/allegro/tech/hermes/api/Topic.java
@@ -57,10 +57,13 @@ public class Topic {
 
     private PublishingAuth publishingAuth;
 
+    private final TopicDataOfflineStorage offlineStorage;
+
     public Topic(TopicName name, String description, OwnerId owner, RetentionTime retentionTime,
                  boolean migratedFromJsonType, Ack ack, boolean trackingEnabled, ContentType contentType,
                  boolean jsonToAvroDryRunEnabled, boolean schemaVersionAwareSerializationEnabled,
-                 int maxMessageSize, PublishingAuth publishingAuth, boolean subscribingRestricted) {
+                 int maxMessageSize, PublishingAuth publishingAuth, boolean subscribingRestricted,
+                 TopicDataOfflineStorage offlineStorage) {
         this.name = name;
         this.description = description;
         this.owner = owner;
@@ -74,6 +77,7 @@ public class Topic {
         this.maxMessageSize = maxMessageSize;
         this.publishingAuth = publishingAuth;
         this.subscribingRestricted = subscribingRestricted;
+        this.offlineStorage = offlineStorage;
     }
 
     @JsonCreator
@@ -90,13 +94,16 @@ public class Topic {
             @JsonProperty("contentType") ContentType contentType,
             @JsonProperty("maxMessageSize") Integer maxMessageSize,
             @JsonProperty("auth") PublishingAuth publishingAuth,
-            @JsonProperty("subscribingRestricted") boolean subscribingRestricted
+            @JsonProperty("subscribingRestricted") boolean subscribingRestricted,
+            @JsonProperty("offlineStorage") TopicDataOfflineStorage offlineStorage
             ) {
         this(TopicName.fromQualifiedName(qualifiedName), description, owner, retentionTime, migratedFromJsonType, ack,
                 trackingEnabled, contentType, jsonToAvroDryRunEnabled, schemaVersionAwareSerializationEnabled,
                 maxMessageSize == null ? DEFAULT_MAX_MESSAGE_SIZE : maxMessageSize,
                 publishingAuth == null ? PublishingAuth.disabled() : publishingAuth,
-                subscribingRestricted);
+                subscribingRestricted,
+                offlineStorage == null ? TopicDataOfflineStorage.defaultOfflineStorage() : offlineStorage
+        );
     }
 
     public RetentionTime getRetentionTime() {
@@ -106,7 +113,8 @@ public class Topic {
     @Override
     public int hashCode() {
         return Objects.hash(name, description, owner, retentionTime, migratedFromJsonType, trackingEnabled, ack, contentType,
-                jsonToAvroDryRunEnabled, schemaVersionAwareSerializationEnabled, maxMessageSize, publishingAuth, subscribingRestricted);
+                jsonToAvroDryRunEnabled, schemaVersionAwareSerializationEnabled, maxMessageSize, publishingAuth, subscribingRestricted,
+                offlineStorage);
     }
 
     @Override
@@ -131,7 +139,8 @@ public class Topic {
                 && Objects.equals(this.contentType, other.contentType)
                 && Objects.equals(this.maxMessageSize, other.maxMessageSize)
                 && Objects.equals(this.subscribingRestricted, other.subscribingRestricted)
-                && Objects.equals(this.publishingAuth, other.publishingAuth);
+                && Objects.equals(this.publishingAuth, other.publishingAuth)
+                && Objects.equals(this.offlineStorage, other.offlineStorage);
     }
 
     @JsonProperty("name")
@@ -208,6 +217,10 @@ public class Topic {
 
     public boolean isSubscribingRestricted() {
         return subscribingRestricted;
+    }
+
+    public TopicDataOfflineStorage getOfflineStorage() {
+        return offlineStorage;
     }
 
     @Override

--- a/hermes-api/src/main/java/pl/allegro/tech/hermes/api/TopicDataOfflineStorage.java
+++ b/hermes-api/src/main/java/pl/allegro/tech/hermes/api/TopicDataOfflineStorage.java
@@ -1,0 +1,25 @@
+package pl.allegro.tech.hermes.api;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class TopicOfflineStorage {
+
+    private final boolean store;
+
+    private final int retention;
+
+    @JsonCreator
+    public TopicOfflineStorage(@JsonProperty("store") boolean store, @JsonProperty("retention") int retention) {
+        this.store = store;
+        this.retention = retention;
+    }
+
+    public boolean isStore() {
+        return store;
+    }
+
+    public int getRetention() {
+        return retention;
+    }
+}

--- a/hermes-api/src/main/java/pl/allegro/tech/hermes/api/TopicDataOfflineStorage.java
+++ b/hermes-api/src/main/java/pl/allegro/tech/hermes/api/TopicDataOfflineStorage.java
@@ -3,23 +3,51 @@ package pl.allegro.tech.hermes.api;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-public class TopicOfflineStorage {
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+import java.util.Objects;
 
-    private final boolean store;
+/**
+ * Topic offline storage metadata - not used in Hermes, but exposed as part of API for other systems to use.
+ */
+public class TopicDataOfflineStorage {
 
-    private final int retention;
+    private final boolean enabled;
+
+    @Valid
+    @NotNull
+    private final OfflineRetentionTime retentionTime;
 
     @JsonCreator
-    public TopicOfflineStorage(@JsonProperty("store") boolean store, @JsonProperty("retention") int retention) {
-        this.store = store;
-        this.retention = retention;
+    public TopicDataOfflineStorage(@JsonProperty("enabled") boolean enabled,
+                                   @JsonProperty("retentionTime") OfflineRetentionTime retentionTime) {
+        this.enabled = enabled;
+        this.retentionTime = retentionTime;
     }
 
-    public boolean isStore() {
-        return store;
+    public static TopicDataOfflineStorage defaultOfflineStorage() {
+        return new TopicDataOfflineStorage(false, OfflineRetentionTime.of(0));
     }
 
-    public int getRetention() {
-        return retention;
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public OfflineRetentionTime getRetentionTime() {
+        return retentionTime;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof TopicDataOfflineStorage)) return false;
+        TopicDataOfflineStorage that = (TopicDataOfflineStorage) o;
+        return enabled == that.enabled &&
+                Objects.equals(retentionTime, that.retentionTime);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(enabled, retentionTime);
     }
 }

--- a/hermes-api/src/main/java/pl/allegro/tech/hermes/api/TopicWithSchema.java
+++ b/hermes-api/src/main/java/pl/allegro/tech/hermes/api/TopicWithSchema.java
@@ -16,7 +16,7 @@ public class TopicWithSchema extends Topic {
         this(schema, topic.getQualifiedName(), topic.getDescription(), topic.getOwner(), topic.getRetentionTime(),
                 topic.isJsonToAvroDryRunEnabled(), topic.getAck(), topic.isTrackingEnabled(), topic.wasMigratedFromJsonType(),
                 topic.isSchemaVersionAwareSerializationEnabled(), topic.getContentType(), topic.getMaxMessageSize(),
-                topic.getPublishingAuth(), topic.isSubscribingRestricted());
+                topic.getPublishingAuth(), topic.isSubscribingRestricted(), topic.getOfflineStorage());
     }
 
     @JsonCreator
@@ -33,9 +33,11 @@ public class TopicWithSchema extends Topic {
                            @JsonProperty("contentType") ContentType contentType,
                            @JsonProperty("maxMessageSize") Integer maxMessageSize,
                            @JsonProperty("auth") PublishingAuth publishingAuth,
-                           @JsonProperty("subscribingRestricted") boolean subscribingRestricted) {
+                           @JsonProperty("subscribingRestricted") boolean subscribingRestricted,
+                           @JsonProperty("offlineStorage") TopicDataOfflineStorage offlineStorage) {
         super(qualifiedName, description, owner, retentionTime, jsonToAvroDryRunEnabled, ack, trackingEnabled,
-                migratedFromJsonType, schemaVersionAwareSerializationEnabled, contentType, maxMessageSize, publishingAuth, subscribingRestricted);
+                migratedFromJsonType, schemaVersionAwareSerializationEnabled, contentType, maxMessageSize,
+                publishingAuth, subscribingRestricted, offlineStorage);
         this.topic = convertToTopic();
         this.schema = schema;
     }
@@ -51,7 +53,8 @@ public class TopicWithSchema extends Topic {
     private Topic convertToTopic() {
         return new Topic(this.getQualifiedName(), this.getDescription(), this.getOwner(), this.getRetentionTime(),
                 this.isJsonToAvroDryRunEnabled(), this.getAck(), this.isTrackingEnabled(), this.wasMigratedFromJsonType(),
-                this.isSchemaVersionAwareSerializationEnabled(), this.getContentType(), this.getMaxMessageSize(), this.getPublishingAuth(), this.isSubscribingRestricted());
+                this.isSchemaVersionAwareSerializationEnabled(), this.getContentType(), this.getMaxMessageSize(),
+                this.getPublishingAuth(), this.isSubscribingRestricted(), this.getOfflineStorage());
     }
 
     public String getSchema() {

--- a/hermes-console/static/js/console/topic/TopicFactory.js
+++ b/hermes-console/static/js/console/topic/TopicFactory.js
@@ -14,6 +14,12 @@ topics.factory('TopicFactory', ['TOPIC_CONFIG',
                     owner: {
                         id: '',
                         source: ''
+                    },
+                    offlineStorage: {
+                        enabled: false,
+                        retentionTime: {
+                            duration: 60
+                        }
                     }
                 };
                 _.merge(defaults, topicConfig.defaults);

--- a/hermes-console/static/partials/modal/editTopic.html
+++ b/hermes-console/static/partials/modal/editTopic.html
@@ -101,6 +101,31 @@
                     </div>
                 </div>
             </div>
+
+            <hr />
+            <div class="form-group">
+                <label for="topicStoreOffline" class="col-md-3 control-label">Store offline</label>
+                <div class="col-md-9">
+                    <input type="checkbox" id="topicStoreOffline" name="topicStoreOffline" ng-model="topic.offlineStorage.enabled"/>
+                </div>
+            </div>
+            <div class="form-group {{topicForm.topicOfflineRetention.$valid ? '' : 'has-error'}}" ng-show="topic.offlineStorage.enabled && !topic.offlineStorage.retentionTime.infinity">
+                <label for="topicOfflineRetention" class="col-md-3 control-label">Offline retention time</label>
+                <div class="col-md-9">
+                    <div class="input-group">
+                        <input type="number" min="1" max="120" required class="form-control" id="topicOfflineRetention" name="topicOfflineRetention" ng-model="topic.offlineStorage.retentionTime.duration" placeholder="how long should it be stored in offline storage?"/>
+                        <span class="input-group-addon">days</span>
+                    </div>
+                </div>
+            </div>
+            <div class="form-group">
+                <label for="topicOfflineRetentionInfinity" class="col-md-3 control-label">Keep forever</label>
+                <div class="col-md-9">
+                    <input type="checkbox" id="topicOfflineRetentionInfinity" name="topicOfflineRetentionInfinity" ng-model="topic.offlineStorage.retentionTime.infinity"/>
+                </div>
+            </div>
+
+            <hr />
             <div class="form-group {{topicForm.messageSchema.$valid ? '' : 'has-error'}}" ng-show="topic.contentType === 'AVRO'">
                 <label for="messageSchema" class="col-md-3 control-label">
                     <a href="http://hermes-pubsub.rtfd.org/en/latest/user/publishing-avro/" target="_blank">AVRO schema</a>

--- a/hermes-console/static/partials/topic.html
+++ b/hermes-console/static/partials/topic.html
@@ -92,6 +92,16 @@
                         <span uib-popover='When subscribing is restricted, only owner of this topic can create new subscriptions.' popover-trigger="mouseenter" class="fa helpme pull-right">&#xf128;</span>
                     </p>
 
+                    <hr />
+                    <p>
+                        <strong>Store offline:</strong> {{topic.offlineStorage.enabled}}
+                        <span uib-popover='Should data from this topic be stored in offline storage (e.g. HDFS).' popover-trigger="mouseenter" class="fa helpme pull-right">&#xf128;</span>
+                    </p>
+                    <p ng-show="topic.offlineStorage.enabled">
+                        <strong>Offline retention:</strong> {{topic.offlineStorage.retentionTime.infinite < 1 ? 'infinite' : topic.offlineStorage.retentionTime.duration + ' days'}}
+                        <span uib-popover='For how long should this topic be stored in offline storage.' popover-trigger="mouseenter" class="fa helpme pull-right">&#xf128;</span>
+                    </p>
+
                 </div>
             </div>
         </div>

--- a/hermes-test-helper/src/main/java/pl/allegro/tech/hermes/test/helper/builder/TopicBuilder.java
+++ b/hermes-test-helper/src/main/java/pl/allegro/tech/hermes/test/helper/builder/TopicBuilder.java
@@ -1,10 +1,12 @@
 package pl.allegro.tech.hermes.test.helper.builder;
 
 import pl.allegro.tech.hermes.api.ContentType;
+import pl.allegro.tech.hermes.api.OfflineRetentionTime;
 import pl.allegro.tech.hermes.api.OwnerId;
 import pl.allegro.tech.hermes.api.PublishingAuth;
 import pl.allegro.tech.hermes.api.RetentionTime;
 import pl.allegro.tech.hermes.api.Topic;
+import pl.allegro.tech.hermes.api.TopicDataOfflineStorage;
 import pl.allegro.tech.hermes.api.TopicName;
 
 import java.util.ArrayList;
@@ -42,6 +44,8 @@ public class TopicBuilder {
 
     private boolean subscribingRestricted = false;
 
+    private TopicDataOfflineStorage offlineStorage = TopicDataOfflineStorage.defaultOfflineStorage();
+
     private TopicBuilder(TopicName topicName) {
         this.name = topicName;
     }
@@ -62,7 +66,8 @@ public class TopicBuilder {
         return new Topic(
                 name, description, owner, retentionTime, migratedFromJsonType, ack, trackingEnabled, contentType,
                 jsonToAvroDryRunEnabled, schemaVersionAwareSerialization, maxMessageSize,
-                new PublishingAuth(publishers, authEnabled, unauthenticatedAccessEnabled), subscribingRestricted
+                new PublishingAuth(publishers, authEnabled, unauthenticatedAccessEnabled), subscribingRestricted,
+                offlineStorage
         );
     }
 
@@ -138,6 +143,11 @@ public class TopicBuilder {
 
     public TopicBuilder withUnauthenticatedAccessDisabled() {
         this.unauthenticatedAccessEnabled = false;
+        return this;
+    }
+
+    public TopicBuilder withOfflineStorage(int days) {
+        this.offlineStorage = new TopicDataOfflineStorage(true, OfflineRetentionTime.of(days));
         return this;
     }
 }

--- a/vagrant_provisioning/install_kafka.sh
+++ b/vagrant_provisioning/install_kafka.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-KAFKA_VERSION=0.10.1.0
+KAFKA_VERSION=0.10.2.1
 SCALA_VERSION=2.10
 
 if [ ! -d /opt/kafka ]; then


### PR DESCRIPTION
Offline storage metadata are not actually used in Hermes, but they can signal if systems like Goblin or Camus should dump data from underlying Kafka topic onto offline store (e.g. HDFS)