### PR TITLE
Consumers maxrate eager start

### DIFF
--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/infrastructure/zookeeper/ZookeeperPaths.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/infrastructure/zookeeper/ZookeeperPaths.java
@@ -114,6 +114,10 @@ public class ZookeeperPaths {
         return Joiner.on(URL_SEPARATOR).join(basePath, CONSUMERS_RATE_PATH, "runtime");
     }
 
+    public String consumersRateSubscriptionPath(SubscriptionName subscription) {
+        return Joiner.on(URL_SEPARATOR).join(consumersRateRuntimePath(), subscription);
+    }
+
     public String consumersRatePath(SubscriptionName subscription, String consumerId) {
         return Joiner.on(URL_SEPARATOR).join(consumersRateRuntimePath(), subscription, consumerId);
     }

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/rate/maxrate/MaxRateRegistry.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/rate/maxrate/MaxRateRegistry.java
@@ -218,7 +218,9 @@ public class MaxRateRegistry {
     }
 
     private void loadExistingEntries() {
-        subscriptionsCache.listActiveSubscriptionNames().forEach(subscriptionName -> {
+        List<SubscriptionName> subscriptions = subscriptionsCache.listActiveSubscriptionNames();
+        int loadedMaxRates = 0;
+        for (SubscriptionName subscriptionName : subscriptions) {
             try {
                 String subscriptionConsumersPath = zookeeperPaths.consumersRateSubscriptionPath(subscriptionName);
                 for (String consumerId : curator.getChildren().forPath(subscriptionConsumersPath)) {
@@ -228,9 +230,11 @@ public class MaxRateRegistry {
                     MaxRate maxRate = objectMapper.readValue(rawMaxRate, MaxRate.class);
                     rateInfos.put(consumer, RateInfo.withNoHistory(maxRate));
                 }
+                loadedMaxRates++;
             } catch (Exception e) {
-                logger.error("Exception occurred when initializing cache for subscription {}", subscriptionName, e);
+                logger.warn("Exception occurred when initializing cache for subscription {}", subscriptionName, e);
             }
-        });
+        };
+        logger.info("Loaded max-rates of {} out of {} subscriptions", loadedMaxRates, subscriptions.size());
     }
 }

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/workload/SubscriptionAssignmentCache.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/workload/SubscriptionAssignmentCache.java
@@ -7,6 +7,7 @@ import pl.allegro.tech.hermes.api.SubscriptionName;
 import pl.allegro.tech.hermes.consumers.subscription.cache.SubscriptionsCache;
 import pl.allegro.tech.hermes.infrastructure.zookeeper.cache.HierarchicalCache;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -65,6 +66,8 @@ public class SubscriptionAssignmentCache {
     }
 
     public void start() throws Exception {
+        long startNanos = System.nanoTime();
+
         logger.info("Starting assignment cache for {}", basePath);
 
         List<SubscriptionAssignment> currentAssignments = readExistingAssignments();
@@ -74,7 +77,10 @@ public class SubscriptionAssignmentCache {
 
         started = true;
 
-        logger.info("Started assignment cache for {}. Read {} assignments", basePath, currentAssignments.size());
+        long elapsedMillis = Duration.ofNanos(System.nanoTime() - startNanos).toMillis();
+
+        logger.info("Started assignment cache for {}. Read {} assignments. Took {}ms",
+                basePath, currentAssignments.size(), elapsedMillis);
     }
 
     public void stop() throws Exception {

--- a/hermes-consumers/src/test/java/pl/allegro/tech/hermes/consumers/consumer/rate/maxrate/MaxRateRegistryTest.java
+++ b/hermes-consumers/src/test/java/pl/allegro/tech/hermes/consumers/consumer/rate/maxrate/MaxRateRegistryTest.java
@@ -7,12 +7,16 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import pl.allegro.tech.hermes.api.SubscriptionName;
+import pl.allegro.tech.hermes.consumers.subscription.cache.SubscriptionsCache;
 import pl.allegro.tech.hermes.infrastructure.zookeeper.ZookeeperPaths;
 import pl.allegro.tech.hermes.test.helper.zookeeper.ZookeeperBaseTest;
 
+import java.util.Collections;
 import java.util.Optional;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class MaxRateRegistryTest extends ZookeeperBaseTest {
 
@@ -20,11 +24,14 @@ public class MaxRateRegistryTest extends ZookeeperBaseTest {
     private final SubscriptionName subscription = qualifiedName("subscription");
     private final ObjectMapper objectMapper = new ObjectMapper();
     private final MaxRatePathSerializer pathSerializer = new MaxRatePathSerializer();
+    private final SubscriptionsCache subscriptionsCache = mock(SubscriptionsCache.class);
+
     private final MaxRateRegistry maxRateRegistry = new MaxRateRegistry(
-            zookeeperClient, objectMapper, zookeeperPaths, pathSerializer);
+            zookeeperClient, objectMapper, zookeeperPaths, pathSerializer, subscriptionsCache);
 
     @Before
     public void setUp() throws Exception {
+        when(subscriptionsCache.listActiveSubscriptionNames()).thenReturn(Collections.singletonList(subscription));
         maxRateRegistry.start();
     }
 

--- a/integration/src/test/resources/config.properties
+++ b/integration/src/test/resources/config.properties
@@ -27,6 +27,7 @@ consumer.sender.backoff.time.ms=1
 consumer.supervisor.background.interval=100
 consumer.workload.algorithm=selective
 consumer.workload.rebalance.interval.seconds=1
+consumer.workload.consumers.per.subscription=1
 consumer.status.health.port=10802
 kafka.simple.consumer.buffer.size=1024
 kafka.consumer.auto.offset.reset=smallest


### PR DESCRIPTION
Lazy loading of MaxRateRegistry's Zookeeper cache can take a very long time. Eagerly initializing the tree should significantly speed up start time of Hermes Consumers.
More improvements can be made, but this one is the low hanging fruit we ought to consider.