### PR TITLE
Clean schema cache on topic removal

### DIFF
--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/common/schema/AvroCompiledSchemaRepositoryFactory.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/common/schema/AvroCompiledSchemaRepositoryFactory.java
@@ -2,8 +2,11 @@ package pl.allegro.tech.hermes.common.schema;
 
 import org.apache.avro.Schema;
 import org.glassfish.hk2.api.Factory;
+import pl.allegro.tech.hermes.api.Topic;
 import pl.allegro.tech.hermes.common.config.ConfigFactory;
 import pl.allegro.tech.hermes.common.config.Configs;
+import pl.allegro.tech.hermes.domain.notifications.InternalNotificationsBus;
+import pl.allegro.tech.hermes.domain.notifications.TopicCallback;
 import pl.allegro.tech.hermes.schema.CachedCompiledSchemaRepository;
 import pl.allegro.tech.hermes.schema.CompiledSchemaRepository;
 import pl.allegro.tech.hermes.schema.DirectCompiledSchemaRepository;
@@ -16,19 +19,30 @@ public class AvroCompiledSchemaRepositoryFactory implements Factory<CompiledSche
 
     private final RawSchemaClient rawSchemaClient;
     private final ConfigFactory configFactory;
+    private final InternalNotificationsBus notificationsBus;
 
     @Inject
