### PR TITLE
Supporting schema-registry validation endpoint

### DIFF
--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/config/SchemaRepositoryConfiguration.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/config/SchemaRepositoryConfiguration.java
@@ -45,7 +45,8 @@ public class SchemaRepositoryConfiguration {
     @ConditionalOnMissingBean(RawSchemaClient.class)
     @ConditionalOnProperty(value = "schema.repository.type", havingValue = "schema_registry")
     public RawSchemaClient schemaRegistryRawSchemaClient(Client httpClient, ObjectMapper objectMapper) {
-        return new SchemaRegistryRawSchemaClient(httpClient, URI.create(schemaRepositoryProperties.getServerUrl()), objectMapper);
+        return new SchemaRegistryRawSchemaClient(httpClient, URI.create(schemaRepositoryProperties.getServerUrl()),
+                objectMapper, schemaRepositoryProperties.isValidationEnabled());
     }
 
     @Bean

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/config/SchemaRepositoryProperties.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/config/SchemaRepositoryProperties.java
@@ -10,6 +10,8 @@ public class SchemaRepositoryProperties {
 
     private String serverUrl = Configs.SCHEMA_REPOSITORY_SERVER_URL.getDefaultValue();
 
+    private boolean validationEnabled = false;
+
     public String getType() {
         return type;
     }
@@ -24,5 +26,13 @@ public class SchemaRepositoryProperties {
 
     public void setServerUrl(String serverUrl) {
         this.serverUrl = serverUrl;
+    }
+
+    public boolean isValidationEnabled() {
+        return validationEnabled;
+    }
+
+    public void setValidationEnabled(boolean validationEnabled) {
+        this.validationEnabled = validationEnabled;
     }
 }

--- a/hermes-schema/src/main/java/pl/allegro/tech/hermes/schema/confluent/SchemaRegistryCompatibilityResponse.java
+++ b/hermes-schema/src/main/java/pl/allegro/tech/hermes/schema/confluent/SchemaRegistryCompatibilityResponse.java
@@ -1,0 +1,37 @@
+package pl.allegro.tech.hermes.schema.confluent;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Objects;
+
+class SchemaRegistryCompatibilityResponse {
+
+    private final boolean compatible;
+
+    @JsonCreator
+    SchemaRegistryCompatibilityResponse(@JsonProperty("is_compatible") boolean compatible) {
+        this.compatible = compatible;
+    }
+
+    public boolean isCompatible() {
+        return compatible;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        SchemaRegistryCompatibilityResponse that = (SchemaRegistryCompatibilityResponse) o;
+        return compatible == that.compatible;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(compatible);
+    }
+}

--- a/hermes-schema/src/main/java/pl/allegro/tech/hermes/schema/confluent/SchemaRegistryValidationError.java
+++ b/hermes-schema/src/main/java/pl/allegro/tech/hermes/schema/confluent/SchemaRegistryValidationError.java
@@ -1,0 +1,32 @@
+package pl.allegro.tech.hermes.schema.confluent;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Objects;
+
+class SchemaRegistryValidationError {
+    private final String message;
+
+    @JsonCreator
+    SchemaRegistryValidationError(@JsonProperty("message") String message) {
+        this.message = message;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof SchemaRegistryValidationError)) return false;
+        SchemaRegistryValidationError that = (SchemaRegistryValidationError) o;
+        return Objects.equals(message, that.message);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(message);
+    }
+}

