### PR TITLE
Extending offline clients by 'owners' field

### DIFF
--- a/hermes-console/static/partials/topic.html
+++ b/hermes-console/static/partials/topic.html
@@ -181,6 +181,7 @@
                         <th></th>
                         <th>User</th>
                         <th>Last access date</th>
+                        <th>Owners</th>
                     </tr>
                 </thead>
                 <tbody>
@@ -188,6 +189,7 @@
                         <td>{{$index + 1}}</td>
                         <td>{{client.user}}</td>
                         <td>{{client.lastAccess}}</td>
+                        <td>{{client.owners.join(", ")}}</td>
                     </tr>
                 </tbody>
             </table>

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/domain/clients/OfflineClient.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/domain/clients/OfflineClient.java
@@ -5,19 +5,24 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.time.LocalDate;
+import java.util.Collections;
+import java.util.List;
 
 public class OfflineClient {
 
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
     private final LocalDate lastAccess;
     private final String user;
+    private final List<String> owners;
 
     @JsonCreator
     public OfflineClient(
             @JsonProperty("lastAccess") LocalDate lastAccess,
-            @JsonProperty("user") String user) {
+            @JsonProperty("user") String user,
+            @JsonProperty("owners") List<String> owners) {
         this.lastAccess = lastAccess;
         this.user = user;
+        this.owners = owners == null ? Collections.emptyList() : owners;
     }
 
     public LocalDate getLastAccess() {
@@ -26,5 +31,9 @@ public class OfflineClient {
 
     public String getUser() {
         return user;
+    }
+
+    public List<String> getOwners() {
+        return owners;
     }
 }


### PR DESCRIPTION
We would like to add additional field `owners` in offline clients feature. This field can contain list of owners for technical user.

Here is a screen how it can look for our internal implementation of offline clients feature:

![Screenshot 2019-04-24 at 16 20 53](https://user-images.githubusercontent.com/4473056/56667387-07a35c80-66ae-11e9-9123-2a0eb9722fcf.png)
