### PR TITLE
Console subscription name regexp fix

### DIFF
--- a/hermes-console/static/partials/modal/editSubscription.html
+++ b/hermes-console/static/partials/modal/editSubscription.html
@@ -15,7 +15,7 @@
             <div class="form-group {{subscriptionForm.subscriptionName.$valid ? '' : 'has-error'}} " ng-show="operation === 'ADD'">
                 <label for="subscriptionName" class="col-md-3 control-label">Name</label>
                 <div class="col-md-9">
-                    <input class="form-control" id="subscriptionName" name="subscriptionName" required placeholder="name of subscription" ng-model="subscription.name" ng-pattern="/^[a-zA-Z0-9.-]+$/"/>
+                    <input class="form-control" id="subscriptionName" name="subscriptionName" required placeholder="name of subscription" ng-model="subscription.name" ng-pattern="/^[a-zA-Z0-9._-]+$/"/>
                 </div>
             </div>
 


### PR DESCRIPTION
There was a difference in subscription name regexp between `hermes-console` nad `hermes-management`, so subscriptions with `_` in the name created via hermes http api could not be edited through console, as the name was invalid. 