### PR TITLE
Message sending handlers triggered only when consumer is running

### DIFF
--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/ConsumerMessageSender.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/ConsumerMessageSender.java
@@ -168,7 +168,7 @@ public class ConsumerMessageSender {
         message.incrementRetryCounter(succeededUris);
 
         long retryDelay = extractRetryDelay(result);
-        if (running && shouldAttemptResending(message, result, retryDelay)) {
+        if (shouldAttemptResending(message, result, retryDelay)) {
             retrySingleThreadExecutor.schedule(() -> resend(message, result), retryDelay, TimeUnit.MILLISECONDS);
         } else {
             handleMessageDiscarding(message, result);
@@ -241,10 +241,12 @@ public class ConsumerMessageSender {
         @Override
         public void accept(MessageSendingResult result) {
             timer.stop();
-            if (result.succeeded()) {
-                handleMessageSendingSuccess(message, result);
-            } else {
-                handleFailedSending(message, result);
+            if (running) {
+                if (result.succeeded()) {
+                    handleMessageSendingSuccess(message, result);
+                } else {
+                    handleFailedSending(message, result);
+                }
             }
         }
     }


### PR DESCRIPTION
I've moved the `is-running` check to upper level, so none of the message sending handlers will be triggered  when the consumer is being closed.
resolves #1026, resolves #623