### PR TITLE
Sending Delay is not required in batch subscription

### DIFF
--- a/hermes-console/static/partials/modal/editSubscription.html
+++ b/hermes-console/static/partials/modal/editSubscription.html
@@ -75,7 +75,7 @@
                     <div class="input-group">
                         <input type="number" min="0" max="5000" step="10" ng-required="subscription.deliveryType === 'SERIAL'" class="form-control" id="subscriptionRateLimit" name="subscriptionRateLimit" placeholder="limit of messages sent by Hermes" ng-model="subscription.subscriptionPolicy.rate"/>
                         <span class="input-group-addon">messages/second</span>
-                        <span class="input-group-addon helpme-addon" uib-tooltip="Maximum rate defined by user (per data center). Maximum rate calculated by algorithm can be observed in "Output rate" metric.">?</span>
+                        <span class="input-group-addon helpme-addon" uib-tooltip="Maximum rate defined by user (per data center). Maximum rate calculated by algorithm can be observed in 'Output rate' metric.">?</span>
                     </div>
                 </div>
             </div>
@@ -123,7 +123,7 @@
                 <label for="subscriptionSendingDelay" class="col-md-3 control-label">Sending delay</label>
                 <div class="col-md-9">
                     <div class="input-group">
-                        <input type="number" min="0" max="5000" step="1" required class="form-control" id="subscriptionSendingDelay" name="subscriptionSendingDelay" placeholder="Delay after which an event will be send" ng-model="subscription.subscriptionPolicy.sendingDelay"/>
+                        <input type="number" min="0" max="5000" step="1" ng-required="subscription.deliveryType === 'SERIAL'" class="form-control" id="subscriptionSendingDelay" name="subscriptionSendingDelay" placeholder="Delay after which an event will be send" ng-model="subscription.subscriptionPolicy.sendingDelay"/>
                         <span class="input-group-addon">milliseconds</span>
                         <span class="input-group-addon helpme-addon" uib-tooltip="Amount of time in ms after which an event will be send. Useful if events from two topics are sent at the same time and you want to increase chance that events from one topic will be deliver after events from other topic.">?</span>
                     </div>


### PR DESCRIPTION
Sending delay should not be required in batch subscription. Right now, it blocks batch subscription editing.