### PR TITLE
Sending delay

### DIFF
--- a/docs/docs/user/subscribing.md
+++ b/docs/docs/user/subscribing.md
@@ -551,3 +551,9 @@ It returns array of message tracking information in following format:
     }
 ]
 ```
+
+## Sending delay
+
+Sending delay can be defined for each serial subscription. Consumers will wait for a given time before trying to deliver a message.
+This might be useful in situations when there are multiple topics that sends events in the same time, but you want to increase
+chance that events from one topics will be delivered later than events from another topic. 

--- a/hermes-api/src/main/java/pl/allegro/tech/hermes/api/SubscriptionPolicy.java
+++ b/hermes-api/src/main/java/pl/allegro/tech/hermes/api/SubscriptionPolicy.java
@@ -16,6 +16,7 @@ public class SubscriptionPolicy {
     private static final int DEFAULT_MESSAGE_BACKOFF = 100;
     private static final int DEFAULT_REQUEST_TIMEOUT = 1000;
     private static final int DEFAULT_INFLIGHT_SIZE = 100;
+    private static final int DEFAULT_SENDING_DELAY = 0;
 
     @Min(1)
     private int rate = DEFAULT_RATE;
@@ -34,6 +35,10 @@ public class SubscriptionPolicy {
     @Min(1)
     private int inflightSize = DEFAULT_INFLIGHT_SIZE;
 
+    @Min(0)
+    @Max(5000)
+    private int sendingDelay = DEFAULT_SENDING_DELAY;
+
     private boolean retryClientErrors = false;
 
     private SubscriptionPolicy() {
@@ -44,13 +49,15 @@ public class SubscriptionPolicy {
                               int requestTimeout,
                               boolean retryClientErrors,
                               int messageBackoff,
-                              Integer inflightSize) {
+                              Integer inflightSize,
+                              int sendingDelay) {
         this.rate = rate;
         this.messageTtl = messageTtl;
         this.requestTimeout = requestTimeout;
         this.retryClientErrors = retryClientErrors;
         this.messageBackoff = messageBackoff;
         this.inflightSize = inflightSize;
+        this.sendingDelay = sendingDelay;
     }
 
     @JsonCreator
@@ -61,13 +68,14 @@ public class SubscriptionPolicy {
                 (Integer) properties.getOrDefault("requestTimeout", DEFAULT_REQUEST_TIMEOUT),
                 (Boolean) properties.getOrDefault("retryClientErrors", false),
                 (Integer) properties.getOrDefault("messageBackoff", DEFAULT_MESSAGE_BACKOFF),
-                (Integer) properties.getOrDefault("inflightSize", DEFAULT_INFLIGHT_SIZE)
+                (Integer) properties.getOrDefault("inflightSize", DEFAULT_INFLIGHT_SIZE),
+                (Integer) properties.getOrDefault("sendingDelay", DEFAULT_SENDING_DELAY)
         );
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(rate, messageTtl, messageBackoff, retryClientErrors, requestTimeout, inflightSize);
+        return Objects.hash(rate, messageTtl, messageBackoff, retryClientErrors, requestTimeout, inflightSize, sendingDelay);
     }
 
     @Override
@@ -84,7 +92,8 @@ public class SubscriptionPolicy {
                 && Objects.equals(this.messageBackoff, other.messageBackoff)
                 && Objects.equals(this.retryClientErrors, other.retryClientErrors)
                 && Objects.equals(this.requestTimeout, other.requestTimeout)
-                && Objects.equals(this.inflightSize, other.inflightSize);
+                && Objects.equals(this.inflightSize, other.inflightSize)
+                && Objects.equals(this.sendingDelay, other.sendingDelay);
     }
 
     @Override
@@ -96,6 +105,7 @@ public class SubscriptionPolicy {
                 .add("messageBackoff", messageBackoff)
                 .add("retryClientErrors", retryClientErrors)
                 .add("inflightSize", inflightSize)
+                .add("sendingDelay", sendingDelay)
                 .toString();
     }
 
@@ -125,6 +135,10 @@ public class SubscriptionPolicy {
 
     public Integer getInflightSize() {
         return inflightSize;
+    }
+
+    public Integer getSendingDelay() {
+        return sendingDelay;
     }
 
     public static class Builder {
@@ -168,6 +182,11 @@ public class SubscriptionPolicy {
 
         public Builder withClientErrorRetry() {
             subscriptionPolicy.retryClientErrors = true;
+            return this;
+        }
+
+        public Builder withSendingDelay(int sendingDelay) {
+            subscriptionPolicy.sendingDelay = sendingDelay;
             return this;
         }
 

--- a/hermes-console/static/js/console/subscription/SubscriptionFactory.js
+++ b/hermes-console/static/js/console/subscription/SubscriptionFactory.js
@@ -18,6 +18,7 @@ subscriptions.factory('SubscriptionFactory', ['SUBSCRIPTION_CONFIG', function (s
                     subscriptionPolicy: {
                         messageTtl: 3600,
                         messageBackoff: 100,
+                        sendingDelay: 0
                     },
                     monitoringDetails: {
                         severity: 'NON_IMPORTANT',

--- a/hermes-console/static/partials/modal/editSubscription.html
+++ b/hermes-console/static/partials/modal/editSubscription.html
@@ -134,7 +134,7 @@
                 <div class="col-md-9">
                     <div class="input-group">
                         <input type="number" min="0" max="7200" step="1" required class="form-control" id="subscriptionMessageTtl" name="subscriptionMessageTtl" placeholder="Time when message can be resent to endpoint after failed sending attempts" ng-model="subscription.subscriptionPolicy.messageTtl"/>
-                        <span class="input-group-addon">seconds</span>
+                        <span class="input-group-addon">milliseconds</span>
                         <span class="input-group-addon helpme-addon" uib-tooltip="Amount of time a message can be held in sending queue and retried. If message will not be delivered during this time, it will be discarded.">?</span>
                     </div>
                 </div>

--- a/hermes-console/static/partials/modal/editSubscription.html
+++ b/hermes-console/static/partials/modal/editSubscription.html
@@ -119,7 +119,16 @@
                     </div>
                 </div>
             </div>
-
+            <div class="form-group {{subscriptionForm.subscriptionSendingDelay.$valid ? '' : 'has-error'}}" ng-show="subscription.deliveryType === 'SERIAL'">
+                <label for="subscriptionSendingDelay" class="col-md-3 control-label">Sending delay</label>
+                <div class="col-md-9">
+                    <div class="input-group">
+                        <input type="number" min="0" max="5000" step="1" required class="form-control" id="subscriptionSendingDelay" name="subscriptionSendingDelay" placeholder="Delay after which an event will be send" ng-model="subscription.subscriptionPolicy.sendingDelay"/>
+                        <span class="input-group-addon">seconds</span>
+                        <span class="input-group-addon helpme-addon" uib-tooltip="Amount of time in ms after which an event will be send. Useful if events from two topics are sent at the same time and you want to increase chance that events from one topic will be deliver after events from other topic.">?</span>
+                    </div>
+                </div>
+            </div>
             <div class="form-group {{subscriptionForm.subscriptionMessageTtl.$valid ? '' : 'has-error'}}">
                 <label for="subscriptionMessageTtl" class="col-md-3 control-label">Inflight message TTL</label>
                 <div class="col-md-9">

--- a/hermes-console/static/partials/subscription.html
+++ b/hermes-console/static/partials/subscription.html
@@ -139,6 +139,10 @@
                         <strong>Request timeout:</strong> {{subscription.subscriptionPolicy.requestTimeout}} milliseconds
                         <span uib-popover='Max time for processing message by subscriber.' popover-trigger="mouseenter" class="fa helpme pull-right">&#xf128;</span>
                     </p>
+                    <p ng-show="subscription.deliveryType === 'SERIAL'">
+                        <strong>Sending delay:</strong> {{subscription.subscriptionPolicy.sendingDelay}} milliseconds
+                        <span uib-popover='Amount of time in ms after which an event will be send. Useful if events from two topics are sent at the same time and you want to increase chance that events from one topic will be deliver after events from other topic.' popover-trigger="mouseenter" class="fa helpme pull-right">&#xf128;</span>
+                    </p>
                     <p>
                         <strong>Message TTL:</strong> {{subscription.subscriptionPolicy.messageTtl}} seconds
                         <span uib-popover='Amount of time a message can be held in sending queue and retried. If message will not be delivered during this time, it will be discarded.' popover-trigger="mouseenter" class="fa helpme pull-right">&#xf128;</span>

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/ConsumerMessageSender.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/ConsumerMessageSender.java
@@ -97,11 +97,7 @@ public class ConsumerMessageSender {
     }
 
     private int delayForSubscription() {
-        if (!subscription.isBatchSubscription()) {
-            return subscription.getSerialSubscriptionPolicy().getSendingDelay();
-        } else {
-            return 0;
-        }
+        return subscription.getSerialSubscriptionPolicy().getSendingDelay();
     }
 
     /**

--- a/hermes-consumers/src/test/java/pl/allegro/tech/hermes/consumers/consumer/ConsumerMessageSenderTest.java
+++ b/hermes-consumers/src/test/java/pl/allegro/tech/hermes/consumers/consumer/ConsumerMessageSenderTest.java
@@ -323,7 +323,7 @@ public class ConsumerMessageSenderTest {
         sender.sendAsync(message);
 
         // then
-        verify(otherMessageSender).send(message);
+        verify(otherMessageSender, timeout(1000)).send(message);
     }
 
     @Test

--- a/hermes-consumers/src/test/java/pl/allegro/tech/hermes/consumers/consumer/ConsumerMessageSenderTest.java
+++ b/hermes-consumers/src/test/java/pl/allegro/tech/hermes/consumers/consumer/ConsumerMessageSenderTest.java
@@ -345,7 +345,7 @@ public class ConsumerMessageSenderTest {
     }
 
     @Test
-    public void shouldDelaySendingMessageForOneSecond() {
+    public void shouldDelaySendingMessageForHalfSecond() {
         // given
         Subscription subscription = subscriptionBuilderWithTestValues()
                 .withSubscriptionPolicy(subscriptionPolicy().applyDefaults()

--- a/hermes-consumers/src/test/java/pl/allegro/tech/hermes/consumers/consumer/ConsumerMessageSenderTest.java
+++ b/hermes-consumers/src/test/java/pl/allegro/tech/hermes/consumers/consumer/ConsumerMessageSenderTest.java
@@ -29,7 +29,13 @@ import java.util.concurrent.Executors;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
 import static pl.allegro.tech.hermes.api.SubscriptionOAuthPolicy.passwordGrantOAuthPolicy;
 import static pl.allegro.tech.hermes.api.SubscriptionPolicy.Builder.subscriptionPolicy;
 import static pl.allegro.tech.hermes.test.helper.builder.SubscriptionBuilder.subscription;
@@ -98,7 +104,7 @@ public class ConsumerMessageSenderTest {
         when(messageSender.send(message)).thenReturn(success());
 
         // when
-        sender.sendMessage(message);
+        sender.sendAsync(message);
         verify(successHandler, timeout(1000)).handleSuccess(eq(message), eq(subscription), any(MessageSendingResult.class));
 
         // then
@@ -116,7 +122,7 @@ public class ConsumerMessageSenderTest {
         doReturn(failure()).doReturn(failure()).doReturn(success()).when(messageSender).send(message);
 
         // when
-        sender.sendMessage(message);
+        sender.sendAsync(message);
         verify(successHandler, timeout(1000)).handleSuccess(eq(message), eq(subscription), any(MessageSendingResult.class));
 
         // then
@@ -134,7 +140,7 @@ public class ConsumerMessageSenderTest {
         doReturn(failure()).when(messageSender).send(message);
 
         // when
-        sender.sendMessage(message);
+        sender.sendAsync(message);
 
         // then
         verify(errorHandler, timeout(1000)).handleDiscarded(eq(message), eq(subscription), any(MessageSendingResult.class));
@@ -151,7 +157,7 @@ public class ConsumerMessageSenderTest {
         doReturn(failure(403)).doReturn(success()).when(messageSender).send(message);
 
         // when
-        sender.sendMessage(message);
+        sender.sendAsync(message);
 
         // then
         verify(errorHandler, timeout(1000)).handleDiscarded(eq(message), eq(subscription), any(MessageSendingResult.class));
@@ -168,7 +174,7 @@ public class ConsumerMessageSenderTest {
         doReturn(failure(403)).doReturn(failure(403)).doReturn(failure(403)).doReturn(success()).when(messageSender).send(message);
 
         // when
-        sender.sendMessage(message);
+        sender.sendAsync(message);
         verify(successHandler, timeout(1000)).handleSuccess(eq(message), eq(subscriptionWith4xxRetry), any(MessageSendingResult.class));
 
         // then
@@ -183,7 +189,7 @@ public class ConsumerMessageSenderTest {
         doReturn(failure(403)).doReturn(success()).when(messageSender).send(message);
 
         // when
-        sender.sendMessage(message);
+        sender.sendAsync(message);
 
         // then
         verifyRateLimiterFailedSendingCountedTimes(0);
@@ -198,7 +204,7 @@ public class ConsumerMessageSenderTest {
         doReturn(failure(500)).doReturn(success()).when(messageSender).send(message);
 
         // when
-        sender.sendMessage(message);
+        sender.sendAsync(message);
 
         // then
         verifyRateLimiterFailedSendingCountedTimes(1);
@@ -213,7 +219,7 @@ public class ConsumerMessageSenderTest {
         doReturn(failure(403)).doReturn(failure(403)).doReturn(success()).when(messageSender).send(message);
 
         // when
-        sender.sendMessage(message);
+        sender.sendAsync(message);
 
         // then
         verifyRateLimiterFailedSendingCountedTimes(2);
@@ -230,7 +236,7 @@ public class ConsumerMessageSenderTest {
         doReturn(failure(401)).doReturn(failure(401)).doReturn(success()).when(messageSender).send(message);
 
         // when
-        sender.sendMessage(message);
+        sender.sendAsync(message);
 
         // then
         verifyRateLimiterFailedSendingCountedTimes(2);
@@ -244,7 +250,7 @@ public class ConsumerMessageSenderTest {
         when(messageSender.send(message)).thenReturn(new CompletableFuture<>());
 
         // when
-        sender.sendMessage(message);
+        sender.sendAsync(message);
 
         // then
         verifyErrorHandlerHandleFailed(message, subscription, 1, 3000);
@@ -263,7 +269,7 @@ public class ConsumerMessageSenderTest {
         doReturn(failure(500)).when(messageSender).send(message);
 
         //when
-        sender.sendMessage(message);
+        sender.sendAsync(message);
 
         //then
         Thread.sleep(executionTime);
@@ -278,7 +284,7 @@ public class ConsumerMessageSenderTest {
         doReturn(backoff(retrySeconds)).doReturn(success()).when(messageSender).send(message);
 
         // when
-        sender.sendMessage(message);
+        sender.sendAsync(message);
 
         // then
         verifyRateLimiterFailedSendingCountedTimes(0);
@@ -294,7 +300,7 @@ public class ConsumerMessageSenderTest {
         doReturn(backoff(retrySeconds)).when(messageSender).send(message);
 
         // when
-        sender.sendMessage(message);
+        sender.sendAsync(message);
 
         // then
         verifyRateLimiterSuccessfulSendingCountedTimes(1);
@@ -314,7 +320,7 @@ public class ConsumerMessageSenderTest {
 
         // when
         sender.updateSubscription(subscriptionWithModfiedEndpoint);
-        sender.sendMessage(message);
+        sender.sendAsync(message);
 
         // then
         verify(otherMessageSender).send(message);
@@ -332,10 +338,34 @@ public class ConsumerMessageSenderTest {
 
         // when
         sender.updateSubscription(subscriptionWithModfiedTimeout);
-        sender.sendMessage(message);
+        sender.sendAsync(message);
 
         // then
-        verify(otherMessageSender).send(message);
+        verify(otherMessageSender, timeout(1000)).send(message);
+    }
+
+    @Test
+    public void shouldDelaySendingMessageForOneSecond() {
+        // given
+        Subscription subscription = subscriptionBuilderWithTestValues()
+                .withSubscriptionPolicy(subscriptionPolicy().applyDefaults()
+                        .withSendingDelay(500)
+                        .build())
+                .build();
+        setUpMetrics(subscription);
+
+        Message message = message();
+        when(messageSender.send(message)).thenReturn(success());
+        ConsumerMessageSender sender = consumerMessageSender(subscription);
+
+        // when
+        long sendingStartTime = System.currentTimeMillis();
+        sender.sendAsync(message);
+        verify(successHandler, timeout(1000)).handleSuccess(eq(message), eq(subscription), any(MessageSendingResult.class));
+
+        // then
+        long sendingTime = System.currentTimeMillis() - sendingStartTime;
+        assertThat(sendingTime).isGreaterThan(500);
     }
 
     private ConsumerMessageSender consumerMessageSender(Subscription subscription) {

--- a/hermes-test-helper/src/main/java/pl/allegro/tech/hermes/test/helper/builder/SubscriptionBuilder.java
+++ b/hermes-test-helper/src/main/java/pl/allegro/tech/hermes/test/helper/builder/SubscriptionBuilder.java
@@ -19,7 +19,7 @@ public class SubscriptionBuilder {
 
     private String description = "description";
 
-    private SubscriptionPolicy serialSubscriptionPolicy = new SubscriptionPolicy(100, 10, 1000, false, 100, 100);
+    private SubscriptionPolicy serialSubscriptionPolicy = new SubscriptionPolicy(100, 10, 1000, false, 100, 100, 0);
 
     private BatchSubscriptionPolicy batchSubscriptionPolicy;
 

--- a/integration/src/integration/java/pl/allegro/tech/hermes/integration/FilteringJsonTest.java
+++ b/integration/src/integration/java/pl/allegro/tech/hermes/integration/FilteringJsonTest.java
@@ -31,7 +31,7 @@ public class FilteringJsonTest extends IntegrationTest {
     final static AvroUser ALICE_GREY = new AvroUser("Alice", 20, "grey");
     final static AvroUser BOB_GREY = new AvroUser("Bob", 50, "grey");
 
-    private final static SubscriptionPolicy SUBSCRIPTION_POLICY = new SubscriptionPolicy(100, 2000, 1000, true, 100, 100);
+    private final static SubscriptionPolicy SUBSCRIPTION_POLICY = new SubscriptionPolicy(100, 2000, 1000, true, 100, 100, 0);
 
     @BeforeMethod
     public void initializeAlways() {


### PR DESCRIPTION
This PR implements feature of delayed events. We want to give users possibility to postpone sending an event for given time (max 5 seconds) so if there are multiple topics that sends messages at the same time, then can increase chance of receiving an event from one topic before an event from another topic.

I implemented this feature in serial subscriptions. It will require more code and testing to support batch subscriptions. I believe that clients that asked about this feature use serial subscriptions. We can always support batches in a separate PR.