### PR TITLE
Optimizing elasticsearch template mapping

### DIFF
--- a/hermes-tracker-elasticsearch/src/main/java/pl/allegro/tech/hermes/tracker/elasticsearch/SchemaManager.java
+++ b/hermes-tracker-elasticsearch/src/main/java/pl/allegro/tech/hermes/tracker/elasticsearch/SchemaManager.java
@@ -13,7 +13,6 @@ import pl.allegro.tech.hermes.tracker.elasticsearch.frontend.FrontendIndexFactor
 
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.function.Function;
 
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
@@ -115,9 +114,9 @@ public class SchemaManager {
         return prepareMapping(SENT_TYPE, xContentBuilder -> {
             try {
                 return xContentBuilder
-                        .startObject(SUBSCRIPTION).field("type", "keyword").endObject()
-                        .startObject(PUBLISH_TIMESTAMP).field("type", "long").endObject()
-                        .startObject(BATCH_ID).field("type", "keyword").endObject()
+                        .startObject(SUBSCRIPTION).field("type", "keyword").field("norms", false).endObject()
+                        .startObject(PUBLISH_TIMESTAMP).field("type", "date").field("index", false).endObject()
+                        .startObject(BATCH_ID).field("type", "keyword").field("norms", false).endObject()
                         .startObject(OFFSET).field("type", "long").endObject()
                         .startObject(PARTITION).field("type", "integer").endObject();
             } catch (IOException e) {
@@ -134,15 +133,15 @@ public class SchemaManager {
                         .field("dynamic", dynamicMappingEnabled)
                         .startObject("_all").field("enabled", false).endObject()
                         .startObject("properties")
-                            .startObject(MESSAGE_ID).field("type", "keyword").endObject()
-                            .startObject(TIMESTAMP).field("type", "long").field("index", false).endObject()
-                            .startObject(TIMESTAMP_SECONDS).field("type", "long").endObject()
-                            .startObject(TOPIC_NAME).field("type", "keyword").endObject()
-                            .startObject(STATUS).field("type", "keyword").endObject()
-                            .startObject(CLUSTER).field("type", "keyword").endObject()
-                            .startObject(SOURCE_HOSTNAME).field("type", "keyword").endObject()
-                            .startObject(REMOTE_HOSTNAME).field("type", "keyword").endObject()
-                            .startObject(REASON).field("type", "text").endObject();
+                            .startObject(MESSAGE_ID).field("type", "keyword").field("norms", false).endObject()
+                            .startObject(TIMESTAMP).field("type", "date").field("index", false).endObject()
+                            .startObject(TIMESTAMP_SECONDS).field("type", "date").field("format", "epoch_second").endObject()
+                            .startObject(TOPIC_NAME).field("type", "keyword").field("norms", false).endObject()
+                            .startObject(STATUS).field("type", "keyword").field("norms", false).endObject()
+                            .startObject(CLUSTER).field("type", "keyword").field("norms", false).endObject()
+                            .startObject(SOURCE_HOSTNAME).field("type", "keyword").field("norms", false).endObject()
+                            .startObject(REMOTE_HOSTNAME).field("type", "keyword").field("norms", false).endObject()
+                            .startObject(REASON).field("type", "text").field("norms", false).endObject();
 
             return additionalMapping.apply(jsonBuilder).endObject().endObject().endObject();
         } catch (IOException ex) {

--- a/hermes-tracker-elasticsearch/src/test/java/pl/allegro/tech/hermes/tracker/elasticsearch/consumers/ConsumersElasticsearchLogRepositoryTest.java
+++ b/hermes-tracker-elasticsearch/src/test/java/pl/allegro/tech/hermes/tracker/elasticsearch/consumers/ConsumersElasticsearchLogRepositoryTest.java
@@ -30,7 +30,7 @@ public class ConsumersElasticsearchLogRepositoryTest extends AbstractLogReposito
 
     private static final String CLUSTER_NAME = "primary";
 
-    private static final Clock clock = Clock.fixed(LocalDate.of(2000, 1, 1).atStartOfDay().toInstant(ZoneOffset.UTC), ZoneId.systemDefault());
+    private static final Clock clock = Clock.fixed(LocalDate.now().atStartOfDay().toInstant(ZoneOffset.UTC), ZoneId.systemDefault());
     private static final ConsumersIndexFactory indexFactory = new ConsumersDailyIndexFactory(clock);
     private static final FrontendIndexFactory frontendIndexFactory = new FrontendDailyIndexFactory(clock);
 

--- a/hermes-tracker-elasticsearch/src/test/java/pl/allegro/tech/hermes/tracker/elasticsearch/frontend/FrontendElasticsearchLogRepositoryTest.java
+++ b/hermes-tracker-elasticsearch/src/test/java/pl/allegro/tech/hermes/tracker/elasticsearch/frontend/FrontendElasticsearchLogRepositoryTest.java
@@ -31,7 +31,7 @@ public class FrontendElasticsearchLogRepositoryTest extends AbstractLogRepositor
 
     private static final String CLUSTER_NAME = "primary";
 
-    private static final Clock clock = Clock.fixed(LocalDate.of(2000, 1, 1).atStartOfDay().toInstant(ZoneOffset.UTC), ZoneId.systemDefault());
+    private static final Clock clock = Clock.fixed(LocalDate.now().atStartOfDay().toInstant(ZoneOffset.UTC), ZoneId.systemDefault());
     private static final FrontendIndexFactory frontendIndexFactory = new FrontendDailyIndexFactory(clock);
     private static final ConsumersIndexFactory consumersIndexFactory = new ConsumersDailyIndexFactory(clock);
 

--- a/hermes-tracker-elasticsearch/src/test/java/pl/allegro/tech/hermes/tracker/elasticsearch/management/ElasticsearchLogRepositoryTest.java
+++ b/hermes-tracker-elasticsearch/src/test/java/pl/allegro/tech/hermes/tracker/elasticsearch/management/ElasticsearchLogRepositoryTest.java
@@ -40,7 +40,7 @@ public class ElasticsearchLogRepositoryTest implements LogSchemaAware {
     private static final String CLUSTER_NAME = "primary";
     private static final String REASON_MESSAGE = "Bad Request";
 
-    private static final Clock clock = Clock.fixed(LocalDate.of(2000, 1, 1).atStartOfDay().toInstant(ZoneOffset.UTC), ZoneId.systemDefault());
+    private static final Clock clock = Clock.fixed(LocalDate.now().atStartOfDay().toInstant(ZoneOffset.UTC), ZoneId.systemDefault());
     private static final FrontendIndexFactory frontendIndexFactory = new FrontendDailyIndexFactory(clock);
     private static final ConsumersIndexFactory consumersIndexFactory = new ConsumersDailyIndexFactory(clock);
 

--- a/hermes-tracker/src/test/java/pl/allegro/tech/hermes/tracker/frontend/AbstractLogRepositoryTest.java
+++ b/hermes-tracker/src/test/java/pl/allegro/tech/hermes/tracker/frontend/AbstractLogRepositoryTest.java
@@ -10,6 +10,7 @@ import pl.allegro.tech.hermes.api.PublishedMessageTraceStatus;
 import pl.allegro.tech.hermes.test.helper.retry.RetryListener;
 import pl.allegro.tech.hermes.test.helper.retry.Retry;
 
+import static java.lang.System.currentTimeMillis;
 import static pl.allegro.tech.hermes.api.PublishedMessageTraceStatus.ERROR;
 import static pl.allegro.tech.hermes.api.PublishedMessageTraceStatus.INFLIGHT;
 import static pl.allegro.tech.hermes.api.PublishedMessageTraceStatus.SUCCESS;
@@ -41,7 +42,7 @@ public abstract class AbstractLogRepositoryTest {
         String hostname = "172.16.254.1";
 
         // when
-        logRepository.logPublished(id, 1234L, topic, hostname);
+        logRepository.logPublished(id, currentTimeMillis(), topic, hostname);
 
         // then
         awaitUntilMessageIsPersisted(topic, id, SUCCESS, hostname);
@@ -55,7 +56,7 @@ public abstract class AbstractLogRepositoryTest {
         String hostname = "172.16.254.1";
 
         // when
-        logRepository.logError(id, 1234L, topic, "reason", hostname);
+        logRepository.logError(id, currentTimeMillis(), topic, "reason", hostname);
 
         // then
         awaitUntilMessageIsPersisted(topic, id, ERROR, "reason", hostname);
@@ -69,7 +70,7 @@ public abstract class AbstractLogRepositoryTest {
         String hostname = "172.16.254.1";
 
         // when
-        logRepository.logInflight(id, 1234L, topic, hostname);
+        logRepository.logInflight(id, currentTimeMillis(), topic, hostname);
 
         // then
         awaitUntilMessageIsPersisted(topic, id, INFLIGHT, hostname);


### PR DESCRIPTION
Changes for elasticsearch template mapping.

1. Converting timestamp fields to `date` type. Thanks to this it will be easier to search documents from kibana.
2. Indexing `timestamp_seconds` but not `timestamp` field (which has values in milliseconds). Related to [performance](https://engineering.mixmax.com/blog/30x-faster-elasticsearch-queries) improvement.
3. Disabling [norms](https://www.elastic.co/guide/en/elasticsearch/reference/current/norms.html) feature for text fields. Related to disk usage optimization.