### PR TITLE
added waiting between unsuccessful polls to reduce cpu utilization

### DIFF
--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/common/config/Configs.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/common/config/Configs.java
@@ -156,9 +156,13 @@ public enum Configs {
     MESSAGES_LOADING_WAIT_FOR_BROKER_TOPIC_INFO("frontend.messages.loading.wait.for.broker.topic.info", 5),
     MESSAGES_LOCAL_STORAGE_SIZE_REPORTING_ENABLED("frontend.messages.local.storage.size.reporting.enabled", true),
 
-    CONSUMER_RECEIVER_POOL_TIMEOUT("consumer.receiver.pool.timeout", 100),
+    CONSUMER_RECEIVER_POOL_TIMEOUT("consumer.receiver.pool.timeout", 30),
     CONSUMER_RECEIVER_READ_QUEUE_CAPACITY("consumer.receiver.read.queue.capacity", 1000),
     CONSUMER_RETRANSMISSION_QUEUE_CAPACITY("consumer.receiver.retransmission.queue.capacity", 20),
+
+    CONSUMER_RECEIVER_WAIT_BETWEEN_UNSUCCESSFUL_POLLS("consumer.receiver.wait.between.unsuccessful.polls", true),
+    CONSUMER_RECEIVER_INITIAL_IDLE_TIME("consumer.receiver.initial.idle.time", 10),
+    CONSUMER_RECEIVER_MAX_IDLE_TIME("consumer.receiver.max.idle.time", 1000),
 
     CONSUMER_COMMIT_OFFSET_PERIOD("consumer.commit.offset.period", 60),
     CONSUMER_COMMIT_OFFSET_QUEUES_SIZE("consumer.commit.offset.queues.size", 200_000),

--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/common/metric/Timers.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/common/metric/Timers.java
@@ -39,6 +39,7 @@ public class Timers {
             GET_SCHEMA_VERSIONS_LATENCY = SCHEMA + ".get-schema-versions",
 
             CONSUMER_WORKLOAD_REBALANCE_DURATION = "consumers-workload." + KAFKA_CLUSTER + ".selective.rebalance-duration",
+            CONSUMER_IDLE_TIME = "idle-time." + GROUP + "." + TOPIC + "." + SUBSCRIPTION,
 
             OAUTH_PROVIDER_TOKEN_REQUEST_LATENCY = "oauth.provider." + OAUTH_PROVIDER_NAME + ".token-request-latency",
 

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/idleTime/ExponentiallyGrowingIdleTimeCalculator.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/idleTime/ExponentiallyGrowingIdleTimeCalculator.java
@@ -1,0 +1,45 @@
+package pl.allegro.tech.hermes.consumers.consumer.idleTime;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.lang.Math.min;
+
+public class ExponentiallyGrowingIdleTimeCalculator implements IdleTimeCalculator {
+
+    private final long base;
+    private final long initialIdleTime;
+    private final long maxIdleTime;
+    private long currentIdleTime;
+
+    public ExponentiallyGrowingIdleTimeCalculator(long initialIdleTime, long maxIdleTime) {
+        this(2, initialIdleTime, maxIdleTime);
+    }
+
+    public ExponentiallyGrowingIdleTimeCalculator(long base, long initialIdleTime, long maxIdleTime) {
+        checkArgument(base > 0, "base should be greater than zero");
+        checkArgument(initialIdleTime > 0, "initialIdleTime should be greater than zero");
+        checkArgument(maxIdleTime > 0, "maxIdleTime should be greater than zero");
+        checkArgument(initialIdleTime <= maxIdleTime, "maxIdleTime should be grater or equal initialIdleTime");
+
+        this.base = base;
+        this.initialIdleTime = initialIdleTime;
+        this.maxIdleTime = maxIdleTime;
+        this.currentIdleTime = initialIdleTime;
+    }
+
+    @Override
+    public long increaseIdleTime() {
+        long previousIdleTime = this.currentIdleTime;
+        this.currentIdleTime = min(this.currentIdleTime * base, maxIdleTime);
+        return previousIdleTime;
+    }
+
+    @Override
+    public long getIdleTime() {
+        return currentIdleTime;
+    }
+
+    @Override
+    public void reset() {
+        this.currentIdleTime = initialIdleTime;
+    }
+}

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/idleTime/IdleTimeCalculator.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/idleTime/IdleTimeCalculator.java
@@ -1,0 +1,7 @@
+package pl.allegro.tech.hermes.consumers.consumer.idleTime;
+
+public interface IdleTimeCalculator {
+    long increaseIdleTime();
+    long getIdleTime();
+    void reset();
+}

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/receiver/ThrottlingMessageReceiver.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/receiver/ThrottlingMessageReceiver.java
@@ -1,0 +1,73 @@
+package pl.allegro.tech.hermes.consumers.consumer.receiver;
+
+import com.codahale.metrics.Timer;
+import pl.allegro.tech.hermes.api.Subscription;
+import pl.allegro.tech.hermes.common.metric.HermesMetrics;
+import pl.allegro.tech.hermes.consumers.consumer.Message;
+import pl.allegro.tech.hermes.consumers.consumer.idleTime.IdleTimeCalculator;
+import pl.allegro.tech.hermes.consumers.consumer.offset.SubscriptionPartitionOffset;
+
+import java.util.Optional;
+import java.util.Set;
+
+import static pl.allegro.tech.hermes.common.metric.Timers.CONSUMER_IDLE_TIME;
+
+public class ThrottlingMessageReceiver implements MessageReceiver {
+
+    private final MessageReceiver receiver;
+    private final IdleTimeCalculator idleTimeCalculator;
+    private final HermesMetrics metrics;
+    private Subscription subscription;
+
+    public ThrottlingMessageReceiver(MessageReceiver receiver,
+                                     IdleTimeCalculator idleTimeCalculator,
+                                     Subscription subscription,
+                                     HermesMetrics metrics) {
+        this.receiver = receiver;
+        this.idleTimeCalculator = idleTimeCalculator;
+        this.subscription = subscription;
+        this.metrics = metrics;
+    }
+
+    @Override
+    public Optional<Message> next() {
+        Optional<Message> next = receiver.next();
+        if (next.isPresent()) {
+            idleTimeCalculator.reset();
+        } else {
+            awaitUntilNextPoll();
+        }
+        return next;
+    }
+
+    private void awaitUntilNextPoll() {
+        try (Timer.Context ctx = metrics.timer(CONSUMER_IDLE_TIME,
+                subscription.getTopicName(),
+                subscription.getName()).time()) {
+            Thread.sleep(idleTimeCalculator.increaseIdleTime());
+        } catch (InterruptedException ex) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    @Override
+    public void commit(Set<SubscriptionPartitionOffset> offsets) {
+        receiver.commit(offsets);
+    }
+
+    @Override
+    public void moveOffset(SubscriptionPartitionOffset offset) {
+        receiver.moveOffset(offset);
+    }
+
+    @Override
+    public void stop() {
+        receiver.stop();
+    }
+
+    @Override
+    public void update(Subscription newSubscription) {
+        this.subscription = newSubscription;
+        this.receiver.update(newSubscription);
+    }
+}

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/receiver/kafka/KafkaMessageReceiverFactory.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/receiver/kafka/KafkaMessageReceiverFactory.java
@@ -11,8 +11,11 @@ import pl.allegro.tech.hermes.common.message.wrapper.MessageContentWrapper;
 import pl.allegro.tech.hermes.common.metric.HermesMetrics;
 import pl.allegro.tech.hermes.consumers.consumer.filtering.FilteredMessageHandler;
 import pl.allegro.tech.hermes.consumers.consumer.filtering.chain.FilterChainFactory;
+import pl.allegro.tech.hermes.consumers.consumer.idleTime.ExponentiallyGrowingIdleTimeCalculator;
+import pl.allegro.tech.hermes.consumers.consumer.idleTime.IdleTimeCalculator;
 import pl.allegro.tech.hermes.consumers.consumer.offset.OffsetQueue;
 import pl.allegro.tech.hermes.consumers.consumer.rate.ConsumerRateLimiter;
+import pl.allegro.tech.hermes.consumers.consumer.receiver.ThrottlingMessageReceiver;
 import pl.allegro.tech.hermes.consumers.consumer.receiver.MessageReceiver;
 import pl.allegro.tech.hermes.consumers.consumer.receiver.ReceiverFactory;
 import pl.allegro.tech.hermes.tracker.consumers.Trackers;
@@ -22,6 +25,8 @@ import java.time.Clock;
 import java.util.Properties;
 
 import static org.apache.kafka.clients.consumer.ConsumerConfig.*;
+import static pl.allegro.tech.hermes.common.config.Configs.CONSUMER_RECEIVER_INITIAL_IDLE_TIME;
+import static pl.allegro.tech.hermes.common.config.Configs.CONSUMER_RECEIVER_MAX_IDLE_TIME;
 
 public class KafkaMessageReceiverFactory implements ReceiverFactory {
 
@@ -69,6 +74,15 @@ public class KafkaMessageReceiverFactory implements ReceiverFactory {
                 configs.getIntProperty(Configs.CONSUMER_RECEIVER_POOL_TIMEOUT),
                 configs.getIntProperty(Configs.CONSUMER_RECEIVER_READ_QUEUE_CAPACITY),
                 configs.getIntProperty(Configs.CONSUMER_RETRANSMISSION_QUEUE_CAPACITY));
+
+
+        if (configs.getBooleanProperty(Configs.CONSUMER_RECEIVER_WAIT_BETWEEN_UNSUCCESSFUL_POLLS)) {
+            IdleTimeCalculator idleTimeCalculator = new ExponentiallyGrowingIdleTimeCalculator(
+                    configs.getIntProperty(CONSUMER_RECEIVER_INITIAL_IDLE_TIME),
+                    configs.getIntProperty(CONSUMER_RECEIVER_MAX_IDLE_TIME)
+            );
+            receiver = new ThrottlingMessageReceiver(receiver, idleTimeCalculator, subscription, hermesMetrics);
+        }
 
         if (configs.getBooleanProperty(Configs.CONSUMER_FILTERING_ENABLED)) {
             FilteredMessageHandler filteredMessageHandler = new FilteredMessageHandler(

--- a/hermes-consumers/src/test/groovy/pl/allegro/tech/hermes/consumers/consumer/ExponentiallyGrowingIdleTimeCalculatorTest.groovy
+++ b/hermes-consumers/src/test/groovy/pl/allegro/tech/hermes/consumers/consumer/ExponentiallyGrowingIdleTimeCalculatorTest.groovy
@@ -1,0 +1,49 @@
+package pl.allegro.tech.hermes.consumers.consumer
+
+import pl.allegro.tech.hermes.consumers.consumer.idleTime.ExponentiallyGrowingIdleTimeCalculator
+import pl.allegro.tech.hermes.consumers.consumer.idleTime.IdleTimeCalculator
+import spock.lang.Specification
+
+
+class ExponentiallyGrowingIdleTimeCalculatorTest extends Specification {
+
+    def initialIdleTime = 10
+    def maxIdleTime = 1000
+    def base = 2
+
+    IdleTimeCalculator calculator
+
+    def setup() {
+        this.calculator = new ExponentiallyGrowingIdleTimeCalculator(base, initialIdleTime, maxIdleTime)
+    }
+
+    def "initial-idle-time is returned first"() {
+        expect:
+        calculator.idleTime == initialIdleTime
+    }
+
+    def "each consecutive idle-time is multiplied by base"() {
+        expect:
+        (0..6).each {
+            assert calculator.increaseIdleTime() == initialIdleTime * (base ** it)
+        }
+    }
+
+    def "idle-time should be lower or equal to max-idle-time"() {
+        expect:
+        10.times {
+            assert calculator.increaseIdleTime() <= maxIdleTime
+        }
+    }
+
+    def "initial-idle-time is returned after reset"() {
+        given:
+        3.times { calculator.increaseIdleTime() }
+
+        when:
+        calculator.reset()
+
+        then:
+        calculator.idleTime == initialIdleTime
+    }
+}


### PR DESCRIPTION
Added waiting between unsuccessful polls to reduce cpu utilization. Right now call to`kafkaConsumer.poll(timeout)` is very cpu intensive because KafkaConsumer implementation is constantly looping until timeout is reached. I used simple exponentially growing waiting strategy.