### PR TITLE
Giving names to all anonymous thread pools

### DIFF
--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/common/metric/executor/InstrumentedExecutorServiceFactory.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/common/metric/executor/InstrumentedExecutorServiceFactory.java
@@ -1,11 +1,13 @@
 package pl.allegro.tech.hermes.common.metric.executor;
 
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import pl.allegro.tech.hermes.common.metric.HermesMetrics;
 
 import javax.inject.Inject;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadFactory;
 
 import static java.util.concurrent.Executors.newScheduledThreadPool;
 
@@ -19,7 +21,8 @@ public class InstrumentedExecutorServiceFactory {
     }
 
     public ExecutorService getExecutorService(String name, int size, boolean monitoringEnabled) {
-        ExecutorService executor = Executors.newFixedThreadPool(size);
+        ThreadFactory threadFactory = new ThreadFactoryBuilder().setNameFormat(name + "-executor-%d").build();
+        ExecutorService executor = Executors.newFixedThreadPool(size, threadFactory);
         if (monitoringEnabled) {
             return new InstrumentedExecutorService(executor, hermesMetrics, name);
         } else {
@@ -28,7 +31,8 @@ public class InstrumentedExecutorServiceFactory {
     }
 
     public ScheduledExecutorService getScheduledExecutorService(String name, int size, boolean monitoringEnabled) {
-        ScheduledExecutorService executor = newScheduledThreadPool(size);
+        ThreadFactory threadFactory = new ThreadFactoryBuilder().setNameFormat(name + "-scheduled-executor-%d").build();
+        ScheduledExecutorService executor = newScheduledThreadPool(size, threadFactory);
         if (monitoringEnabled) {
             return new InstrumentedScheduledExecutorService(executor, hermesMetrics, name);
         } else {

--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/infrastructure/zookeeper/cache/ModelAwareZookeeperNotifyingCache.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/infrastructure/zookeeper/cache/ModelAwareZookeeperNotifyingCache.java
@@ -1,5 +1,6 @@
 package pl.allegro.tech.hermes.infrastructure.zookeeper.cache;
 
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.recipes.cache.PathChildrenCacheEvent;
 import pl.allegro.tech.hermes.common.cache.queue.LinkedHashSetBlockingQueue;
@@ -7,6 +8,7 @@ import pl.allegro.tech.hermes.infrastructure.zookeeper.ZookeeperPaths;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
@@ -26,9 +28,9 @@ public class ModelAwareZookeeperNotifyingCache {
         List<String> levelPrefixes = Arrays.asList(
                 ZookeeperPaths.GROUPS_PATH, ZookeeperPaths.TOPICS_PATH, ZookeeperPaths.SUBSCRIPTIONS_PATH
         );
-
+        ThreadFactory threadFactory = new ThreadFactoryBuilder().setNameFormat(rootPath + "-zk-cache-%d").build();
         executor = new ThreadPoolExecutor(1, processingThreadPoolSize,
-                Integer.MAX_VALUE, TimeUnit.SECONDS, new LinkedHashSetBlockingQueue<>());
+                Integer.MAX_VALUE, TimeUnit.SECONDS, new LinkedHashSetBlockingQueue<>(), threadFactory);
         this.cache = new HierarchicalCache(
                 curator,
                 executor,

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/ConsumerMessageSender.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/ConsumerMessageSender.java
@@ -1,5 +1,6 @@
 package pl.allegro.tech.hermes.consumers.consumer;
 
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.eclipse.jetty.http.HttpStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -24,6 +25,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 
 import static java.lang.String.format;
@@ -74,7 +76,8 @@ public class ConsumerMessageSender {
 
     public void initialize() {
         running = true;
-        this.retrySingleThreadExecutor = Executors.newScheduledThreadPool(1);
+        ThreadFactory threadFactory = new ThreadFactoryBuilder().setNameFormat(subscription.getQualifiedName() + "-retry-executor-%d").build();
+        this.retrySingleThreadExecutor = Executors.newScheduledThreadPool(1, threadFactory);
     }
 
     public void shutdown() {

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/oauth/OAuthProvidersNotifyingCacheFactory.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/oauth/OAuthProvidersNotifyingCacheFactory.java
@@ -1,6 +1,7 @@
 package pl.allegro.tech.hermes.consumers.consumer.oauth;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.apache.curator.framework.CuratorFramework;
 import org.glassfish.hk2.api.Factory;
 import pl.allegro.tech.hermes.common.di.CuratorType;
@@ -10,6 +11,7 @@ import javax.inject.Inject;
 import javax.inject.Named;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
 
 public class OAuthProvidersNotifyingCacheFactory implements Factory<OAuthProvidersNotifyingCache> {
 
@@ -29,7 +31,8 @@ public class OAuthProvidersNotifyingCacheFactory implements Factory<OAuthProvide
     @Override
     public OAuthProvidersNotifyingCache provide() {
         String path = paths.oAuthProvidersPath();
-        ExecutorService executorService = Executors.newSingleThreadExecutor();
+        ThreadFactory threadFactory = new ThreadFactoryBuilder().setNameFormat("oauth-providers-notifying-cache-%d").build();
+        ExecutorService executorService = Executors.newSingleThreadExecutor(threadFactory);
         OAuthProvidersNotifyingCache cache = new OAuthProvidersNotifyingCache(curator, path, executorService, objectMapper);
         try {
             cache.start();

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/oauth/OAuthSubscriptionHandler.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/oauth/OAuthSubscriptionHandler.java
@@ -1,5 +1,6 @@
 package pl.allegro.tech.hermes.consumers.consumer.oauth;
 
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.eclipse.jetty.http.HttpStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -9,6 +10,7 @@ import pl.allegro.tech.hermes.consumers.consumer.sender.MessageSendingResult;
 
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 
 public class OAuthSubscriptionHandler {
@@ -31,7 +33,8 @@ public class OAuthSubscriptionHandler {
         this.providerName = providerName;
         this.accessTokens = accessTokens;
         this.rateLimiter = rateLimiter;
-        this.executorService = Executors.newScheduledThreadPool(1);
+        ThreadFactory threadFactory = new ThreadFactoryBuilder().setNameFormat(subscriptionName.getQualifiedName() + "-oauth-handler-%d").build();
+        this.executorService = Executors.newScheduledThreadPool(1, threadFactory);
     }
 
     public void initialize() {

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/offset/OffsetCommitter.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/offset/OffsetCommitter.java
@@ -2,6 +2,7 @@ package pl.allegro.tech.hermes.consumers.consumer.offset;
 
 import com.codahale.metrics.Timer;
 import com.google.common.collect.Sets;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.jctools.queues.MessagePassingQueue;
 import org.jctools.queues.MpscArrayQueue;
 import org.slf4j.Logger;
@@ -17,6 +18,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiFunction;
 import java.util.function.Function;
@@ -62,9 +64,11 @@ import java.util.function.Function;
  */
 public class OffsetCommitter implements Runnable {
 
+
     private static final Logger logger = LoggerFactory.getLogger(OffsetCommitter.class);
 
-    private final ScheduledExecutorService scheduledExecutor = Executors.newSingleThreadScheduledExecutor();
+    private final ScheduledExecutorService scheduledExecutor = Executors.newSingleThreadScheduledExecutor(
+            new ThreadFactoryBuilder().setNameFormat("offset-committer-%d").build());
 
     private final int offsetCommitPeriodSeconds;
 

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/message/undelivered/UndeliveredMessageLogPersister.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/message/undelivered/UndeliveredMessageLogPersister.java
@@ -1,5 +1,6 @@
 package pl.allegro.tech.hermes.consumers.message.undelivered;
 
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import pl.allegro.tech.hermes.common.config.ConfigFactory;
 import pl.allegro.tech.hermes.common.config.Configs;
 import pl.allegro.tech.hermes.common.message.undelivered.UndeliveredMessageLog;
@@ -20,7 +21,8 @@ public class UndeliveredMessageLogPersister {
     public UndeliveredMessageLogPersister(UndeliveredMessageLog undeliveredMessageLog, ConfigFactory configFactory) {
         this.undeliveredMessageLog = undeliveredMessageLog;
         this.periodMs = configFactory.getIntProperty(Configs.UNDELIVERED_MESSAGE_LOG_PERSIST_PERIOD_MS);
-        this.scheduledExecutorService = Executors.newSingleThreadScheduledExecutor();
+        this.scheduledExecutorService = Executors.newSingleThreadScheduledExecutor(
+                new ThreadFactoryBuilder().setNameFormat("undelivered-message-log-persister-%d").build());
     }
 
     public void start() {

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/workload/SubscriptionAssignmentCache.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/workload/SubscriptionAssignmentCache.java
@@ -1,5 +1,6 @@
 package pl.allegro.tech.hermes.consumers.supervisor.workload;
 
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.apache.curator.framework.CuratorFramework;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -18,6 +19,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
 import java.util.stream.Collectors;
 
 import static pl.allegro.tech.hermes.common.config.Configs.KAFKA_CLUSTER_NAME;
@@ -56,8 +58,9 @@ public class SubscriptionAssignmentCache {
         this.basePath = zookeeperPaths.consumersRuntimePath(configFactory.getStringProperty(KAFKA_CLUSTER_NAME));
         this.subscriptionsCache = subscriptionsCache;
         this.pathSerializer = new SubscriptionAssignmentPathSerializer(basePath, AUTO_ASSIGNED_MARKER);
+        ThreadFactory threadFactory = new ThreadFactoryBuilder().setNameFormat("subscription-assignment-cache-%d").build();
         this.cache = new HierarchicalCache(
-                curator, Executors.newSingleThreadScheduledExecutor(), basePath, 2, Collections.emptyList()
+                curator, Executors.newSingleThreadScheduledExecutor(threadFactory), basePath, 2, Collections.emptyList()
         );
 
         cache.registerCallback(ASSIGNMENT_LEVEL, (e) -> {

--- a/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/publishing/preview/MessagePreviewPersister.java
+++ b/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/publishing/preview/MessagePreviewPersister.java
@@ -1,5 +1,6 @@
 package pl.allegro.tech.hermes.frontend.publishing.preview;
 
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import pl.allegro.tech.hermes.common.config.ConfigFactory;
 import pl.allegro.tech.hermes.common.config.Configs;
 import pl.allegro.tech.hermes.domain.topic.preview.MessagePreviewRepository;
@@ -29,7 +30,8 @@ public class MessagePreviewPersister {
         this.period = configFactory.getIntProperty(Configs.FRONTEND_MESSAGE_PREVIEW_LOG_PERSIST_PERIOD);
 
         boolean previewEnabled = configFactory.getBooleanProperty(FRONTEND_MESSAGE_PREVIEW_ENABLED);
-        this.scheduledExecutorService = previewEnabled ? Optional.of(Executors.newSingleThreadScheduledExecutor()) : Optional.empty();
+        this.scheduledExecutorService = previewEnabled ? Optional.of(Executors.newSingleThreadScheduledExecutor(
+                new ThreadFactoryBuilder().setNameFormat("message-preview-persister-%d").build())) : Optional.empty();
     }
 
     public void start() {


### PR DESCRIPTION
There were some unnamed thread pools left in code (in consumers module mostly). Naming them should help in thread dump analysis.