### PR TITLE
Updates Undertow to 1.4.21.Final (deadlock fix)

### DIFF
--- a/hermes-frontend/build.gradle
+++ b/hermes-frontend/build.gradle
@@ -4,7 +4,7 @@ dependencies {
     compile project(':hermes-metrics')
     compile project(':hermes-schema')
 
-    compile group: 'io.undertow', name: 'undertow-core', version: '1.4.11.Final'
+    compile group: 'io.undertow', name: 'undertow-core', version: '1.4.21.Final'
     compile group: 'org.apache.commons', name: 'commons-lang3', version: '3.0'
     compile group: 'net.openhft', name: 'chronicle-map', version: '2.4.13'
     compile group: 'commons-io', name: 'commons-io', version: '2.4'


### PR DESCRIPTION
Fixes a possible deadlock in `io.undertow.protocols.http2.Http2Channel` that we observed recently. See https://issues.jboss.org/browse/UNDERTOW-1231.