### PR TITLE
List topics by owners

### DIFF
--- a/hermes-api/src/main/java/pl/allegro/tech/hermes/api/endpoints/TopicEndpoint.java
+++ b/hermes-api/src/main/java/pl/allegro/tech/hermes/api/endpoints/TopicEndpoint.java
@@ -1,6 +1,7 @@
 package pl.allegro.tech.hermes.api.endpoints;
 
 import pl.allegro.tech.hermes.api.PatchData;
+import pl.allegro.tech.hermes.api.Topic;
 import pl.allegro.tech.hermes.api.TopicWithSchema;
 import pl.allegro.tech.hermes.api.TopicMetrics;
 
@@ -81,5 +82,10 @@ public interface TopicEndpoint {
                    @PathParam("brokersClusterName") String brokersClusterName,
                    @PathParam("partition") Integer partition,
                    @PathParam("offset") Long offset);
+
+    @GET
+    @Produces(APPLICATION_JSON)
+    @Path("/owner/{ownerSourceName}/{ownerId}")
+    List<Topic> listForOwner(@PathParam("ownerSourceName") String ownerSourceName, @PathParam("ownerId") String ownerId);
 
 }

--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/domain/topic/TopicRepository.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/domain/topic/TopicRepository.java
@@ -3,6 +3,7 @@ package pl.allegro.tech.hermes.domain.topic;
 import pl.allegro.tech.hermes.api.Topic;
 import pl.allegro.tech.hermes.api.TopicName;
 
