### PR TITLE
Updating wiremock

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,7 @@ allprojects {
             jetty    : '9.3.18.v20170406',
             curator  : '2.12.0',
             metrics  : '3.2.5',
-            wiremock : '1.58',
+            wiremock : '2.19.0',
             fongo    : '1.6.1',
             spock    : '1.0-groovy-2.4',
             alpn_api : '1.1.2.v20150522',

--- a/hermes-client/build.gradle
+++ b/hermes-client/build.gradle
@@ -8,7 +8,7 @@ dependencies {
     compile group: 'net.jodah', name: 'failsafe', version: '0.9.3'
 
     testCompile group: 'org.spockframework', name: 'spock-core', version: versions.spock
-    testCompile group: 'com.github.tomakehurst', name: 'wiremock', version: versions.wiremock
+    testCompile group: 'com.github.tomakehurst', name: 'wiremock-standalone', version: versions.wiremock
     testCompile group: 'javax.servlet', name: 'javax.servlet-api', version: '3.1.0'
     testCompile group: 'com.jayway.jsonpath', name: 'json-path', version: '2.2.0'
 

--- a/hermes-consumers/build.gradle
+++ b/hermes-consumers/build.gradle
@@ -27,12 +27,6 @@ dependencies {
     testCompile group: 'org.apache.curator', name: 'curator-test', version: versions.curator
     testCompile group: 'javax.servlet', name: 'javax.servlet-api', version: '3.1.0'
 
-    testCompile(group: 'com.github.tomakehurst', name: 'wiremock', version: versions.wiremock) {
-        exclude group: 'org.mortbay.jetty', module: 'servlet-api'
-        exclude group: 'org.apache.httpcomponents', module: 'httpclient'
-        exclude group: 'net.sf.jopt-simple'
-    }
-
     testCompile project(':hermes-common')
 
     testCompile(group: 'com.jayway.awaitility', name: 'awaitility', version: '1.6.1') {

--- a/hermes-management/build.gradle
+++ b/hermes-management/build.gradle
@@ -33,10 +33,6 @@ dependencies {
     testCompile group: 'org.spockframework', name: 'spock-spring', version: versions.spock
 
     testCompile group: 'com.github.fakemongo', name: 'fongo', version: versions.fongo
-    testCompile(group: 'com.github.tomakehurst', name: 'wiremock', version: versions.wiremock) {
-        exclude group: 'org.mortbay.jetty', module: 'servlet-api'
-        exclude group: 'net.sf.jopt-simple'
-    }
 }
 
 if (project.hasProperty('distribution')) {

--- a/hermes-mock/build.gradle
+++ b/hermes-mock/build.gradle
@@ -5,7 +5,7 @@ plugins {
 
 dependencies {
     compile group: 'junit', name: 'junit', version: '4.11'
-    compile group: 'com.github.tomakehurst', name: 'wiremock', version: '2.14.0'
+    compile group: 'com.github.tomakehurst', name: 'wiremock', version: versions.wiremock
     compile group: 'com.jayway.awaitility', name: 'awaitility', version: '1.6.1'
     compile group: 'org.apache.avro', name: 'avro', version: versions.avro
     compile group: 'tech.allegro.schema.json2avro', name: 'converter', version: versions.json2avro

--- a/hermes-schema/src/test/groovy/pl/allegro/tech/hermes/schema/confluent/SchemaRegistryRawSchemaClientTest.groovy
+++ b/hermes-schema/src/test/groovy/pl/allegro/tech/hermes/schema/confluent/SchemaRegistryRawSchemaClientTest.groovy
@@ -3,8 +3,8 @@ package pl.allegro.tech.hermes.schema.confluent
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder
-import com.github.tomakehurst.wiremock.client.UrlMatchingStrategy
 import com.github.tomakehurst.wiremock.client.WireMock
+import com.github.tomakehurst.wiremock.matching.UrlPattern
 import pl.allegro.tech.hermes.api.RawSchema
 import pl.allegro.tech.hermes.api.TopicName
 import pl.allegro.tech.hermes.schema.BadSchemaRequestException
@@ -313,23 +313,23 @@ class SchemaRegistryRawSchemaClientTest extends Specification {
         e.message.contains("name should start with uppercase")
     }
 
-    private UrlMatchingStrategy versionsUrl(TopicName topic) {
+    private UrlPattern versionsUrl(TopicName topic) {
         urlEqualTo("/subjects/${topic.qualifiedName()}/versions")
     }
 
-    private UrlMatchingStrategy schemaVersionUrl(TopicName topic, int version) {
+    private UrlPattern schemaVersionUrl(TopicName topic, int version) {
         urlEqualTo("/subjects/${topic.qualifiedName()}/versions/$version")
     }
 
-    private UrlMatchingStrategy schemaLatestVersionUrl(TopicName topic) {
+    private UrlPattern schemaLatestVersionUrl(TopicName topic) {
         urlEqualTo("/subjects/${topic.qualifiedName()}/versions/latest")
     }
 
-    private UrlMatchingStrategy schemaCompatibilityUrl(TopicName topic) {
+    private UrlPattern schemaCompatibilityUrl(TopicName topic) {
         urlEqualTo("/compatibility/subjects/${topic.qualifiedName()}/versions/latest")
     }
 
-    private UrlMatchingStrategy schemaValidationUrl(TopicName topic) {
+    private UrlPattern schemaValidationUrl(TopicName topic) {
         urlEqualTo("/subjects/${topic.qualifiedName()}/validation")
     }
 

--- a/hermes-schema/src/test/groovy/pl/allegro/tech/hermes/schema/schemarepo/SchemaRepoRawSchemaClientTest.groovy
+++ b/hermes-schema/src/test/groovy/pl/allegro/tech/hermes/schema/schemarepo/SchemaRepoRawSchemaClientTest.groovy
@@ -2,8 +2,8 @@ package pl.allegro.tech.hermes.schema.schemarepo
 
 import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder
-import com.github.tomakehurst.wiremock.client.UrlMatchingStrategy
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration
+import com.github.tomakehurst.wiremock.matching.UrlPattern
 import pl.allegro.tech.hermes.api.RawSchema
 import pl.allegro.tech.hermes.api.TopicName
 import pl.allegro.tech.hermes.schema.BadSchemaRequestException
@@ -195,23 +195,23 @@ class SchemaRepoRawSchemaClientTest extends Specification {
         schema.get().value() == "{}"
     }
 
-    private UrlMatchingStrategy subjectUrl(TopicName topic) {
+    private UrlPattern subjectUrl(TopicName topic) {
         urlEqualTo("/schema-repo/${topic.qualifiedName()}")
     }
 
-    private UrlMatchingStrategy latestSchemaUrl(TopicName topic) {
+    private UrlPattern latestSchemaUrl(TopicName topic) {
         urlEqualTo("/schema-repo/${topic.qualifiedName()}/latest")
     }
 
-    private UrlMatchingStrategy schemaVersionUrl(TopicName topic, int version) {
+    private UrlPattern schemaVersionUrl(TopicName topic, int version) {
         urlEqualTo("/schema-repo/${topic.qualifiedName()}/id/$version")
     }
 
-    private UrlMatchingStrategy allSchemasUrl(TopicName topic) {
+    private UrlPattern allSchemasUrl(TopicName topic) {
         urlEqualTo("/schema-repo/${topic.qualifiedName()}/all")
     }
 
-    private UrlMatchingStrategy registerSchemaUrl(TopicName topic) {
+    private UrlPattern registerSchemaUrl(TopicName topic) {
         urlEqualTo("/schema-repo/${topic.qualifiedName()}/register")
     }
 

--- a/hermes-test-helper/build.gradle
+++ b/hermes-test-helper/build.gradle
@@ -14,10 +14,7 @@ dependencies {
         exclude module: 'slf4j-log4j12'
         exclude module: 'log4j'
     }
-    compile(group: 'com.github.tomakehurst', name: 'wiremock', version: versions.wiremock) {
-        exclude group: 'org.mortbay.jetty', module: 'servlet-api'
-        exclude group: 'net.sf.jopt-simple'
-    }
+    compile group: 'com.github.tomakehurst', name: 'wiremock-standalone', version: versions.wiremock
     compile (group: 'org.apache.curator', name: 'curator-test', version: versions.curator) {
         exclude module: 'slf4j-log4j12'
         exclude module: 'log4j'

--- a/integration/src/integration/java/pl/allegro/tech/hermes/integration/BatchRetryPolicyTest.java
+++ b/integration/src/integration/java/pl/allegro/tech/hermes/integration/BatchRetryPolicyTest.java
@@ -2,8 +2,8 @@ package pl.allegro.tech.hermes.integration;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.tomakehurst.wiremock.WireMockServer;
-import com.github.tomakehurst.wiremock.client.UrlMatchingStrategy;
 import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.matching.UrlPattern;
 import com.github.tomakehurst.wiremock.stubbing.Scenario;
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
 import org.testng.annotations.AfterClass;
@@ -18,10 +18,16 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.containing;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static java.util.Comparator.comparingLong;
 import static javax.ws.rs.core.Response.Status.CREATED;
-import static org.apache.http.HttpStatus.*;
+import static org.apache.http.HttpStatus.SC_BAD_REQUEST;
+import static org.apache.http.HttpStatus.SC_CREATED;
+import static org.apache.http.HttpStatus.SC_INTERNAL_SERVER_ERROR;
 import static pl.allegro.tech.hermes.integration.test.HermesAssertions.assertThat;
 
 public class BatchRetryPolicyTest extends IntegrationTest {
@@ -184,11 +190,11 @@ public class BatchRetryPolicyTest extends IntegrationTest {
         wait.until(() -> assertThat(recordedRequests(topic).size()).isPositive());
     }
 
-    private UrlMatchingStrategy topicUrl(Topic topic) {
+    private UrlPattern topicUrl(Topic topic) {
         return topicUrl(topic.getName().getName());
     }
 
-    private UrlMatchingStrategy topicUrl(String topicName) {
+    private UrlPattern topicUrl(String topicName) {
         return urlEqualTo("/" + topicName);
     }
 


### PR DESCRIPTION
Updating wiremock to the latest version (2.19.0) and using standalone version where it is possible to avoid conflicts of its dependencies. Solves #804 