### PR TITLE
fixed bug with some portion of events not being sent during migration from json to avro

### DIFF
--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/common/config/Configs.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/common/config/Configs.java
@@ -158,6 +158,7 @@ public enum Configs {
 
     CONSUMER_RECEIVER_POOL_TIMEOUT("consumer.receiver.pool.timeout", 100),
     CONSUMER_RECEIVER_READ_QUEUE_CAPACITY("consumer.receiver.read.queue.capacity", 1000),
+    CONSUMER_RETRANSMISSION_QUEUE_CAPACITY("consumer.receiver.retransmission.queue.capacity", 20),
 
     CONSUMER_COMMIT_OFFSET_PERIOD("consumer.commit.offset.period", 60),
     CONSUMER_COMMIT_OFFSET_QUEUES_SIZE("consumer.commit.offset.queues.size", 200_000),

--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/common/exception/RetransmissionException.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/common/exception/RetransmissionException.java
@@ -4,6 +4,10 @@ import pl.allegro.tech.hermes.api.ErrorCode;
 
 public class RetransmissionException extends HermesException {
 
+    public RetransmissionException(String message) {
+        super(message);
+    }
+
     public RetransmissionException(Throwable cause) {
         super("Error during retransmitting messages.", cause);
     }

--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/common/message/wrapper/MessageContentWrapper.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/common/message/wrapper/MessageContentWrapper.java
@@ -97,8 +97,8 @@ public class MessageContentWrapper {
                         schemaRepository.getAvroSchema(topic, version);
                 return avroMessageContentWrapper.unwrapContent(data, schema);
             } catch (Exception ex) {
-                logger.debug("Failed to match schema for message for topic {}, schema version {}, fallback to previous.",
-                        topic.getQualifiedName(), version.value());
+                logger.error("Failed to match schema for message for topic {}, schema version {}, fallback to previous.",
+                        topic.getQualifiedName(), version.value(), ex);
             }
         }
         logger.error("Could not match schema {} for message of topic {} {}",

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/offset/kafka/broker/KafkaConsumerOffsetMover.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/offset/kafka/broker/KafkaConsumerOffsetMover.java
@@ -1,0 +1,29 @@
+package pl.allegro.tech.hermes.consumers.consumer.offset.kafka.broker;
+
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.TopicPartition;
+import pl.allegro.tech.hermes.consumers.consumer.offset.SubscriptionPartitionOffset;
+
+class KafkaConsumerOffsetMover implements PartitionAssigningAwareRetransmitter.OffsetMover {
+    private KafkaConsumer consumer;
+
+    KafkaConsumerOffsetMover(KafkaConsumer consumer) {
+        this.consumer = consumer;
+    }
+
+    @Override
+    public void move(SubscriptionPartitionOffset offset) {
+        try {
+            consumer.seek(new TopicPartition(offset.getKafkaTopicName().asString(), offset.getPartition()), offset.getOffset());
+        } catch (IllegalStateException ex) {
+            /*
+                Unfortunately we can't differentiate between different kind of illegal states in KafkaConsumer.
+                What we are really interested in is IllegalStateException with message containing
+                "No current assignment for partition" but because this message can change in any minor release
+                we can just do a leap of fate and interpret IllegalStateException as PartitionNotAssignedException.
+                Throwing this exception should only cause retransmission to be retried after consumer rebalancing.
+            */
+            throw new PartitionNotAssignedException(ex);
+        }
+    }
+}

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/offset/kafka/broker/PartitionAssigningAwareRetransmitter.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/offset/kafka/broker/PartitionAssigningAwareRetransmitter.java
@@ -1,0 +1,85 @@
+package pl.allegro.tech.hermes.consumers.consumer.offset.kafka.broker;
+
+import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.TopicPartition;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import pl.allegro.tech.hermes.api.SubscriptionName;
+import pl.allegro.tech.hermes.consumers.consumer.offset.SubscriptionPartitionOffset;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+
+public class PartitionAssigningAwareRetransmitter implements ConsumerRebalanceListener {
+    private static final Logger logger = LoggerFactory.getLogger(PartitionAssigningAwareRetransmitter.class);
+
+    private final OffsetMover offsetMover;
+    private final SubscriptionName subscriptionName;
+    private final BlockingQueue<SubscriptionPartitionOffset> retransmissionQueue;
+
+    public PartitionAssigningAwareRetransmitter(SubscriptionName subscriptionName, int queueSize, KafkaConsumer consumer) {
+        this(subscriptionName, queueSize, new KafkaConsumerOffsetMover(consumer));
+    }
+
+    public PartitionAssigningAwareRetransmitter(SubscriptionName subscriptionName, int queueSize, OffsetMover offsetMover) {
+        this.offsetMover = offsetMover;
+        this.subscriptionName = subscriptionName;
+        this.retransmissionQueue = new ArrayBlockingQueue<>(queueSize);
+    }
+
+    @Override
+    public void onPartitionsRevoked(Collection<TopicPartition> partitions) {
+        // not interesting for retransmission
+    }
+
+    @Override
+    public void onPartitionsAssigned(Collection<TopicPartition> partitions) {
+        if (!retransmissionQueue.isEmpty()) {
+            logger.info("Detected scheduled retransmission for subscription {}", subscriptionName);
+            moveScheduledOffsets();
+        }
+    }
+
+    public void moveOffsetOrSchedule(SubscriptionPartitionOffset offset) {
+        try {
+            logger.info("Moving offset for subscription {} {}", offset.getSubscriptionName(), offset.toString());
+            offsetMover.move(offset);
+        } catch (PartitionNotAssignedException ex) {
+            logger.info("Failed to move offset right now, reason: {}", ex.getMessage());
+            boolean scheduled = retransmissionQueue.offer(offset);
+            if (scheduled) {
+                logger.info("Scheduled retransmission for subscription {} on next rebalance," +
+                        " offset {}", subscriptionName, offset.toString());
+            } else {
+                logger.info("Failed to schedule new retransmission for subscription {}," +
+                        "there is already retransmission scheduled on next rebalance.", subscriptionName);
+            }
+        }
+    }
+
+    public boolean isQueueEmpty() {
+        return retransmissionQueue.isEmpty();
+    }
+
+    private void moveScheduledOffsets() {
+        List<SubscriptionPartitionOffset> offsets = new ArrayList<>();
+        retransmissionQueue.drainTo(offsets);
+        offsets.forEach(offset -> {
+            try {
+                offsetMover.move(offset);
+            } catch (Exception ex) {
+                logger.info("Still cannot move offset after rebalance for partition {} for subscription {}," +
+                                " possibly owned by different node",
+                        offset.getPartition(), offset.getSubscriptionName(), ex);
+            }
+        });
+    }
+
+    interface OffsetMover {
+        void move(SubscriptionPartitionOffset offset) throws PartitionNotAssignedException;
+    }
+}

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/offset/kafka/broker/PartitionNotAssignedException.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/offset/kafka/broker/PartitionNotAssignedException.java
@@ -1,0 +1,13 @@
+package pl.allegro.tech.hermes.consumers.consumer.offset.kafka.broker;
+
+import pl.allegro.tech.hermes.common.exception.RetransmissionException;
+
+public class PartitionNotAssignedException extends RetransmissionException {
+    public PartitionNotAssignedException() {
+        super("");
+    }
+
+    public PartitionNotAssignedException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/receiver/kafka/KafkaMessageReceiverFactory.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/receiver/kafka/KafkaMessageReceiverFactory.java
@@ -67,7 +67,8 @@ public class KafkaMessageReceiverFactory implements ReceiverFactory {
                 subscription,
                 clock,
                 configs.getIntProperty(Configs.CONSUMER_RECEIVER_POOL_TIMEOUT),
-                configs.getIntProperty(Configs.CONSUMER_RECEIVER_READ_QUEUE_CAPACITY));
+                configs.getIntProperty(Configs.CONSUMER_RECEIVER_READ_QUEUE_CAPACITY),
+                configs.getIntProperty(Configs.CONSUMER_RETRANSMISSION_QUEUE_CAPACITY));
 
         if (configs.getBooleanProperty(Configs.CONSUMER_FILTERING_ENABLED)) {
             FilteredMessageHandler filteredMessageHandler = new FilteredMessageHandler(

--- a/hermes-consumers/src/test/groovy/pl/allegro/tech/hermes/consumers/consumer/offset/kafka/broker/PartitionAssigningAwareRetransmitterTest.groovy
+++ b/hermes-consumers/src/test/groovy/pl/allegro/tech/hermes/consumers/consumer/offset/kafka/broker/PartitionAssigningAwareRetransmitterTest.groovy
@@ -1,0 +1,53 @@
+package pl.allegro.tech.hermes.consumers.consumer.offset.kafka.broker
+
+import spock.lang.Specification
+
+import static pl.allegro.tech.hermes.api.SubscriptionName.fromString
+import static pl.allegro.tech.hermes.consumers.consumer.offset.SubscriptionPartitionOffset.subscriptionPartitionOffset
+
+
+class PartitionAssigningAwareRetransmitterTest extends Specification {
+
+    def topic = "group.topic"
+    def subscriptionName = "$topic\$subscription"
+    def offsetMover = Mock(PartitionAssigningAwareRetransmitter.OffsetMover)
+    def offset = subscriptionPartitionOffset(topic, subscriptionName, 1, 1)
+
+    def retransmitter = new PartitionAssigningAwareRetransmitter(fromString(subscriptionName), 10, offsetMover)
+
+    def "should move offset when partitions are already assigned"() {
+        when:
+        retransmitter.moveOffsetOrSchedule(offset)
+
+        then:
+        1 * offsetMover.move(offset)
+        retransmitter.isQueueEmpty()
+    }
+
+    def "should schedule retransmission if consumer does not have partitions assigned yet"() {
+        when:
+        retransmitter.moveOffsetOrSchedule(offset)
+
+        then:
+        1 * offsetMover.move(offset) >> { throw new PartitionNotAssignedException() }
+        !retransmitter.isQueueEmpty()
+    }
+
+    def "should trigger scheduled retransmission when partitions are assigned"() {
+        when:
+        retransmitter.moveOffsetOrSchedule(offset)
+        retransmitter.onPartitionsAssigned([])
+
+        then:
+        2 * offsetMover.move(offset) >> { throw new PartitionNotAssignedException() }
+        retransmitter.isQueueEmpty()
+    }
+
+    def "should not move offset after rebalance if nothing was scheduled"() {
+        when:
+        retransmitter.onPartitionsAssigned([])
+
+        then:
+        0 * offsetMover.move(_)
+    }
+}

--- a/hermes-schema/src/main/java/pl/allegro/tech/hermes/schema/confluent/SchemaRegistryRawSchemaClient.java
+++ b/hermes-schema/src/main/java/pl/allegro/tech/hermes/schema/confluent/SchemaRegistryRawSchemaClient.java
@@ -81,6 +81,7 @@ public class SchemaRegistryRawSchemaClient implements RawSchemaClient {
     private Optional<String> extractSchema(String subject, String version, Response response) {
         switch (response.getStatusInfo().getFamily()) {
             case SUCCESSFUL:
+                logger.info("Found schema for subject {} at version {}", subject,  version);
                 String schema = response.readEntity(SchemaRegistryResponse.class).getSchema();
                 return Optional.of(schema);
             case CLIENT_ERROR:
@@ -88,6 +89,7 @@ public class SchemaRegistryRawSchemaClient implements RawSchemaClient {
                 return Optional.empty();
             case SERVER_ERROR:
             default:
+                logger.error("Could not find schema for subject {} at version {}, reason: {}", subject, version, response.getStatus());
                 throw new InternalSchemaRepositoryException(subject, response);
         }
     }


### PR DESCRIPTION
There is an issue that we're not sending some portion of events when migrating from json to avro.

Events not being sent to subscriber:
- last events from json topic
- initial events from avro topic

Causes:
- issue with trying to deserialize json event with avro schema (wrong content type used when unwrapping event read from kafka)
- retransmission after migration was happening before consumer had any partition assigned from kafka which resulted in failed retransmission