+import java.util.Collection;
 import java.util.List;
 
 public interface TopicRepository {
@@ -24,6 +25,8 @@ public interface TopicRepository {
     void touchTopic(TopicName topicName);
 
     Topic getTopicDetails(TopicName topicName);
+
+    List<Topic> getTopicsDetails(Collection<TopicName> topicNames);
 
     boolean isSubscribingRestricted(TopicName topicName);
 }

--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/infrastructure/zookeeper/ZookeeperTopicRepository.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/infrastructure/zookeeper/ZookeeperTopicRepository.java
@@ -14,6 +14,7 @@ import pl.allegro.tech.hermes.domain.topic.TopicNotEmptyException;
 import pl.allegro.tech.hermes.domain.topic.TopicNotExistsException;
 import pl.allegro.tech.hermes.domain.topic.TopicRepository;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -118,6 +119,15 @@ public class ZookeeperTopicRepository extends ZookeeperBasedRepository implement
     @Override
     public Topic getTopicDetails(TopicName topicName) {
         return getTopicDetails(topicName, false).get();
+    }
+
+    @Override
+    public List<Topic> getTopicsDetails(Collection<TopicName> topicNames) {
+        return topicNames.stream()
+                .map(topicName -> getTopicDetails(topicName, true))
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .collect(Collectors.toList());
     }
 
     @Override

--- a/hermes-common/src/test/groovy/pl/allegro/tech/hermes/infrastructure/zookeeper/ZookeeperTopicRepositoryTest.groovy
+++ b/hermes-common/src/test/groovy/pl/allegro/tech/hermes/infrastructure/zookeeper/ZookeeperTopicRepositoryTest.groovy
@@ -88,6 +88,23 @@ class ZookeeperTopicRepositoryTest extends IntegrationTest {
         topics.containsAll([topic1, topic2])
     }
 
+    def "should topics details by topic names"() {
+        given:
+        Topic topic1 = topic(GROUP, 'listByNames1').build()
+        Topic topic2 = topic(GROUP, 'listByNames2').build()
+        repository.createTopic(topic1)
+        repository.createTopic(topic2)
+
+        wait.untilTopicCreated(GROUP, 'listByNames1')
+        wait.untilTopicCreated(GROUP, 'listByNames2')
+
+        when:
+        List topics = repository.getTopicsDetails([topic1.name, topic2.name])
+
+        then:
+        topics.containsAll([topic1, topic2])
+    }
+
     def "should load topic details"() {
         given:
         repository.createTopic(topic(GROUP, 'details').withDescription('description').build())

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/domain/topic/TopicOwnerCache.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/domain/topic/TopicOwnerCache.java
@@ -1,0 +1,60 @@
+package pl.allegro.tech.hermes.management.domain.topic;
+
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.Multimaps;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import pl.allegro.tech.hermes.api.OwnerId;
+import pl.allegro.tech.hermes.api.Topic;
+import pl.allegro.tech.hermes.api.TopicName;
+import pl.allegro.tech.hermes.domain.topic.TopicRepository;
+import pl.allegro.tech.hermes.management.domain.group.GroupService;
+
+import javax.annotation.PostConstruct;
+import java.util.Collection;
+
+@Component
+public class TopicOwnerCache {
+
+    private static final Logger logger = LoggerFactory.getLogger(TopicOwnerCache.class);
+
+    private final TopicRepository topicRepository;
+    private final GroupService groupService;
+
+    private final Multimap<OwnerId, TopicName> cache = Multimaps.synchronizedMultimap(ArrayListMultimap.create());
+
+    public TopicOwnerCache(TopicRepository topicRepository, GroupService groupService) {
+        this.topicRepository = topicRepository;
+        this.groupService = groupService;
+    }
+
+    public Collection<TopicName> get(OwnerId ownerId) {
+        return cache.get(ownerId);
+    }
+
+    @PostConstruct
+    public void fillCache() {
+        logger.info("Starting filling Owner Id to Topic Name cache");
+        long start = System.currentTimeMillis();
+        groupService.listGroupNames().stream()
+                .flatMap(groupName -> topicRepository.listTopics(groupName).stream())
+                .forEach(topic -> cache.put(topic.getOwner(), topic.getName()));
+        long end = System.currentTimeMillis();
+        logger.info("Cache filled. Took {}ms", end - start);
+    }
+
+    public void onRemovedTopic(Topic topic) {
+        cache.remove(topic.getOwner(), topic.getName());
+    }
+
+    public void onCreatedTopic(Topic topic) {
+        cache.put(topic.getOwner(), topic.getName());
+    }
+
+    public void onUpdatedTopic(Topic oldTopic, Topic newTopic) {
+        cache.remove(oldTopic.getOwner(), oldTopic.getName());
+        cache.put(newTopic.getOwner(), newTopic.getName());
+    }
+}

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/domain/topic/TopicOwnerCache.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/domain/topic/TopicOwnerCache.java
@@ -3,8 +3,10 @@ package pl.allegro.tech.hermes.management.domain.topic;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Multimaps;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import pl.allegro.tech.hermes.api.OwnerId;
 import pl.allegro.tech.hermes.api.Topic;
@@ -12,8 +14,11 @@ import pl.allegro.tech.hermes.api.TopicName;
 import pl.allegro.tech.hermes.domain.topic.TopicRepository;
 import pl.allegro.tech.hermes.management.domain.group.GroupService;
 
-import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
 import java.util.Collection;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 
 @Component
 public class TopicOwnerCache {
@@ -22,20 +27,31 @@ public class TopicOwnerCache {
 
     private final TopicRepository topicRepository;
     private final GroupService groupService;
+    private final ScheduledExecutorService scheduledExecutorService;
 
     private final Multimap<OwnerId, TopicName> cache = Multimaps.synchronizedMultimap(ArrayListMultimap.create());
 
-    public TopicOwnerCache(TopicRepository topicRepository, GroupService groupService) {
+    public TopicOwnerCache(TopicRepository topicRepository, GroupService groupService,
+                           @Value("${topicOwnerCache.refreshRateInSeconds}") int refreshRateInSeconds) {
         this.topicRepository = topicRepository;
         this.groupService = groupService;
+        scheduledExecutorService = Executors.newSingleThreadScheduledExecutor(
+                new ThreadFactoryBuilder()
+                        .setNameFormat("topic-owner-cache-%d")
+                        .build());
+        scheduledExecutorService.scheduleAtFixedRate(this::fillCache, 0, refreshRateInSeconds, TimeUnit.SECONDS);
+    }
+
+    @PreDestroy
+    public void stop() {
+        scheduledExecutorService.shutdown();
     }
 
     public Collection<TopicName> get(OwnerId ownerId) {
         return cache.get(ownerId);
     }
 
-    @PostConstruct
-    public void fillCache() {
+    private void fillCache() {
         logger.info("Starting filling Owner Id to Topic Name cache");
         long start = System.currentTimeMillis();
         groupService.listGroupNames().stream()
@@ -45,15 +61,15 @@ public class TopicOwnerCache {
         logger.info("Cache filled. Took {}ms", end - start);
     }
 
-    public void onRemovedTopic(Topic topic) {
+    void onRemovedTopic(Topic topic) {
         cache.remove(topic.getOwner(), topic.getName());
     }
 
-    public void onCreatedTopic(Topic topic) {
+    void onCreatedTopic(Topic topic) {
         cache.put(topic.getOwner(), topic.getName());
     }
 
-    public void onUpdatedTopic(Topic oldTopic, Topic newTopic) {
+    void onUpdatedTopic(Topic oldTopic, Topic newTopic) {
         cache.remove(oldTopic.getOwner(), oldTopic.getName());
         cache.put(newTopic.getOwner(), newTopic.getName());
     }

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/domain/topic/TopicOwnerCache.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/domain/topic/TopicOwnerCache.java
@@ -52,15 +52,19 @@ public class TopicOwnerCache {
     }
 
     private void refillCache() {
-        logger.info("Starting filling Owner Id to Topic Name cache");
-        long start = System.currentTimeMillis();
-        Multimap<OwnerId, TopicName> cache = ArrayListMultimap.create();
-        groupService.listGroupNames().stream()
-                .flatMap(groupName -> topicRepository.listTopics(groupName).stream())
-                .forEach(topic -> cache.put(topic.getOwner(), topic.getName()));
-        this.cache = Multimaps.synchronizedMultimap(cache);
-        long end = System.currentTimeMillis();
-        logger.info("Cache filled. Took {}ms", end - start);
+        try {
+            logger.info("Starting filling Owner Id to Topic Name cache");
+            long start = System.currentTimeMillis();
+            Multimap<OwnerId, TopicName> cache = ArrayListMultimap.create();
+            groupService.listGroupNames().stream()
+                    .flatMap(groupName -> topicRepository.listTopics(groupName).stream())
+                    .forEach(topic -> cache.put(topic.getOwner(), topic.getName()));
+            this.cache = Multimaps.synchronizedMultimap(cache);
+            long end = System.currentTimeMillis();
+            logger.info("Cache filled. Took {}ms", end - start);
+        } catch (Exception e) {
+            logger.error("Error while filling cache", e);
+        }
     }
 
     void onRemovedTopic(Topic topic) {

--- a/hermes-management/src/main/resources/application.yaml
+++ b/hermes-management/src/main/resources/application.yaml
@@ -29,3 +29,6 @@ management:
 schema.repository.type: schema_registry
 
 audit.enabled: false
+
+topicOwnerCache:
+  refreshRateInSeconds: 300 # 5 minutes

--- a/integration/src/integration/java/pl/allegro/tech/hermes/integration/management/ListTopicForOwnerTest.java
+++ b/integration/src/integration/java/pl/allegro/tech/hermes/integration/management/ListTopicForOwnerTest.java
@@ -1,0 +1,86 @@
+package pl.allegro.tech.hermes.integration.management;
+
+import org.testng.annotations.Test;
+import pl.allegro.tech.hermes.api.OwnerId;
+import pl.allegro.tech.hermes.api.PatchData;
+import pl.allegro.tech.hermes.api.Topic;
+import pl.allegro.tech.hermes.integration.IntegrationTest;
+import pl.allegro.tech.hermes.test.helper.builder.TopicBuilder;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ListTopicForOwnerTest extends IntegrationTest {
+
+    @Test
+    public void shouldListTopicsForOwnerId() {
+        // given
+        createTopicForOwner("groupOwnerId1a", "topic", "ownerIdTest1");
+        createTopicForOwner("groupOwnerId1b", "topic", "ownerIdTest1");
+        createTopicForOwner("groupOwnerId2", "topic", "ownerIdTest2");
+
+        // expect
+        assertThat(listTopicsForOwner("ownerIdTest1")).containsExactly("groupOwnerId1a.topic", "groupOwnerId1b.topic");
+        assertThat(listTopicsForOwner("ownerIdTest2")).containsExactly("groupOwnerId2.topic");
+    }
+
+    @Test
+    public void shouldListTopicAfterNewTopicIsAdded() {
+        // expect empty list on start
+        assertThat(listTopicsForOwner("ownerIdTest3")).isEmpty();
+
+        // when
+        createTopicForOwner("groupOwnerId3", "topic", "ownerIdTest3");
+
+        // then
+        assertThat(listTopicsForOwner("ownerIdTest3")).containsExactly("groupOwnerId3.topic");
+    }
+
+    @Test
+    public void shouldListTopicAfterOwnerIsChanged() {
+        // given
+        createTopicForOwner("groupOwnerId4", "topic", "ownerIdTest4");
+
+        // then
+        assertThat(listTopicsForOwner("ownerIdTest4")).containsExactly("groupOwnerId4.topic");
+        assertThat(listTopicsForOwner("ownerIdTest5")).isEmpty();
+
+        // when
+        operations.updateTopic("groupOwnerId4", "topic", PatchData.patchData()
+                .set("owner", new OwnerId("Plaintext", "ownerIdTest5"))
+                .build());
+
+        // then
+        assertThat(listTopicsForOwner("ownerIdTest4")).isEmpty();
+        assertThat(listTopicsForOwner("ownerIdTest5")).containsExactly("groupOwnerId4.topic");
+    }
+
+    @Test
+    public void shouldNotListTopicAfterTopicIsDeleted() {
+        // given
+        createTopicForOwner("groupOwnerId6", "topic", "ownerIdTest6");
+        assertThat(listTopicsForOwner("ownerIdTest6")).containsExactly("groupOwnerId6.topic");
+
+        // when
+        management.topic().remove("groupOwnerId6.topic");
+
+        // then
+        assertThat(listTopicsForOwner("ownerIdTest6")).isEmpty();
+    }
+
+    private void createTopicForOwner(String group, String topic, String ownerId) {
+        operations.createGroup(group);
+        operations.createTopic(TopicBuilder.topic(group, topic)
+                .withOwner(new OwnerId("Plaintext", ownerId))
+                .build());
+    }
+
+    private List<String> listTopicsForOwner(String ownerId) {
+        return management.topic().listForOwner("Plaintext", ownerId)
+                .stream()
+                .map(Topic::getQualifiedName)
+                .collect(Collectors.toList());
+    }
+}

--- a/integration/src/test/resources/application-integration.yaml
+++ b/integration/src/test/resources/application-integration.yaml
@@ -41,3 +41,6 @@ spring.groovy.template.check-template-location: false
 
 schema.repository:
   type: schema_registry
+
+topicOwnerCache:
+  refreshRateInSeconds: 300 # 5 minutes


### PR DESCRIPTION
We want to be able to list topics by owners. We can do this right now by using `QueryEndpoint`, but quering requires scanning through whole Zookeeper, which is too slow (something about 1 to 15 seconds on production).

Another reason that seperate endpoint is better is that we can change response structure. We may also add list subscriptions for topics.

I built cache from `OwnerId` to `TopicName` which is filled after application startup. Then every CRUD operation on topic updates the cache.

I created seperate class that is used by `TopicService`. I considered implementing existing `Audit` interface and inject `List<Audit>` instead of `Audit` so that `TopicService` would not know about cache, but I feel like `Audit` and `Cache` is a different thing. Moreover, Audit methods are called by multiple Services, not only `TopicService` so I would have to check class with `instanceof`.