-    public AvroCompiledSchemaRepositoryFactory(RawSchemaClient rawSchemaClient, ConfigFactory configFactory) {
+    public AvroCompiledSchemaRepositoryFactory(RawSchemaClient rawSchemaClient, ConfigFactory configFactory, InternalNotificationsBus notificationsBus) {
         this.rawSchemaClient = rawSchemaClient;
         this.configFactory = configFactory;
+        this.notificationsBus = notificationsBus;
     }
 
     @Override
     public CompiledSchemaRepository<Schema> provide() {
-        return new CachedCompiledSchemaRepository<>(
+        CachedCompiledSchemaRepository<Schema> repository = new CachedCompiledSchemaRepository<>(
                 new DirectCompiledSchemaRepository<>(rawSchemaClient, SchemaCompilersFactory.avroSchemaCompiler()),
                 configFactory.getIntProperty(Configs.SCHEMA_CACHE_COMPILED_MAXIMUM_SIZE),
                 configFactory.getIntProperty(Configs.SCHEMA_CACHE_COMPILED_EXPIRE_AFTER_ACCESS_MINUTES));
+
+        notificationsBus.registerTopicCallback(new TopicCallback() {
+            @Override
+            public void onTopicRemoved(Topic topic) {
+                repository.removeFromCache(topic);
+            }
+        });
+
+        return repository;
     }
 
     @Override

--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/common/schema/SchemaVersionsRepositoryFactory.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/common/schema/SchemaVersionsRepositoryFactory.java
@@ -2,8 +2,11 @@ package pl.allegro.tech.hermes.common.schema;
 
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.glassfish.hk2.api.Factory;
+import pl.allegro.tech.hermes.api.Topic;
 import pl.allegro.tech.hermes.common.config.ConfigFactory;
 import pl.allegro.tech.hermes.common.config.Configs;
+import pl.allegro.tech.hermes.domain.notifications.InternalNotificationsBus;
+import pl.allegro.tech.hermes.domain.notifications.TopicCallback;
 import pl.allegro.tech.hermes.schema.CachedSchemaVersionsRepository;
 import pl.allegro.tech.hermes.schema.RawSchemaClient;
 import pl.allegro.tech.hermes.schema.SchemaVersionsRepository;
@@ -17,20 +20,31 @@ public class SchemaVersionsRepositoryFactory implements Factory<SchemaVersionsRe
 
     private final RawSchemaClient rawSchemaClient;
     private final ConfigFactory configFactory;
+    private final InternalNotificationsBus notificationsBus;
 
     @Inject
-    public SchemaVersionsRepositoryFactory(RawSchemaClient rawSchemaClient, ConfigFactory configFactory) {
+    public SchemaVersionsRepositoryFactory(RawSchemaClient rawSchemaClient, ConfigFactory configFactory, InternalNotificationsBus notificationsBus) {
         this.rawSchemaClient = rawSchemaClient;
         this.configFactory = configFactory;
+        this.notificationsBus = notificationsBus;
     }
 
     @Override
     public SchemaVersionsRepository provide() {
         if (configFactory.getBooleanProperty(Configs.SCHEMA_CACHE_ENABLED)) {
-            return new CachedSchemaVersionsRepository(rawSchemaClient,
+            CachedSchemaVersionsRepository repository = new CachedSchemaVersionsRepository(rawSchemaClient,
                     getVersionsReloader(),
                     configFactory.getIntProperty(Configs.SCHEMA_CACHE_REFRESH_AFTER_WRITE_MINUTES),
                     configFactory.getIntProperty(Configs.SCHEMA_CACHE_EXPIRE_AFTER_WRITE_MINUTES));
+
+            notificationsBus.registerTopicCallback(new TopicCallback() {
+                @Override
+                public void onTopicRemoved(Topic topic) {
+                    repository.removeFromCache(topic);
+                }
+            });
+
+            return repository;
         }
         return new DirectSchemaVersionsRepository(rawSchemaClient);
     }

--- a/hermes-schema/src/main/java/pl/allegro/tech/hermes/schema/CachedCompiledSchemaRepository.java
+++ b/hermes-schema/src/main/java/pl/allegro/tech/hermes/schema/CachedCompiledSchemaRepository.java
@@ -6,7 +6,9 @@ import com.google.common.cache.LoadingCache;
 import pl.allegro.tech.hermes.api.Topic;
 
 import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 public class CachedCompiledSchemaRepository<T> implements CompiledSchemaRepository<T> {
 
@@ -27,6 +29,13 @@ public class CachedCompiledSchemaRepository<T> implements CompiledSchemaReposito
         } catch (Exception e) {
             throw new CouldNotLoadSchemaException(e);
         }
+    }
+
+    public void removeFromCache(Topic topic) {
+        Set<TopicAndSchemaVersion> topicWithSchemas = cache.asMap().keySet().stream()
+                .filter(topicWithSchema -> topicWithSchema.topic.equals(topic))
+                .collect(Collectors.toSet());
+        cache.invalidateAll(topicWithSchemas);
     }
 
     private static class CompiledSchemaLoader<T> extends CacheLoader<TopicAndSchemaVersion, CompiledSchema<T>> {

--- a/hermes-schema/src/main/java/pl/allegro/tech/hermes/schema/CachedSchemaVersionsRepository.java
+++ b/hermes-schema/src/main/java/pl/allegro/tech/hermes/schema/CachedSchemaVersionsRepository.java
@@ -59,6 +59,10 @@ public class CachedSchemaVersionsRepository implements SchemaVersionsRepository 
         }
     }
 
+    public void removeFromCache(Topic topic) {
+        versionsCache.invalidate(topic);
+    }
+
     private static class SchemaVersionsLoader extends CacheLoader<Topic, List<SchemaVersion>> {
 
         private final RawSchemaClient rawSchemaClient;

--- a/hermes-schema/src/test/groovy/pl/allegro/tech/hermes/schema/CachedCompiledSchemaRepositoryTest.groovy
+++ b/hermes-schema/src/test/groovy/pl/allegro/tech/hermes/schema/CachedCompiledSchemaRepositoryTest.groovy
@@ -13,7 +13,7 @@ class CachedCompiledSchemaRepositoryTest extends Specification {
 
     def "should provide schema from source of given version"() {
         given:
-        def version = SchemaVersion.valueOf(1);
+        def version = SchemaVersion.valueOf(1)
         def schema = new CompiledSchema('stuff', version)
         delegate.getSchema(topic, version) >> schema
 
@@ -23,7 +23,7 @@ class CachedCompiledSchemaRepositoryTest extends Specification {
 
     def "should provide previously compiled schema without reloading its schema source"() {
         given:
-        def version = SchemaVersion.valueOf(1);
+        def version = SchemaVersion.valueOf(1)
         def firstSchema = new CompiledSchema('stuff', version)
         def secondSchema = new CompiledSchema('other stuff', version)
 
@@ -36,7 +36,7 @@ class CachedCompiledSchemaRepositoryTest extends Specification {
 
     def "should fail to provide schema if delegate failed to load it"() {
         given:
-        def version = SchemaVersion.valueOf(1);
+        def version = SchemaVersion.valueOf(1)
         delegate.getSchema(topic, version) >> { throw new RuntimeException("loading failed") }
 
         when:
@@ -44,6 +44,24 @@ class CachedCompiledSchemaRepositoryTest extends Specification {
 
         then:
         thrown CouldNotLoadSchemaException
+    }
+
+    def "should remove schema from cache on topic removal"() {
+        given:
+        def version = SchemaVersion.valueOf(1)
+        def firstSchema = new CompiledSchema('stuff', version)
+        def secondSchema = new CompiledSchema('other stuff', version)
+
+        delegate.getSchema(topic, version) >>> [firstSchema, secondSchema]
+
+        expect:
+        repository.getSchema(topic, version) == firstSchema
+
+        when:
+        repository.removeFromCache(topic)
+
+        then:
+        repository.getSchema(topic, version) == secondSchema
     }
 
 }

--- a/hermes-schema/src/test/groovy/pl/allegro/tech/hermes/schema/CachedSchemaVersionsRepositoryTest.groovy
+++ b/hermes-schema/src/test/groovy/pl/allegro/tech/hermes/schema/CachedSchemaVersionsRepositoryTest.groovy
@@ -117,4 +117,18 @@ class CachedSchemaVersionsRepositoryTest extends Specification {
         versionsRepository.schemaVersionExists(topic, v1)
         versionsRepository.latestSchemaVersion(topic).get() == v1
     }
+
+    def "should remove schema version from cache on topic removal"() {
+        given:
+        rawSchemaClient.getVersions(topic.getName()) >>> [[v1], [v0]]
+
+        expect:
+        versionsRepository.versions(topic, false) == [v1]
+
+        when:
+        versionsRepository.removeFromCache(topic)
+
+        then:
+        versionsRepository.versions(topic, false) == [v0]
+    }
 }


### PR DESCRIPTION
Fixes #811

I haven't included integrations tests, because Confluent Schema Registry does not allow to remove schema. I would have to mock rawClient which is already done in unit tests.