### PR TITLE
Splits unit, integration and JMH tests into separate, parallel builds on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,16 @@
-sudo: required
+sudo: false
 dist: trusty
 
 language: java
 
+env:
+  - TEST_SUITE=check
+  - TEST_SUITE=integrationTest
+  - TEST_SUITE="jmh -Pjmh.iterations=1 -Pjmh.timeOnIteration=5s -Pjmh.warmupIterations=0"
+
 install: ./gradlew assemble
 script:
-  - "./gradlew check -Ptests.timeout.multiplier=3"
-  - "./gradlew -Ptests.timeout.multiplier=3 integrationTest"
-  - "./gradlew jmh -Pjmh.iterations=1 -Pjmh.timeOnIteration=5s -Pjmh.warmupIterations=0 -Pjmh.jvmArgs=\"-Xmx256m -XX:+UseConcMarkSweepGC\""
+  - "./gradlew -Ptests.timeout.multiplier=3 $TEST_SUITE"
 
 jdk:
   - oraclejdk8
@@ -22,10 +25,3 @@ branches:
       - master
       - develop
 
-before_cache:
-  - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
-  - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
-cache:
-  directories:
-    - $HOME/.gradle/caches/
-    - $HOME/.gradle/wrapper/

--- a/hermes-benchmark/build.gradle
+++ b/hermes-benchmark/build.gradle
@@ -11,13 +11,13 @@ jmh {
     humanOutputFile = null
     jmhVersion = '1.12'
     zip64 = true
-    verbosity = 'EXTRA'
+    verbosity = 'SILENT'
     iterations = intProperty('jmh.iterations', 4)
     timeOnIteration = stringProperty('jmh.timeOnIteration', '80s')
     fork = intProperty('jmh.fork', 1)
     warmupIterations = intProperty('jmh.warmupIterations', 4)
     warmup = stringProperty('jmh.timeOnWarmupIteration', '80s')
-    jvmArgs = listProperty('jmh.jvmArgs', ['-Xmx1g', '-Xms1g', '-XX:+UseConcMarkSweepGC', '-XX:+CMSIncrementalMode'])
+    jvmArgs = listProperty('jmh.jvmArgs', ['-Xmx1g', '-Xms1g', '-XX:+UseConcMarkSweepGC'])
     failOnError = booleanProperty('jmh.failOnError', true)
     threads = intProperty('jmh.threads', 4)
     synchronizeIterations = false

--- a/integration/build.gradle
+++ b/integration/build.gradle
@@ -46,7 +46,7 @@ def getAlpnVersion() {
                 return '8.1.9.v20160720'
             case 112..120:
                 return '8.1.10.v20161026'
-            case 121..144:
+            case 121..151:
                 return '8.1.11.v20170118'
             default:
                 throw new IllegalStateException("ALPN version not defined for Java version: ${javaVersion}; extracted minor version: ${version}")


### PR DESCRIPTION
Removed caching because it basically doesn't work.