### PR TITLE
Eliminating consumer's resources sharing between multiple processes

### DIFF
--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/NonblockingConsumersSupervisor.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/NonblockingConsumersSupervisor.java
@@ -37,7 +37,6 @@ public class NonblockingConsumersSupervisor implements ConsumersSupervisor {
     private static final Logger logger = LoggerFactory.getLogger(NonblockingConsumersSupervisor.class);
 
     private final ConsumerProcessSupervisor backgroundProcess;
-    private final ConsumerFactory consumerFactory;
     private final UndeliveredMessageLogPersister undeliveredMessageLogPersister;
     private final ConfigFactory configs;
     private final OffsetCommitter offsetCommitter;
@@ -56,11 +55,11 @@ public class NonblockingConsumersSupervisor implements ConsumersSupervisor {
                                           HermesMetrics metrics,
                                           ConsumerMonitor monitor,
                                           Clock clock) {
-        this.consumerFactory = consumerFactory;
         this.undeliveredMessageLogPersister = undeliveredMessageLogPersister;
         this.subscriptionRepository = subscriptionRepository;
         this.configs = configFactory;
-        this.backgroundProcess = new ConsumerProcessSupervisor(executor, retransmitter, clock, metrics, configFactory);
+        this.backgroundProcess = new ConsumerProcessSupervisor(executor, retransmitter, clock, metrics,
+                configFactory, consumerFactory);
         this.scheduledExecutor = createExecutorForSupervision();
         this.offsetCommitter = new OffsetCommitter(
                 offsetQueue,
@@ -83,20 +82,16 @@ public class NonblockingConsumersSupervisor implements ConsumersSupervisor {
 
     @Override
     public void assignConsumerForSubscription(Subscription subscription) {
-        logger.info("Creating consumer for {}", subscription.getQualifiedName());
         try {
-            Consumer consumer = consumerFactory.createConsumer(subscription);
-            Signal start = Signal.of(Signal.SignalType.START, subscription.getQualifiedName(), consumer);
-            logger.info("Created consumer for {}. {}", subscription.getQualifiedName(), start.getLogWithIdAndType());
+            Signal start = Signal.of(Signal.SignalType.START, subscription.getQualifiedName(), subscription);
 
             backgroundProcess.accept(start);
 
             if (subscription.getState() == PENDING) {
                 subscriptionRepository.updateSubscriptionState(subscription.getTopicName(), subscription.getName(), ACTIVE);
             }
-            logger.info("Consumer for {} was added for execution. {}", subscription.getQualifiedName(), start.getLogWithIdAndType());
-        } catch (Exception ex) {
-            logger.error("Failed to create consumer for subscription {}", subscription.getQualifiedName(), ex);
+        } catch (RuntimeException e) {
+            logger.error("Error during assigning subscription {} to consumer", subscription.getQualifiedName(), e);
         }
     }
 

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/process/ConsumerProcess.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/process/ConsumerProcess.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableMap;
 import org.jctools.queues.SpscArrayQueue;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import pl.allegro.tech.hermes.api.Subscription;
 import pl.allegro.tech.hermes.api.SubscriptionName;
 import pl.allegro.tech.hermes.consumers.consumer.Consumer;
 
@@ -22,7 +23,7 @@ public class ConsumerProcess implements Runnable {
 
     private final Clock clock;
 
-    private final SubscriptionName subscriptionName;
+    private final Subscription subscription;
 
     private final Consumer consumer;
 
@@ -41,13 +42,13 @@ public class ConsumerProcess implements Runnable {
 
     public ConsumerProcess(
             Signal startSignal,
+            Consumer consumer,
             Retransmitter retransmitter,
             java.util.function.Consumer<Signal> shutdownCallback,
             Clock clock,
-            long unhealthyAfter
-    ) {
-        this.subscriptionName = startSignal.getTarget();
-        this.consumer = startSignal.getPayload();
+            long unhealthyAfter) {
+        this.subscription = startSignal.getPayload();
+        this.consumer = consumer;
         this.retransmitter = retransmitter;
         this.shutdownCallback = shutdownCallback;
         this.clock = clock;
@@ -60,7 +61,7 @@ public class ConsumerProcess implements Runnable {
     @Override
     public void run() {
         try {
-            Thread.currentThread().setName("consumer-" + subscriptionName);
+            Thread.currentThread().setName("consumer-" + getSubscriptionName());
 
             while (running && !Thread.interrupted()) {
                 consumer.consume(this::processSignals);
@@ -68,9 +69,9 @@ public class ConsumerProcess implements Runnable {
             stop();
 
         } catch (Exception ex) {
-            logger.error("Consumer process of subscription {} failed", subscriptionName, ex);
+            logger.error("Consumer process of subscription {} failed", getSubscriptionName(), ex);
         } finally {
-            logger.info("Releasing consumer process thread of subscription {}", subscriptionName);
+            logger.info("Releasing consumer process thread of subscription {}", getSubscriptionName());
             shutdownCallback.accept(lastSignal);
             refreshHealthcheck();
             Thread.currentThread().setName("consumer-released-thread");
@@ -142,55 +143,59 @@ public class ConsumerProcess implements Runnable {
 
     private void start(Signal signal) {
         long startTime = clock.millis();
-        logger.info("Starting consumer for subscription {}. {}", subscriptionName, signal.getLogWithIdAndType());
+        logger.info("Starting consumer for subscription {}. {}",
+                getSubscriptionName(), signal.getLogWithIdAndType());
 
         consumer.initialize();
 
         long initializationTime = clock.millis();
         logger.info("Started consumer for subscription {} in {}ms. {}",
-                subscriptionName, initializationTime - startTime, signal.getLogWithIdAndType());
+                getSubscriptionName(), initializationTime - startTime, signal.getLogWithIdAndType());
         signalTimesheet.put(START, initializationTime);
     }
 
     private void stop() {
         long startTime = clock.millis();
-        logger.info("Stopping consumer for subscription {}", subscriptionName);
+        logger.info("Stopping consumer for subscription {}", getSubscriptionName());
 
         consumer.tearDown();
 
-        logger.info("Stopped consumer for subscription {} in {}ms", subscriptionName, clock.millis() - startTime);
+        logger.info("Stopped consumer for subscription {} in {}ms", getSubscriptionName(), clock.millis() - startTime);
     }
 
     private void retransmit(Signal signal) {
         long startTime = clock.millis();
-        logger.info("Starting retransmission for consumer of subscription {}. {}", subscriptionName, signal.getLogWithIdAndType());
+        logger.info("Starting retransmission for consumer of subscription {}. {}",
+                getSubscriptionName(), signal.getLogWithIdAndType());
         try {
-            retransmitter.reloadOffsets(subscriptionName, consumer);
-            logger.info("Done retransmission for consumer of subscription {} in {}ms", subscriptionName, clock.millis() - startTime);
+            retransmitter.reloadOffsets(getSubscriptionName(), consumer);
+            logger.info("Done retransmission for consumer of subscription {} in {}ms",
+                    getSubscriptionName(), clock.millis() - startTime);
         } catch (Exception ex) {
             logger.error("Failed retransmission for consumer of subscription {} in {}ms",
-                    subscriptionName, clock.millis() - startTime, ex);
+                    getSubscriptionName(), clock.millis() - startTime, ex);
         }
     }
 
     private void restart(Signal signal) {
         long startTime = clock.millis();
         try {
-            logger.info("Restarting consumer for subscription {}. {}", subscriptionName, signal.getLogWithIdAndType());
+            logger.info("Restarting consumer for subscription {}. {}",
+                    getSubscriptionName(), signal.getLogWithIdAndType());
             stop();
             start(signal);
             logger.info("Done restarting consumer for subscription {} in {}ms. {}",
-                    subscriptionName, clock.millis() - startTime, signal.getLogWithIdAndType());
+                    getSubscriptionName(), clock.millis() - startTime, signal.getLogWithIdAndType());
         } catch (Exception e) {
             logger.error("Failed restarting consumer for subscription {} in {}ms. {}",
-                    subscriptionName, clock.millis() - startTime, signal.getLogWithIdAndType(), e);
+                    getSubscriptionName(), clock.millis() - startTime, signal.getLogWithIdAndType(), e);
         }
     }
 
     @Override
     public String toString() {
         return "ConsumerProcess{" +
-                "subscriptionName=" + subscriptionName +
+                "subscriptionName=" + getSubscriptionName() +
                 '}';
     }
 
@@ -199,23 +204,23 @@ public class ConsumerProcess implements Runnable {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         ConsumerProcess that = (ConsumerProcess) o;
-        return Objects.equals(subscriptionName, that.subscriptionName);
+        return Objects.equals(getSubscriptionName(), that.getSubscriptionName());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(subscriptionName);
+        return Objects.hash(getSubscriptionName());
     }
 
-    public SubscriptionName getSubscriptionName() {
-        return subscriptionName;
-    }
-
-    public Consumer getConsumer() {
-        return consumer;
+    public Subscription getSubscription() {
+        return subscription;
     }
 
     public Map<Signal.SignalType, Long> getSignalTimesheet() {
         return ImmutableMap.copyOf(signalTimesheet);
+    }
+
+    private SubscriptionName getSubscriptionName() {
+        return subscription.getQualifiedName();
     }
 }

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/process/ConsumerProcessSupervisor.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/process/ConsumerProcessSupervisor.java
@@ -2,11 +2,14 @@ package pl.allegro.tech.hermes.consumers.supervisor.process;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import pl.allegro.tech.hermes.api.Subscription;
 import pl.allegro.tech.hermes.api.SubscriptionName;
 import pl.allegro.tech.hermes.common.config.ConfigFactory;
 import pl.allegro.tech.hermes.common.config.Configs;
 import pl.allegro.tech.hermes.common.metric.HermesMetrics;
+import pl.allegro.tech.hermes.consumers.consumer.Consumer;
 import pl.allegro.tech.hermes.consumers.queue.MonitoredMpscQueue;
+import pl.allegro.tech.hermes.consumers.supervisor.ConsumerFactory;
 import pl.allegro.tech.hermes.consumers.supervisor.ConsumersExecutorService;
 
 import java.time.Clock;
@@ -39,11 +42,14 @@ public class ConsumerProcessSupervisor implements Runnable {
 
     private long killAfter;
 
+    private ConsumerFactory consumerFactory;
+
     public ConsumerProcessSupervisor(ConsumersExecutorService executor,
                                      Retransmitter retransmitter,
                                      Clock clock,
                                      HermesMetrics metrics,
-                                     ConfigFactory configs) {
+                                     ConfigFactory configs,
+                                     ConsumerFactory consumerFactory) {
         this.executor = executor;
         this.retransmitter = retransmitter;
         this.clock = clock;
@@ -53,6 +59,7 @@ public class ConsumerProcessSupervisor implements Runnable {
         this.taskQueue = new MonitoredMpscQueue<>(metrics, "signalQueue",
                 configs.getIntProperty(Configs.CONSUMER_SIGNAL_PROCESSING_QUEUE_SIZE));
         this.signalsFilter = new SignalsFilter(taskQueue, clock);
+        this.consumerFactory = consumerFactory;
     }
 
     public void accept(Signal signal) {
@@ -82,7 +89,8 @@ public class ConsumerProcessSupervisor implements Runnable {
         runningProcesses.stream()
                 .filter(consumerProcess -> !consumerProcess.isHealthy())
                 .forEach(consumerProcess -> {
-                    Signal restartUnhealthy = Signal.of(RESTART_UNHEALTHY, consumerProcess.getSubscriptionName());
+                    Signal restartUnhealthy =
+                            Signal.of(RESTART_UNHEALTHY, consumerProcess.getSubscription().getQualifiedName());
                     logger.info("Lost contact with consumer {}, last seen {}ms ago {}. {}",
                             consumerProcess, consumerProcess.lastSeen(), restartUnhealthy.getLogWithIdAndType());
                     taskQueue.offer(restartUnhealthy);
@@ -129,7 +137,7 @@ public class ConsumerProcessSupervisor implements Runnable {
                 break;
             case KILL_UNHEALTHY:
                 onConsumerProcess(signal, consumerProcess -> {
-                    taskQueue.offer(signal.createChild(START, clock.millis(), consumerProcess.getConsumer()));
+                    taskQueue.offer(signal.createChild(START, clock.millis(), consumerProcess.getSubscription()));
                     kill(signal);
                 });
                 break;
@@ -176,14 +184,23 @@ public class ConsumerProcessSupervisor implements Runnable {
     }
 
     private void start(Signal start) {
-        logger.info("Starting consumer process for subscription {}. {}", start.getTarget(), start.getLogWithIdAndType());
+        Subscription subscription = start.getPayload();
 
         if (!runningProcesses.hasProcess(start.getTarget())) {
-            ConsumerProcess process = new ConsumerProcess(start, retransmitter,
-                    this::handleProcessShutdown, clock, unhealthyAfter);
-            Future future = executor.execute(process);
-            runningProcesses.add(process, future);
-            logger.info("Started consumer process for subscription {}. {}", start.getTarget(), start.getLogWithIdAndType());
+            try {
+                logger.info("Creating consumer for {}", subscription.getQualifiedName());
+                ConsumerProcess process = createNewConsumerProcess(start);
+                logger.info("Created consumer for {}. {}", subscription.getQualifiedName(), start.getLogWithIdAndType());
+
+                logger.info("Starting consumer process for subscription {}. {}", start.getTarget(), start.getLogWithIdAndType());
+                Future future = executor.execute(process);
+                logger.info("Consumer for {} was added for execution. {}", subscription.getQualifiedName(), start.getLogWithIdAndType());
+
+                runningProcesses.add(process, future);
+                logger.info("Started consumer process for subscription {}. {}", start.getTarget(), start.getLogWithIdAndType());
+            } catch (Exception ex) {
+                logger.error("Failed to create consumer for subscription {}", subscription.getQualifiedName(), ex);
+            }
         } else {
             logger.info("Abort consumer process start: process for subscription {} is already running. {}",
                     start.getTarget(), start.getLogWithIdAndType());
@@ -207,7 +224,7 @@ public class ConsumerProcessSupervisor implements Runnable {
 
     public void shutdown() {
         runningProcesses.stream()
-                .forEach(p -> p.accept(Signal.of(STOP, p.getSubscriptionName())));
+                .forEach(p -> p.accept(Signal.of(STOP, p.getSubscription().getQualifiedName())));
         executor.shutdown();
     }
 
@@ -217,5 +234,18 @@ public class ConsumerProcessSupervisor implements Runnable {
 
     public Integer countRunningSubscriptions() {
         return runningProcesses.count();
+    }
+
+    private ConsumerProcess createNewConsumerProcess(Signal startSignal) {
+        if (startSignal.getType() != START) {
+            throw new IllegalArgumentException("Signal has to be START signal");
+        }
+        if (!(startSignal.getPayload() instanceof Subscription)) {
+            throw new IllegalArgumentException("Signal's payload has to be Subscription type");
+        }
+
+        Consumer consumer = consumerFactory.createConsumer(startSignal.getPayload());
+        return new ConsumerProcess(startSignal, consumer, retransmitter,
+                this::handleProcessShutdown, clock, unhealthyAfter);
     }
 }

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/process/RunningConsumerProcesses.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/process/RunningConsumerProcesses.java
@@ -17,7 +17,7 @@ class RunningConsumerProcesses {
     private final Map<SubscriptionName, RunningProcess> processes = new ConcurrentHashMap<>();
 
     void add(ConsumerProcess process, Future executionHandle) {
-        this.processes.put(process.getSubscriptionName(), new RunningProcess(process, executionHandle));
+        this.processes.put(process.getSubscription().getQualifiedName(), new RunningProcess(process, executionHandle));
     }
 
     void remove(SubscriptionName subscriptionName) {

--- a/hermes-consumers/src/test/java/pl/allegro/tech/hermes/consumers/supervisor/workload/ConsumerTestRuntimeEnvironment.java
+++ b/hermes-consumers/src/test/java/pl/allegro/tech/hermes/consumers/supervisor/workload/ConsumerTestRuntimeEnvironment.java
@@ -8,6 +8,7 @@ import pl.allegro.tech.hermes.api.Group;
 import pl.allegro.tech.hermes.api.Subscription;
 import pl.allegro.tech.hermes.api.SubscriptionName;
 import pl.allegro.tech.hermes.common.admin.zookeeper.ZookeeperAdminCache;
+import pl.allegro.tech.hermes.common.config.Configs;
 import pl.allegro.tech.hermes.common.di.factories.ModelAwareZookeeperNotifyingCacheFactory;
 import pl.allegro.tech.hermes.common.exception.InternalProcessingException;
 import pl.allegro.tech.hermes.common.metric.HermesMetrics;
@@ -304,6 +305,10 @@ class ConsumerTestRuntimeEnvironment {
         await().atMost(adjust(ONE_SECOND)).until(
                 () -> verify(supervisor).assignConsumerForSubscription(subscription));
 
+    }
+
+    void withOverriddenConfigProperty(Configs property, int value) {
+        this.configFactory.overrideProperty(property, value);
     }
 
     static class ConsumerControllers {


### PR DESCRIPTION
This pull request improves consumer's resource managing performed by process supervisor. It tries to resolve multiple problems caused by consumer's resources shared between multiple threads. One of the problem is ConcurrentModificationException on KafkaConsumer object which is not thread safe. The error is caused due to connection problems with Kafka cluster. When ConsumerProcess cannot connect to Kafka it is assumed as unhealthy and is supposed to be restarted. After continuous restarting some corner cases cause to spawn multiple threads (ConsumerProcesses) operating on the same KafkaConsumer object. The fix works by creating new KafkaConsumer object for each spawned ConsumerProcess (previously it was just passed to newly created process in case of restart).
Changes made:
SubscriptionName field on the ConsumerProcess was replaced with Subscription because it is then needed to create new ConsumerProcess from existing one (we need to pass subscription object to ConsumerFactory).
The responsibility for creating ConsumerProcess (via factories) was placed only on the ConsumerProcessSupervisor (previously it was on NonblockingConsumersSupervisor too). Additionally ConsumerProcesses are created in one place and during only on receiving START signal.
Before this change, START singal contained SubscriptionName as payload. We want to create ConsumerProcesses in ConsumerProcessSupervisor, so to enable this, START singal has to contain Subscription object as payload