### PR TITLE
make BackupMessage serializable

### DIFF
--- a/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/buffer/BackupMessage.java
+++ b/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/buffer/BackupMessage.java
@@ -1,9 +1,10 @@
 package pl.allegro.tech.hermes.frontend.buffer;
 
+import java.io.Serializable;
 import java.util.Arrays;
 import java.util.Objects;
 
-public class BackupMessage {
+public class BackupMessage implements Serializable {
 
     private final String messageId;
     private final byte[] data;


### PR DESCRIPTION
This change is needed for a migration tool before a  #893 