--- a/hermes-schema/src/main/java/pl/allegro/tech/hermes/schema/confluent/SchemaRegistryValidationError.java
+++ b/hermes-schema/src/main/java/pl/allegro/tech/hermes/schema/confluent/SchemaRegistryValidationError.java
@@ -1,10 +1,12 @@
 package pl.allegro.tech.hermes.schema.confluent;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.Objects;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 class SchemaRegistryValidationError {
     private final String message;
 

--- a/hermes-schema/src/main/java/pl/allegro/tech/hermes/schema/confluent/SchemaRegistryValidationResponse.java
+++ b/hermes-schema/src/main/java/pl/allegro/tech/hermes/schema/confluent/SchemaRegistryValidationResponse.java
@@ -1,37 +1,29 @@
 package pl.allegro.tech.hermes.schema.confluent;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import java.util.Objects;
+import java.util.List;
+import java.util.stream.Collectors;
 
-public class SchemaRegistryValidationResponse {
+class SchemaRegistryValidationResponse {
 
-    private final boolean compatible;
+    private final boolean valid;
+    private final List<SchemaRegistryValidationError> errors;
 
     @JsonCreator
-    SchemaRegistryValidationResponse(@JsonProperty("is_compatible") boolean compatible) {
-        this.compatible = compatible;
+    SchemaRegistryValidationResponse(@JsonProperty("is_valid") boolean valid, @JsonProperty("errors") List<SchemaRegistryValidationError> errors) {
+        this.valid = valid;
+        this.errors = errors;
     }
 
-    public boolean isCompatible() {
-        return compatible;
+    public boolean isValid() {
+        return valid;
     }
 
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        SchemaRegistryValidationResponse that = (SchemaRegistryValidationResponse) o;
-        return compatible == that.compatible;
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(compatible);
+    @JsonIgnore
+    public String getErrorsMessage() {
+        return errors.stream().map(error -> error.getMessage()).collect(Collectors.joining(". "));
     }
 }

--- a/hermes-schema/src/test/groovy/pl/allegro/tech/hermes/schema/confluent/SchemaRegistryRawSchemaClientTest.groovy
+++ b/hermes-schema/src/test/groovy/pl/allegro/tech/hermes/schema/confluent/SchemaRegistryRawSchemaClientTest.groovy
@@ -299,7 +299,7 @@ class SchemaRegistryRawSchemaClientTest extends Specification {
                 """
 { "is_valid": false,
   "errors": [
-    {"message": "missing doc field"},
+    {"message": "missing doc field", "ignoredField": true},
     {"message": "name should start with uppercase"}
   ]
 }""")))

--- a/hermes-schema/src/test/groovy/pl/allegro/tech/hermes/schema/confluent/SchemaRegistryRawSchemaClientTest.groovy
+++ b/hermes-schema/src/test/groovy/pl/allegro/tech/hermes/schema/confluent/SchemaRegistryRawSchemaClientTest.groovy
@@ -36,10 +36,12 @@ class SchemaRegistryRawSchemaClientTest extends Specification {
 
     @Shared WireMockServer wireMock
 
+    @Shared int port
+
     @Shared @Subject RawSchemaClient client
 
     def setupSpec() {
-        def port = Ports.nextAvailable()
+        port = Ports.nextAvailable()
         wireMock = new WireMockServer(port)
         wireMock.start()
         client = new SchemaRegistryRawSchemaClient(ClientBuilder.newClient(), URI.create("http://localhost:$port"), new ObjectMapper())
@@ -202,9 +204,9 @@ class SchemaRegistryRawSchemaClientTest extends Specification {
         thrown(BadSchemaRequestException)
     }
 
-    def "should validate schema"() {
+    def "should verify schema compatibility"() {
         given:
-        wireMock.stubFor(post(schemaValidationUrl(topicName))
+        wireMock.stubFor(post(schemaCompatibilityUrl(topicName))
                 .willReturn(okResponse()
                 .withHeader("Content-type", "application/json")
                 .withBody("""{"is_compatible":true}""")))
@@ -214,14 +216,14 @@ class SchemaRegistryRawSchemaClientTest extends Specification {
 
         then:
         noExceptionThrown()
-        wireMock.verify(1, postRequestedFor(schemaValidationUrl(topicName))
+        wireMock.verify(1, postRequestedFor(schemaCompatibilityUrl(topicName))
                 .withHeader("Content-type", equalTo(schemaRegistryContentType))
                 .withRequestBody(equalTo("""{"schema":"{}"}""")))
     }
 
     def "should throw exception for incompatible schema"() {
         given:
-        wireMock.stubFor(post(schemaValidationUrl(topicName))
+        wireMock.stubFor(post(schemaCompatibilityUrl(topicName))
                 .willReturn(okResponse()
                 .withHeader("Content-type", "application/json")
                 .withBody("""{"is_compatible":false}""")))
@@ -235,7 +237,7 @@ class SchemaRegistryRawSchemaClientTest extends Specification {
 
     def "should throw exception for 422 unprocessable entity response"() {
         given:
-        wireMock.stubFor(post(schemaValidationUrl(topicName))
+        wireMock.stubFor(post(schemaCompatibilityUrl(topicName))
                 .willReturn(unprocessableEntityResponse()))
 
         when:
@@ -247,7 +249,7 @@ class SchemaRegistryRawSchemaClientTest extends Specification {
 
     def "should accept subject not found response as if schema is valid"() {
         given:
-        wireMock.stubFor(post(schemaValidationUrl(topicName))
+        wireMock.stubFor(post(schemaCompatibilityUrl(topicName))
                 .willReturn(notFoundResponse()))
 
         when:
@@ -255,6 +257,60 @@ class SchemaRegistryRawSchemaClientTest extends Specification {
 
         then:
         noExceptionThrown()
+    }
+
+    def "should successfully validate schema against validation endpoint"() {
+        boolean validationEnabled = true
+        client = new SchemaRegistryRawSchemaClient(ClientBuilder.newClient(), URI.create("http://localhost:$port"),
+                new ObjectMapper(), validationEnabled)
+
+        wireMock.stubFor(post(schemaCompatibilityUrl(topicName))
+                .willReturn(okResponse()
+                .withHeader("Content-type", "application/json")
+                .withBody("""{"is_compatible":true}""")))
+
+        wireMock.stubFor(post(schemaValidationUrl(topicName))
+                .willReturn(okResponse()
+                .withHeader("Content-type", "application/json")
+                .withBody("""{ "is_valid": true}""")))
+
+        when:
+        client.validateSchema(topicName, rawSchema)
+
+        then:
+        noExceptionThrown()
+    }
+
+    def "should receive errors from validation endpoint"() {
+        given:
+        boolean validationEnabled = true
+        client = new SchemaRegistryRawSchemaClient(ClientBuilder.newClient(), URI.create("http://localhost:$port"),
+                new ObjectMapper(), validationEnabled)
+
+        wireMock.stubFor(post(schemaCompatibilityUrl(topicName))
+                .willReturn(okResponse()
+                .withHeader("Content-type", "application/json")
+                .withBody("""{"is_compatible":true}""")))
+
+        wireMock.stubFor(post(schemaValidationUrl(topicName))
+                .willReturn(okResponse()
+                .withHeader("Content-type", "application/json")
+                .withBody(
+                """
+{ "is_valid": false,
+  "errors": [
+    {"message": "missing doc field"},
+    {"message": "name should start with uppercase"}
+  ]
+}""")))
+
+        when:
+        client.validateSchema(topicName, rawSchema)
+
+        then:
+        def e = thrown(BadSchemaRequestException)
+        e.message.contains("missing doc field")
+        e.message.contains("name should start with uppercase")
     }
 
     private UrlMatchingStrategy versionsUrl(TopicName topic) {
@@ -269,8 +325,12 @@ class SchemaRegistryRawSchemaClientTest extends Specification {
         urlEqualTo("/subjects/${topic.qualifiedName()}/versions/latest")
     }
 
-    private UrlMatchingStrategy schemaValidationUrl(TopicName topic) {
+    private UrlMatchingStrategy schemaCompatibilityUrl(TopicName topic) {
         urlEqualTo("/compatibility/subjects/${topic.qualifiedName()}/versions/latest")
+    }
+
+    private UrlMatchingStrategy schemaValidationUrl(TopicName topic) {
+        urlEqualTo("/subjects/${topic.qualifiedName()}/validation")
     }
 
     private ResponseDefinitionBuilder okResponse() {


### PR DESCRIPTION
Adding support for custom schema-registry validation endpoint. The endpoint is disabled by default as it is not in official schema-registry Confluent API.

Solves #767 