### PR TITLE
Interrupting ConsumerProcess thread when catched InterruptException f…

### DIFF
--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/process/ConsumerProcess.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/process/ConsumerProcess.java
@@ -63,7 +63,7 @@ public class ConsumerProcess implements Runnable {
         try {
             Thread.currentThread().setName("consumer-" + getSubscriptionName());
 
-            while (running && !Thread.interrupted()) {
+            while (running && !Thread.currentThread().isInterrupted()) {
                 consumer.consume(this::processSignals);
             }
             stop();


### PR DESCRIPTION
This PR improves dealing with Kafka ```InterruptException``` thrown by ```ConsumerNetworkClient```. Due to the fact that ```InterruptException```'s constructor has ```Thread.currentThread().interrupt()``` call and in some unknown (for us) way does not change Thread to the interrupted state, we have to do it explicitly by making this call once again.
Changes:
1. Interrupting ```ConsumerProcess```'s  thread in places where ```InterruptException``` may be raised from Kafka client (```poll``` and ```commitSync``` methods of ```KafkaConsumer```class) .
2. Added ```Thread.currentThread.isInterrupted()``` to run method of ```ConsumerProcess``` (instead of ```Thread.interrupted()```) to preserve interrupt state once it is set.