### PR TITLE
fixed bug with time conversion when reading message_ttl for batch sub

### DIFF
--- a/hermes-api/src/main/java/pl/allegro/tech/hermes/api/BatchSubscriptionPolicy.java
+++ b/hermes-api/src/main/java/pl/allegro/tech/hermes/api/BatchSubscriptionPolicy.java
@@ -10,7 +10,7 @@ import java.util.Objects;
 
 public class BatchSubscriptionPolicy {
 
-    private static final int DEFAULT_MESSAGE_TTL = 60 * 1000;
+    private static final int DEFAULT_MESSAGE_TTL = 60;
     private static final int DEFAULT_MESSAGE_BACKOFF = 500;
     private static final int DEFAULT_REQUEST_TIMEOUT = 30 * 1000;
     private static final int DEFAULT_BATCH_SIZE = 100;

--- a/integration/src/integration/java/pl/allegro/tech/hermes/integration/BatchDeliveryTest.java
+++ b/integration/src/integration/java/pl/allegro/tech/hermes/integration/BatchDeliveryTest.java
@@ -169,7 +169,7 @@ public class BatchDeliveryTest extends IntegrationTest {
     private BatchSubscriptionPolicy.Builder buildBatchPolicy() {
         return batchSubscriptionPolicy()
                 .applyDefaults()
-                .withMessageTtl(100 * 1000)
+                .withMessageTtl(100)
                 .withRequestTimeout(100)
                 .withMessageBackoff(10);
     }


### PR DESCRIPTION
User supplied ttl in seconds but we expected milliseconds.