### PR TITLE
Enabled /status/health endpoint in hermes-management

### DIFF
--- a/hermes-management/src/main/resources/application.yaml
+++ b/hermes-management/src/main/resources/application.yaml
@@ -23,6 +23,9 @@ server:
   port: 8090
 
 management:
+  endpoints:
+    web:
+      base-path: /
   rest-template:
     connect-timeout: 2000
     read-timeout: 2000

--- a/integration/src/integration/java/pl/allegro/tech/hermes/integration/management/HealthCheckTest.java
+++ b/integration/src/integration/java/pl/allegro/tech/hermes/integration/management/HealthCheckTest.java
@@ -1,0 +1,25 @@
+package pl.allegro.tech.hermes.integration.management;
+
+import org.testng.annotations.Test;
+import pl.allegro.tech.hermes.integration.IntegrationTest;
+import pl.allegro.tech.hermes.test.helper.endpoint.JerseyClientFactory;
+
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.Response;
+import java.util.concurrent.TimeUnit;
+
+import static com.jayway.awaitility.Awaitility.await;
+import static pl.allegro.tech.hermes.integration.test.HermesAssertions.assertThat;
+
+public class HealthCheckTest extends IntegrationTest {
+
+    @Test
+    public void shouldManagementBeHealthy() {
+        // given
+        WebTarget client = JerseyClientFactory.create().target(MANAGEMENT_ENDPOINT_URL).path("status").path("health");
+
+        // when & then
+        await().atMost(5, TimeUnit.SECONDS).until(() ->
+                assertThat(client.request().get()).hasStatus(Response.Status.OK));
+    }
+}

--- a/integration/src/test/resources/application.yaml
+++ b/integration/src/test/resources/application.yaml
@@ -47,7 +47,18 @@ graphite:
 
 spring:
   jersey:
-    type: filter
+    type: servlet
+  mvc:
+    servlet:
+      path: /status
+
+management:
+  endpoints:
+    web:
+      base-path: /
+  server:
+    servlet:
+      context-path: /
 
 spring.groovy.template.check-template-location: false
 


### PR DESCRIPTION
Bringing back to live `/status/health` endpoint in hermes-management after spring-boot dependency upgrade. Issue related to #993 