### PR TITLE
Clearing stale offsets, partition assignment term introduced

### DIFF
--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/BatchConsumer.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/BatchConsumer.java
@@ -12,6 +12,7 @@ import pl.allegro.tech.hermes.api.Subscription;
 import pl.allegro.tech.hermes.api.Topic;
 import pl.allegro.tech.hermes.common.config.ConfigFactory;
 import pl.allegro.tech.hermes.common.config.Configs;
+import pl.allegro.tech.hermes.common.kafka.offset.PartitionOffset;
 import pl.allegro.tech.hermes.common.message.wrapper.MessageContentWrapper;
 import pl.allegro.tech.hermes.common.metric.HermesMetrics;
 import pl.allegro.tech.hermes.consumers.consumer.batch.BatchMonitoring;
@@ -168,9 +169,9 @@ public class BatchConsumer implements Consumer {
     }
 
     @Override
-    public boolean moveOffset(SubscriptionPartitionOffset subscriptionPartitionOffset) {
+    public boolean moveOffset(PartitionOffset partitionOffset) {
         if (receiver != null) {
-            return receiver.moveOffset(subscriptionPartitionOffset);
+            return receiver.moveOffset(partitionOffset);
         }
         return false;
     }

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/BatchConsumer.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/BatchConsumer.java
@@ -12,7 +12,6 @@ import pl.allegro.tech.hermes.api.Subscription;
 import pl.allegro.tech.hermes.api.Topic;
 import pl.allegro.tech.hermes.common.config.ConfigFactory;
 import pl.allegro.tech.hermes.common.config.Configs;
-import pl.allegro.tech.hermes.common.kafka.offset.PartitionOffset;
 import pl.allegro.tech.hermes.common.message.wrapper.MessageContentWrapper;
 import pl.allegro.tech.hermes.common.metric.HermesMetrics;
 import pl.allegro.tech.hermes.consumers.consumer.batch.BatchMonitoring;
@@ -36,8 +35,8 @@ import java.util.Set;
 
 import static com.github.rholder.retry.WaitStrategies.fixedWait;
 import static java.util.Optional.of;
-import static java.util.concurrent.TimeUnit.SECONDS;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
 
 public class BatchConsumer implements Consumer {
 
@@ -115,15 +114,11 @@ public class BatchConsumer implements Consumer {
     }
 
     private void offerInflightOffsets(MessageBatch batch) {
-        for (PartitionOffset offset : batch.getPartitionOffsets()) {
-            offsetQueue.offerInflightOffset(SubscriptionPartitionOffset.subscriptionPartitionOffset(offset, subscription));
-        }
+        batch.getPartitionOffsets().forEach(offsetQueue::offerInflightOffset);
     }
 
     private void offerCommittedOffsets(MessageBatch batch) {
-        for (PartitionOffset offset : batch.getPartitionOffsets()) {
-            offsetQueue.offerCommittedOffset(SubscriptionPartitionOffset.subscriptionPartitionOffset(offset, subscription));
-        }
+        batch.getPartitionOffsets().forEach(offsetQueue::offerCommittedOffset);
     }
 
     @Override

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/Consumer.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/Consumer.java
@@ -2,6 +2,7 @@ package pl.allegro.tech.hermes.consumers.consumer;
 
 import pl.allegro.tech.hermes.api.Subscription;
 import pl.allegro.tech.hermes.api.Topic;
+import pl.allegro.tech.hermes.common.kafka.offset.PartitionOffset;
 import pl.allegro.tech.hermes.consumers.consumer.offset.SubscriptionPartitionOffset;
 
 import java.util.Set;
@@ -20,7 +21,7 @@ public interface Consumer {
 
     void commit(Set<SubscriptionPartitionOffset> offsets);
 
-    boolean moveOffset(SubscriptionPartitionOffset subscriptionPartitionOffset);
+    boolean moveOffset(PartitionOffset subscriptionPartitionOffset);
 
     Subscription getSubscription();
 }

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/Message.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/Message.java
@@ -37,7 +37,7 @@ public class Message {
     private byte[] data;
 
     private int retryCounter = 0;
-
+    private long partitionAssignmentTerm = -1;
     private Map<String, String> externalMetadata = Collections.emptyMap();
 
     private List<Header> additionalHeaders = Collections.emptyList();
@@ -54,6 +54,7 @@ public class Message {
                    long publishingTimestamp,
                    long readingTimestamp,
                    PartitionOffset partitionOffset,
+                   long partitionAssignmentTerm,
                    Map<String, String> externalMetadata,
                    List<Header> additionalHeaders,
                    String subscription,
@@ -66,6 +67,7 @@ public class Message {
         this.publishingTimestamp = publishingTimestamp;
         this.readingTimestamp = readingTimestamp;
         this.partitionOffset = partitionOffset;
+        this.partitionAssignmentTerm = partitionAssignmentTerm;
         this.externalMetadata = ImmutableMap.copyOf(externalMetadata);
         this.additionalHeaders = ImmutableList.copyOf(additionalHeaders);
         this.subscription = subscription;
@@ -82,6 +84,10 @@ public class Message {
 
     public long getOffset() {
         return partitionOffset.getOffset();
+    }
+
+    public long getPartitionAssignmentTerm() {
+        return partitionAssignmentTerm;
     }
 
     public byte[] getData() {
@@ -194,6 +200,7 @@ public class Message {
             this.message.publishingTimestamp = message.getPublishingTimestamp();
             this.message.readingTimestamp = message.getReadingTimestamp();
             this.message.partitionOffset = message.partitionOffset;
+            this.message.partitionAssignmentTerm = message.partitionAssignmentTerm;
             this.message.externalMetadata = message.getExternalMetadata();
             this.message.additionalHeaders = message.getAdditionalHeaders();
             this.message.schema = message.getSchema();

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/SerialConsumer.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/SerialConsumer.java
@@ -24,6 +24,7 @@ import java.util.concurrent.TimeUnit;
 import static pl.allegro.tech.hermes.common.config.Configs.CONSUMER_INFLIGHT_SIZE;
 import static pl.allegro.tech.hermes.common.config.Configs.CONSUMER_SIGNAL_PROCESSING_INTERVAL;
 import static pl.allegro.tech.hermes.consumers.consumer.message.MessageConverter.toMessageMetadata;
+import static pl.allegro.tech.hermes.consumers.consumer.offset.SubscriptionPartitionOffset.subscriptionPartitionOffset;
 
 public class SerialConsumer implements Consumer {
 
@@ -114,7 +115,7 @@ public class SerialConsumer implements Consumer {
     }
 
     private void sendMessage(Message message) {
-        offsetQueue.offerInflightOffset(SubscriptionPartitionOffset.subscriptionPartitionOffset(message, subscription));
+        offsetQueue.offerInflightOffset(subscriptionPartitionOffset(subscription.getQualifiedName(), message.getPartitionOffset(), message.getPartitionAssignmentTerm()));
 
         hermesMetrics.incrementInflightCounter(subscription);
         trackers.get(subscription).logInflight(toMessageMetadata(message, subscription));

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/SerialConsumer.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/SerialConsumer.java
@@ -6,6 +6,7 @@ import pl.allegro.tech.hermes.api.Subscription;
 import pl.allegro.tech.hermes.api.Topic;
 import pl.allegro.tech.hermes.common.config.ConfigFactory;
 import pl.allegro.tech.hermes.common.config.Configs;
+import pl.allegro.tech.hermes.common.kafka.offset.PartitionOffset;
 import pl.allegro.tech.hermes.common.metric.HermesMetrics;
 import pl.allegro.tech.hermes.consumers.consumer.converter.MessageConverterResolver;
 import pl.allegro.tech.hermes.consumers.consumer.offset.OffsetQueue;
@@ -182,7 +183,7 @@ public class SerialConsumer implements Consumer {
     }
 
     @Override
-    public boolean moveOffset(SubscriptionPartitionOffset offset) {
+    public boolean moveOffset(PartitionOffset offset) {
         return messageReceiver.moveOffset(offset);
     }
 

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/batch/MessageBatch.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/batch/MessageBatch.java
@@ -2,7 +2,8 @@ package pl.allegro.tech.hermes.consumers.consumer.batch;
 
 import pl.allegro.tech.hermes.api.ContentType;
 import pl.allegro.tech.hermes.api.Header;
-import pl.allegro.tech.hermes.common.kafka.offset.PartitionOffset;
+import pl.allegro.tech.hermes.api.SubscriptionName;
+import pl.allegro.tech.hermes.consumers.consumer.offset.SubscriptionPartitionOffset;
 import pl.allegro.tech.hermes.tracker.consumers.MessageMetadata;
 
 import java.nio.BufferOverflowException;
@@ -31,7 +32,7 @@ public interface MessageBatch {
 
     ByteBuffer getContent();
 
-    List<PartitionOffset> getPartitionOffsets();
+    List<SubscriptionPartitionOffset> getPartitionOffsets();
 
     List<MessageMetadata> getMessagesMetadata();
 
@@ -57,5 +58,5 @@ public interface MessageBatch {
 
     String getTopic();
 
-    String getSubscription();
+    SubscriptionName getSubscription();
 }

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/batch/MessageBatchReceiver.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/batch/MessageBatchReceiver.java
@@ -5,6 +5,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import pl.allegro.tech.hermes.api.Subscription;
 import pl.allegro.tech.hermes.api.Topic;
+import pl.allegro.tech.hermes.common.kafka.offset.PartitionOffset;
 import pl.allegro.tech.hermes.common.message.wrapper.MessageContentWrapper;
 import pl.allegro.tech.hermes.common.message.wrapper.UnsupportedContentTypeException;
 import pl.allegro.tech.hermes.common.metric.HermesMetrics;
@@ -150,7 +151,7 @@ public class MessageBatchReceiver {
         receiver.commit(offsets);
     };
 
-    public boolean moveOffset(SubscriptionPartitionOffset offset) {
+    public boolean moveOffset(PartitionOffset offset) {
         return receiver.moveOffset(offset);
     };
 }

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/batch/MessageBatchReceiver.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/batch/MessageBatchReceiver.java
@@ -128,7 +128,7 @@ public class MessageBatchReceiver {
     }
 
     private MessageMetadata messageMetadata(Subscription subscription, String batchId, Message message) {
-        return new MessageMetadata(message.getId(), batchId, message.getOffset(), message.getPartition(),
+        return new MessageMetadata(message.getId(), batchId, message.getOffset(), message.getPartition(), message.getPartitionAssignmentTerm(),
                 subscription.getQualifiedTopicName(), subscription.getName(), message.getKafkaTopic().asString(),
                 message.getPublishingTimestamp(), message.getReadingTimestamp());
     }

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/filtering/FilteredMessageHandler.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/filtering/FilteredMessageHandler.java
@@ -9,11 +9,11 @@ import pl.allegro.tech.hermes.common.metric.Meters;
 import pl.allegro.tech.hermes.consumers.consumer.Message;
 import pl.allegro.tech.hermes.consumers.consumer.filtering.chain.FilterResult;
 import pl.allegro.tech.hermes.consumers.consumer.offset.OffsetQueue;
-import pl.allegro.tech.hermes.consumers.consumer.offset.SubscriptionPartitionOffset;
 import pl.allegro.tech.hermes.consumers.consumer.rate.ConsumerRateLimiter;
 import pl.allegro.tech.hermes.tracker.consumers.Trackers;
 
 import static pl.allegro.tech.hermes.consumers.consumer.message.MessageConverter.toMessageMetadata;
+import static pl.allegro.tech.hermes.consumers.consumer.offset.SubscriptionPartitionOffset.subscriptionPartitionOffset;
 
 public class FilteredMessageHandler {
 
@@ -40,7 +40,8 @@ public class FilteredMessageHandler {
                 logger.debug("Message filtered for subscription {} {}", subscription.getQualifiedName(), result);
             }
 
-            offsetQueue.offerCommittedOffset(SubscriptionPartitionOffset.subscriptionPartitionOffset(message, subscription));
+            offsetQueue.offerCommittedOffset(subscriptionPartitionOffset(subscription.getQualifiedName(),
+                    message.getPartitionOffset(), message.getPartitionAssignmentTerm()));
 
             updateMetrics(subscription);
 

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/message/MessageConverter.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/message/MessageConverter.java
@@ -10,6 +10,7 @@ public class MessageConverter {
         return new MessageMetadata(message.getId(),
                 message.getOffset(),
                 message.getPartition(),
+                message.getPartitionAssignmentTerm(),
                 message.getTopic(),
                 subscription.getName(),
                 message.getKafkaTopic().asString(),

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/offset/ConsumerPartitionAssignmentState.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/offset/ConsumerPartitionAssignmentState.java
@@ -1,0 +1,66 @@
+package pl.allegro.tech.hermes.consumers.consumer.offset;
+
+import org.slf4j.Logger;
+import pl.allegro.tech.hermes.api.SubscriptionName;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static java.util.stream.Collectors.toSet;
+import static org.slf4j.LoggerFactory.getLogger;
+
+public class ConsumerPartitionAssignmentState {
+
+    private static final Logger logger = getLogger(ConsumerPartitionAssignmentState.class);
+
+    Map<SubscriptionName, Set<Integer>> assigned = new ConcurrentHashMap<>();
+
+    Map<SubscriptionName, Long> terms = new ConcurrentHashMap<>();
+
+    public void assign(SubscriptionName name, Collection<Integer> partitions) {
+        incrementTerm(name);
+        logger.info("Assigning partitions {} to {}, term={}", partitions, name, currentTerm(name));
+        assigned.compute(name, ((subscriptionName, assigned) -> {
+            HashSet<Integer> extended = new HashSet<>(partitions);
+            if (assigned == null) {
+                return extended;
+            } else {
+                extended.addAll(assigned);
+                return extended;
+            }
+        }));
+    }
+
+    public void revoke(SubscriptionName name, Collection<Integer> partitions) {
+        logger.info("Revoking partitions {} from {}", partitions, name);
+        assigned.computeIfPresent(name, (subscriptionName, assigned) -> {
+            Set<Integer> filtered = assigned.stream().filter(p -> !partitions.contains(p)).collect(toSet());
+            return filtered.isEmpty() ? null : filtered;
+        });
+    }
+
+    public void revokeAll(SubscriptionName name) {
+        logger.info("Revoking all partitions from {}", name);
+        assigned.remove(name);
+    }
+
+    private void incrementTerm(SubscriptionName name) {
+        terms.compute(name, ((subscriptionName, term) -> term == null ? 0L : term + 1L));
+    }
+
+    public long currentTerm(SubscriptionName name) {
+        return terms.getOrDefault(name, -1L);
+    }
+
+    public boolean isAssignedPartitionAtCurrentTerm(SubscriptionPartition subscriptionPartition) {
+        return currentTerm(subscriptionPartition.getSubscriptionName()) == subscriptionPartition.getPartitionAssignmentTerm()
+                && isAssigned(subscriptionPartition.getSubscriptionName(), subscriptionPartition.getPartition());
+    }
+
+    private boolean isAssigned(SubscriptionName name, int partition) {
+        return assigned.containsKey(name) && assigned.get(name).contains(partition);
+    }
+}

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/offset/OffsetCommitterConsumerRebalanceListener.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/offset/OffsetCommitterConsumerRebalanceListener.java
@@ -1,0 +1,35 @@
+package pl.allegro.tech.hermes.consumers.consumer.offset;
+
+import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
+import org.apache.kafka.common.TopicPartition;
+import pl.allegro.tech.hermes.api.SubscriptionName;
+
+import java.util.Collection;
+import java.util.Set;
+
+import static java.util.stream.Collectors.toSet;
+
+public class OffsetCommitterConsumerRebalanceListener implements ConsumerRebalanceListener {
+
+    private final SubscriptionName name;
+    private final ConsumerPartitionAssignmentState state;
+
+    public OffsetCommitterConsumerRebalanceListener(SubscriptionName name, ConsumerPartitionAssignmentState state) {
+        this.name = name;
+        this.state = state;
+    }
+
+    @Override
+    public void onPartitionsRevoked(Collection<TopicPartition> partitions) {
+        state.revoke(name, integerPartitions(partitions));
+    }
+
+    @Override
+    public void onPartitionsAssigned(Collection<TopicPartition> partitions) {
+        state.assign(name, integerPartitions(partitions));
+    }
+
+    private Set<Integer> integerPartitions(Collection<TopicPartition> partitions) {
+        return partitions.stream().map(TopicPartition::partition).collect(toSet());
+    }
+}

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/offset/SubscriptionPartition.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/offset/SubscriptionPartition.java
@@ -9,22 +9,17 @@ public class SubscriptionPartition {
 
     private final KafkaTopicName kafkaTopicName;
 
-    private final SubscriptionName subscription;
+    private final SubscriptionName subscriptionName;
 
     private final int partition;
 
-    public SubscriptionPartition(KafkaTopicName kafkaTopicName, SubscriptionName subscription, int partition) {
-        this.kafkaTopicName = kafkaTopicName;
-        this.subscription = subscription;
-        this.partition = partition;
-    }
+    private final long partitionAssignmentTerm;
 
-    public static SubscriptionPartition subscriptionPartition(String kafkaTopicName, String subscriptionName, int partition) {
-        return new SubscriptionPartition(
-                KafkaTopicName.valueOf(kafkaTopicName),
-                SubscriptionName.fromString(subscriptionName),
-                partition
-        );
+    public SubscriptionPartition(KafkaTopicName kafkaTopicName, SubscriptionName subscriptionName, int partition, long partitionAssignmentTerm) {
+        this.kafkaTopicName = kafkaTopicName;
+        this.subscriptionName = subscriptionName;
+        this.partition = partition;
+        this.partitionAssignmentTerm = partitionAssignmentTerm;
     }
 
     public KafkaTopicName getKafkaTopicName() {
@@ -32,11 +27,15 @@ public class SubscriptionPartition {
     }
 
     public SubscriptionName getSubscriptionName() {
-        return subscription;
+        return subscriptionName;
     }
 
     public int getPartition() {
         return partition;
+    }
+
+    public long getPartitionAssignmentTerm() {
+        return partitionAssignmentTerm;
     }
 
     @Override
@@ -45,19 +44,21 @@ public class SubscriptionPartition {
         if (o == null || getClass() != o.getClass()) return false;
         SubscriptionPartition that = (SubscriptionPartition) o;
         return partition == that.partition &&
-                Objects.equals(subscription, that.subscription);
+                partitionAssignmentTerm == that.partitionAssignmentTerm &&
+                Objects.equals(subscriptionName, that.subscriptionName);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(subscription, partition);
+        return Objects.hash(subscriptionName, partition, partitionAssignmentTerm);
     }
 
     @Override
     public String toString() {
         return "SubscriptionPartition{" +
-                "subscription=" + subscription +
+                "subscriptionName=" + subscriptionName +
                 ", partition=" + partition +
+                ", partitionAssignmentTerm=" + partitionAssignmentTerm +
                 '}';
     }
 }

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/offset/SubscriptionPartitionOffset.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/offset/SubscriptionPartitionOffset.java
@@ -1,10 +1,8 @@
 package pl.allegro.tech.hermes.consumers.consumer.offset;
 
-import pl.allegro.tech.hermes.api.Subscription;
 import pl.allegro.tech.hermes.api.SubscriptionName;
 import pl.allegro.tech.hermes.common.kafka.KafkaTopicName;
 import pl.allegro.tech.hermes.common.kafka.offset.PartitionOffset;
-import pl.allegro.tech.hermes.consumers.consumer.Message;
 
 import java.util.Objects;
 
@@ -19,37 +17,15 @@ public class SubscriptionPartitionOffset {
         this.offset = offset;
     }
 
-    public static SubscriptionPartitionOffset subscriptionPartitionOffset(String kafkaTopicName, String subscriptionName, int partition, long offset) {
-        return new SubscriptionPartitionOffset(
-                SubscriptionPartition.subscriptionPartition(kafkaTopicName, subscriptionName, partition),
-                offset
-        );
-    }
-
-    public static SubscriptionPartitionOffset subscriptionPartitionOffset(Message message, Subscription subscription) {
-        return subscriptionPartitionOffset(message.getPartitionOffset(), subscription);
-    }
-
-    public static SubscriptionPartitionOffset subscriptionPartitionOffset(PartitionOffset partitionOffset, Subscription subscription) {
+    public static SubscriptionPartitionOffset subscriptionPartitionOffset(SubscriptionName subscriptionName, PartitionOffset partitionOffset, long partitionAssignmentTerm) {
         return new SubscriptionPartitionOffset(
                 new SubscriptionPartition(
                         partitionOffset.getTopic(),
-                        subscription.getQualifiedName(),
-                        partitionOffset.getPartition()
+                        subscriptionName,
+                        partitionOffset.getPartition(),
+                        partitionAssignmentTerm
                 ),
-                partitionOffset.getOffset()
-        );
-    }
-
-    public static SubscriptionPartitionOffset subscriptionPartitionOffset(PartitionOffset partitionOffset, SubscriptionName subscription) {
-        return new SubscriptionPartitionOffset(
-                new SubscriptionPartition(
-                        partitionOffset.getTopic(),
-                        subscription,
-                        partitionOffset.getPartition()
-                ),
-                partitionOffset.getOffset()
-        );
+                partitionOffset.getOffset());
     }
 
     public SubscriptionName getSubscriptionName() {
@@ -68,8 +44,20 @@ public class SubscriptionPartitionOffset {
         return offset;
     }
 
+    public long getPartitionAssignmentTerm() {
+        return subscriptionPartition.getPartitionAssignmentTerm();
+    }
+
     public SubscriptionPartition getSubscriptionPartition() {
         return subscriptionPartition;
+    }
+
+    @Override
+    public String toString() {
+        return "SubscriptionPartitionOffset{" +
+                "subscriptionPartition=" + subscriptionPartition +
+                ", offset=" + offset +
+                '}';
     }
 
     @Override
@@ -84,13 +72,5 @@ public class SubscriptionPartitionOffset {
     @Override
     public int hashCode() {
         return Objects.hash(subscriptionPartition, offset);
-    }
-
-    @Override
-    public String toString() {
-        return "SubscriptionPartitionOffset{" +
-                "subscriptionPartition=" + subscriptionPartition +
-                ", offset=" + offset +
-                '}';
     }
 }

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/offset/kafka/broker/KafkaConsumerOffsetMover.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/offset/kafka/broker/KafkaConsumerOffsetMover.java
@@ -4,32 +4,37 @@ import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.common.TopicPartition;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import pl.allegro.tech.hermes.consumers.consumer.offset.SubscriptionPartitionOffset;
+import pl.allegro.tech.hermes.api.SubscriptionName;
+import pl.allegro.tech.hermes.common.kafka.offset.PartitionOffset;
 
 public class KafkaConsumerOffsetMover {
+
     private static final Logger logger = LoggerFactory.getLogger(KafkaConsumerOffsetMover.class);
+
+    private final SubscriptionName subscriptionName;
     private KafkaConsumer consumer;
 
-    public KafkaConsumerOffsetMover(KafkaConsumer consumer) {
+    public KafkaConsumerOffsetMover(SubscriptionName subscriptionName, KafkaConsumer consumer) {
+        this.subscriptionName = subscriptionName;
         this.consumer = consumer;
     }
 
-    public boolean move(SubscriptionPartitionOffset offset) {
+    public boolean move(PartitionOffset offset) {
         try {
-            TopicPartition tp = new TopicPartition(offset.getKafkaTopicName().asString(), offset.getPartition());
+            TopicPartition tp = new TopicPartition(offset.getTopic().asString(), offset.getPartition());
             if (consumer.assignment().contains(tp)) {
                 logger.info("Moving offset for assigned partition {} on subscription {}",
-                        offset.getPartition(), offset.getSubscriptionName());
+                        offset.getPartition(), subscriptionName);
                 consumer.seek(tp, offset.getOffset());
                 return true;
             } else {
                 logger.info("Not assigned to partition {} on subscription {}",
-                        offset.getPartition(), offset.getSubscriptionName());
+                        offset.getPartition(), subscriptionName);
                 return false;
             }
         } catch (IllegalStateException ex) {
             logger.error("Failed to move offset for subscription={}, partition={}, offset={}",
-                    offset.getSubscriptionName(), offset.getPartition(), offset.getOffset(), ex);
+                    subscriptionName, offset.getPartition(), offset.getOffset(), ex);
             return false;
         }
     }

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/receiver/MessageReceiver.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/receiver/MessageReceiver.java
@@ -1,6 +1,7 @@
 package pl.allegro.tech.hermes.consumers.consumer.receiver;
 
 import pl.allegro.tech.hermes.api.Subscription;
+import pl.allegro.tech.hermes.common.kafka.offset.PartitionOffset;
 import pl.allegro.tech.hermes.consumers.consumer.Message;
 import pl.allegro.tech.hermes.consumers.consumer.offset.SubscriptionPartitionOffset;
 
@@ -17,5 +18,5 @@ public interface MessageReceiver {
 
     void commit(Set<SubscriptionPartitionOffset> offsets);
 
-    boolean moveOffset(SubscriptionPartitionOffset offset);
+    boolean moveOffset(PartitionOffset offset);
 }

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/receiver/ThrottlingMessageReceiver.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/receiver/ThrottlingMessageReceiver.java
@@ -2,6 +2,7 @@ package pl.allegro.tech.hermes.consumers.consumer.receiver;
 
 import com.codahale.metrics.Timer;
 import pl.allegro.tech.hermes.api.Subscription;
+import pl.allegro.tech.hermes.common.kafka.offset.PartitionOffset;
 import pl.allegro.tech.hermes.common.metric.HermesMetrics;
 import pl.allegro.tech.hermes.consumers.consumer.Message;
 import pl.allegro.tech.hermes.consumers.consumer.idleTime.IdleTimeCalculator;
@@ -56,7 +57,7 @@ public class ThrottlingMessageReceiver implements MessageReceiver {
     }
 
     @Override
-    public boolean moveOffset(SubscriptionPartitionOffset offset) {
+    public boolean moveOffset(PartitionOffset offset) {
         return receiver.moveOffset(offset);
     }
 

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/receiver/UninitializedMessageReceiver.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/receiver/UninitializedMessageReceiver.java
@@ -1,5 +1,6 @@
 package pl.allegro.tech.hermes.consumers.consumer.receiver;
 
+import pl.allegro.tech.hermes.common.kafka.offset.PartitionOffset;
 import pl.allegro.tech.hermes.consumers.consumer.Message;
 import pl.allegro.tech.hermes.consumers.consumer.offset.SubscriptionPartitionOffset;
 
@@ -18,7 +19,7 @@ public class UninitializedMessageReceiver implements MessageReceiver {
     }
 
     @Override
-    public boolean moveOffset(SubscriptionPartitionOffset offset) {
+    public boolean moveOffset(PartitionOffset offset) {
         throw new ConsumerNotInitializedException();
     }
 }

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/receiver/kafka/FilteringMessageReceiver.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/receiver/kafka/FilteringMessageReceiver.java
@@ -1,6 +1,7 @@
 package pl.allegro.tech.hermes.consumers.consumer.receiver.kafka;
 
 import pl.allegro.tech.hermes.api.Subscription;
+import pl.allegro.tech.hermes.common.kafka.offset.PartitionOffset;
 import pl.allegro.tech.hermes.consumers.consumer.Message;
 import pl.allegro.tech.hermes.consumers.consumer.filtering.FilteredMessageHandler;
 import pl.allegro.tech.hermes.consumers.consumer.filtering.chain.FilterChain;
@@ -65,7 +66,7 @@ public class FilteringMessageReceiver implements MessageReceiver {
     }
 
     @Override
-    public boolean moveOffset(SubscriptionPartitionOffset offset) {
+    public boolean moveOffset(PartitionOffset offset) {
         return receiver.moveOffset(offset);
     }
 }

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/receiver/kafka/KafkaMessageReceiverFactory.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/receiver/kafka/KafkaMessageReceiverFactory.java
@@ -13,11 +13,12 @@ import pl.allegro.tech.hermes.consumers.consumer.filtering.FilteredMessageHandle
 import pl.allegro.tech.hermes.consumers.consumer.filtering.chain.FilterChainFactory;
 import pl.allegro.tech.hermes.consumers.consumer.idleTime.ExponentiallyGrowingIdleTimeCalculator;
 import pl.allegro.tech.hermes.consumers.consumer.idleTime.IdleTimeCalculator;
+import pl.allegro.tech.hermes.consumers.consumer.offset.ConsumerPartitionAssignmentState;
 import pl.allegro.tech.hermes.consumers.consumer.offset.OffsetQueue;
 import pl.allegro.tech.hermes.consumers.consumer.rate.ConsumerRateLimiter;
-import pl.allegro.tech.hermes.consumers.consumer.receiver.ThrottlingMessageReceiver;
 import pl.allegro.tech.hermes.consumers.consumer.receiver.MessageReceiver;
 import pl.allegro.tech.hermes.consumers.consumer.receiver.ReceiverFactory;
+import pl.allegro.tech.hermes.consumers.consumer.receiver.ThrottlingMessageReceiver;
 import pl.allegro.tech.hermes.tracker.consumers.Trackers;
 
 import javax.inject.Inject;
@@ -38,6 +39,7 @@ public class KafkaMessageReceiverFactory implements ReceiverFactory {
     private final KafkaNamesMapper kafkaNamesMapper;
     private final FilterChainFactory filterChainFactory;
     private final Trackers trackers;
+    private final ConsumerPartitionAssignmentState consumerPartitionAssignmentState;
 
     @Inject
     public KafkaMessageReceiverFactory(ConfigFactory configs,
@@ -47,7 +49,8 @@ public class KafkaMessageReceiverFactory implements ReceiverFactory {
                                        Clock clock,
                                        KafkaNamesMapper kafkaNamesMapper,
                                        FilterChainFactory filterChainFactory,
-                                       Trackers trackers) {
+                                       Trackers trackers,
+                                       ConsumerPartitionAssignmentState consumerPartitionAssignmentState) {
         this.configs = configs;
         this.messageContentWrapper = messageContentWrapper;
         this.hermesMetrics = hermesMetrics;
@@ -56,6 +59,7 @@ public class KafkaMessageReceiverFactory implements ReceiverFactory {
         this.kafkaNamesMapper = kafkaNamesMapper;
         this.filterChainFactory = filterChainFactory;
         this.trackers = trackers;
+        this.consumerPartitionAssignmentState = consumerPartitionAssignmentState;
     }
 
     @Override
@@ -72,7 +76,8 @@ public class KafkaMessageReceiverFactory implements ReceiverFactory {
                 subscription,
                 clock,
                 configs.getIntProperty(Configs.CONSUMER_RECEIVER_POOL_TIMEOUT),
-                configs.getIntProperty(Configs.CONSUMER_RECEIVER_READ_QUEUE_CAPACITY));
+                configs.getIntProperty(Configs.CONSUMER_RECEIVER_READ_QUEUE_CAPACITY),
+                consumerPartitionAssignmentState);
 
 
         if (configs.getBooleanProperty(Configs.CONSUMER_RECEIVER_WAIT_BETWEEN_UNSUCCESSFUL_POLLS)) {

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/result/DefaultErrorHandler.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/result/DefaultErrorHandler.java
@@ -9,7 +9,6 @@ import pl.allegro.tech.hermes.common.metric.HermesMetrics;
 import pl.allegro.tech.hermes.common.metric.Meters;
 import pl.allegro.tech.hermes.consumers.consumer.Message;
 import pl.allegro.tech.hermes.consumers.consumer.offset.OffsetQueue;
-import pl.allegro.tech.hermes.consumers.consumer.offset.SubscriptionPartitionOffset;
 import pl.allegro.tech.hermes.consumers.consumer.sender.MessageSendingResult;
 import pl.allegro.tech.hermes.tracker.consumers.Trackers;
 
@@ -17,6 +16,7 @@ import java.time.Clock;
 
 import static pl.allegro.tech.hermes.api.SentMessageTrace.createUndeliveredMessage;
 import static pl.allegro.tech.hermes.consumers.consumer.message.MessageConverter.toMessageMetadata;
+import static pl.allegro.tech.hermes.consumers.consumer.offset.SubscriptionPartitionOffset.subscriptionPartitionOffset;
 
 public class DefaultErrorHandler extends AbstractHandler implements ErrorHandler {
 
@@ -41,7 +41,8 @@ public class DefaultErrorHandler extends AbstractHandler implements ErrorHandler
     public void handleDiscarded(Message message, Subscription subscription, MessageSendingResult result) {
         logResult(message, subscription, result);
 
-        offsetQueue.offerCommittedOffset(SubscriptionPartitionOffset.subscriptionPartitionOffset(message, subscription));
+        offsetQueue.offerCommittedOffset(subscriptionPartitionOffset(subscription.getQualifiedName(),
+                message.getPartitionOffset(), message.getPartitionAssignmentTerm()));
 
         updateMeters(subscription);
         updateMetrics(Counters.DISCARDED, message, subscription);

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/result/DefaultSuccessHandler.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/result/DefaultSuccessHandler.java
@@ -6,11 +6,11 @@ import pl.allegro.tech.hermes.common.metric.HermesMetrics;
 import pl.allegro.tech.hermes.common.metric.Meters;
 import pl.allegro.tech.hermes.consumers.consumer.Message;
 import pl.allegro.tech.hermes.consumers.consumer.offset.OffsetQueue;
-import pl.allegro.tech.hermes.consumers.consumer.offset.SubscriptionPartitionOffset;
 import pl.allegro.tech.hermes.consumers.consumer.sender.MessageSendingResult;
 import pl.allegro.tech.hermes.tracker.consumers.Trackers;
 
 import static pl.allegro.tech.hermes.consumers.consumer.message.MessageConverter.toMessageMetadata;
+import static pl.allegro.tech.hermes.consumers.consumer.offset.SubscriptionPartitionOffset.subscriptionPartitionOffset;
 
 public class DefaultSuccessHandler extends AbstractHandler implements SuccessHandler {
 
@@ -23,7 +23,8 @@ public class DefaultSuccessHandler extends AbstractHandler implements SuccessHan
 
     @Override
     public void handleSuccess(Message message, Subscription subscription, MessageSendingResult result) {
-        offsetQueue.offerCommittedOffset(SubscriptionPartitionOffset.subscriptionPartitionOffset(message, subscription));
+        offsetQueue.offerCommittedOffset(subscriptionPartitionOffset(subscription.getQualifiedName(),
+                message.getPartitionOffset(), message.getPartitionAssignmentTerm()));
 
         updateMeters(message, subscription, result);
         updateMetrics(Counters.DELIVERED, message, subscription);

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/sender/http/ApacheHttpClientMessageBatchSender.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/sender/http/ApacheHttpClientMessageBatchSender.java
@@ -68,7 +68,7 @@ public class ApacheHttpClientMessageBatchSender implements MessageBatchSender {
 
         if (batch.hasSubscriptionIdentityHeaders()) {
             httpPost.addHeader(TOPIC_NAME.getName(), batch.getTopic());
-            httpPost.addHeader(SUBSCRIPTION_NAME.getName(), batch.getSubscription());
+            httpPost.addHeader(SUBSCRIPTION_NAME.getName(), batch.getSubscription().getName());
         }
 
         batch.getAdditionalHeaders().forEach(header -> httpPost.addHeader(header.getName(), header.getValue()));

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/di/ConsumersBinder.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/di/ConsumersBinder.java
@@ -30,6 +30,7 @@ import pl.allegro.tech.hermes.consumers.consumer.oauth.OAuthSubscriptionHandlerF
 import pl.allegro.tech.hermes.consumers.consumer.oauth.OAuthTokenRequestRateLimiterFactory;
 import pl.allegro.tech.hermes.consumers.consumer.oauth.client.OAuthClient;
 import pl.allegro.tech.hermes.consumers.consumer.oauth.client.OAuthHttpClient;
+import pl.allegro.tech.hermes.consumers.consumer.offset.ConsumerPartitionAssignmentState;
 import pl.allegro.tech.hermes.consumers.consumer.offset.OffsetQueue;
 import pl.allegro.tech.hermes.consumers.consumer.rate.ConsumerRateLimitSupervisor;
 import pl.allegro.tech.hermes.consumers.consumer.rate.calculator.OutputRateCalculatorFactory;
@@ -110,6 +111,7 @@ public class ConsumersBinder extends AbstractBinder {
         bindSingleton(AvroToJsonMessageConverter.class);
         bindSingleton(MessageConverterResolver.class);
         bindSingleton(OffsetQueue.class);
+        bindSingleton(ConsumerPartitionAssignmentState.class);
         bindSingleton(ActiveConsumerCounter.class);
         bindSingleton(Retransmitter.class);
         bindSingleton(ConsumerMonitor.class);

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/process/Retransmitter.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/process/Retransmitter.java
@@ -19,6 +19,7 @@ import static pl.allegro.tech.hermes.common.config.Configs.KAFKA_CLUSTER_NAME;
 public class Retransmitter {
 
     private static final Logger logger = LoggerFactory.getLogger(Retransmitter.class);
+    private static final long NON_EXISTENT_PARTITION_ASSIGNMENT_TERM = -1; // real one not needed for retransmission purposes
 
     private SubscriptionOffsetChangeIndicator subscriptionOffsetChangeIndicator;
     private String brokersClusterName;
@@ -38,7 +39,8 @@ public class Retransmitter {
 
             for (PartitionOffset partitionOffset : offsets) {
                 SubscriptionPartitionOffset subscriptionPartitionOffset = new SubscriptionPartitionOffset(
-                        new SubscriptionPartition(partitionOffset.getTopic(), subscriptionName, partitionOffset.getPartition()),
+                        new SubscriptionPartition(partitionOffset.getTopic(), subscriptionName,
+                                partitionOffset.getPartition(), NON_EXISTENT_PARTITION_ASSIGNMENT_TERM),
                         partitionOffset.getOffset());
 
                 if (moveOffset(subscriptionName, consumer, subscriptionPartitionOffset)) {

--- a/hermes-consumers/src/test/groovy/pl/allegro/tech/hermes/consumers/consumer/offset/ConsumerPartitionAssignmentStateTest.groovy
+++ b/hermes-consumers/src/test/groovy/pl/allegro/tech/hermes/consumers/consumer/offset/ConsumerPartitionAssignmentStateTest.groovy
@@ -1,0 +1,97 @@
+package pl.allegro.tech.hermes.consumers.consumer.offset
+
+import pl.allegro.tech.hermes.api.SubscriptionName
+import pl.allegro.tech.hermes.common.kafka.KafkaTopicName
+import spock.lang.Shared
+import spock.lang.Specification
+
+import java.util.concurrent.CountDownLatch
+
+class ConsumerPartitionAssignmentStateTest extends Specification {
+
+    @Shared
+    ConsumerPartitionAssignmentState state = new ConsumerPartitionAssignmentState()
+
+    def "should return -1 when no assignments happened"() {
+        expect:
+        state.currentTerm(subscriptionName('sub1')) == -1
+    }
+
+    def "should increment term when assigning partitions"() {
+        given:
+        def sub = subscriptionName('sub1')
+
+        when:
+        state.assign(sub, [1, 3])
+
+        then:
+        state.currentTerm(sub) == 0
+
+        when:
+        state.assign(sub, [1, 2, 3, 4])
+
+        then:
+        state.currentTerm(sub) == 1
+        state.currentTerm(subscriptionName('sub2')) == -1  // not assigned yet
+    }
+
+    def "should check if partitions are assigned for current term"() {
+        given:
+        def sub1 = subscriptionName('sub1')
+        def sub2 = subscriptionName('sub2')
+
+        when:
+        state.assign(sub1, [1, 2, 3])
+        state.assign(sub2, [4, 5, 6])
+
+        then:
+        [1, 2, 3].forEach { partition ->
+            state.isAssignedPartitionAtCurrentTerm(subscriptionPartition(sub1, partition, 0))
+            !state.isAssignedPartitionAtCurrentTerm(subscriptionPartition(sub1, partition, 1))
+            !state.isAssignedPartitionAtCurrentTerm(subscriptionPartition(sub2, partition, 0))
+        }
+        [4, 5, 6].forEach { partition ->
+            !state.isAssignedPartitionAtCurrentTerm(subscriptionPartition(sub1, partition, 0))
+            state.isAssignedPartitionAtCurrentTerm(subscriptionPartition(sub2, partition, 0))
+            !state.isAssignedPartitionAtCurrentTerm(subscriptionPartition(sub2, partition, 1))
+        }
+        [7, 8, 9].forEach { partition ->
+            !state.isAssignedPartitionAtCurrentTerm(subscriptionPartition(sub1, partition, 0))
+            !state.isAssignedPartitionAtCurrentTerm(subscriptionPartition(sub2, partition, 0))
+        }
+    }
+
+    def "should revoke partitions"() {
+        given:
+        def sub1 = subscriptionName('sub1')
+
+        when:
+        state.assign(sub1, [1, 2, 3])
+
+        and:
+        state.revoke(sub1, [1])
+
+        then:
+        !state.isAssignedPartitionAtCurrentTerm(subscriptionPartition(sub1, 1, 0))
+        [2, 3].forEach { partition ->
+            state.isAssignedPartitionAtCurrentTerm(subscriptionPartition(sub1, partition, 0))
+        }
+
+        when:
+        state.revokeAll(sub1)
+
+        then:
+        [1, 2, 3].forEach { partition ->
+            state.isAssignedPartitionAtCurrentTerm(subscriptionPartition(sub1, partition, 0))
+        }
+    }
+
+    private SubscriptionName subscriptionName(String name) {
+        return SubscriptionName.fromString("group.topic\$$name")
+    }
+
+    private SubscriptionPartition subscriptionPartition(SubscriptionName subscription, partition, term) {
+        new SubscriptionPartition(KafkaTopicName.valueOf('group_topic'), subscription, partition, term)
+    }
+
+}

--- a/hermes-consumers/src/test/groovy/pl/allegro/tech/hermes/consumers/consumer/offset/MockMessageCommitter.groovy
+++ b/hermes-consumers/src/test/groovy/pl/allegro/tech/hermes/consumers/consumer/offset/MockMessageCommitter.groovy
@@ -10,6 +10,10 @@ class MockMessageCommitter implements MessageCommitter {
 
     private int iteration = -1
 
+    boolean nothingCommitted(int iteration) {
+        return wereCommitted(iteration)
+    }
+
     boolean wereCommitted(int iteration, SubscriptionPartitionOffset... expectedOffsets) {
         OffsetsToCommit offsetsToCommit = recordedValues[iteration - 1]
         Set<SubscriptionPartitionOffset> allOffsets = [] as Set

--- a/hermes-consumers/src/test/groovy/pl/allegro/tech/hermes/consumers/consumer/offset/OffsetCommitterTest.groovy
+++ b/hermes-consumers/src/test/groovy/pl/allegro/tech/hermes/consumers/consumer/offset/OffsetCommitterTest.groovy
@@ -3,11 +3,19 @@ package pl.allegro.tech.hermes.consumers.consumer.offset
 import com.codahale.metrics.MetricRegistry
 import pl.allegro.tech.hermes.api.SubscriptionName
 import pl.allegro.tech.hermes.common.config.ConfigFactory
+import pl.allegro.tech.hermes.common.kafka.KafkaTopicName
 import pl.allegro.tech.hermes.common.metric.HermesMetrics
 import pl.allegro.tech.hermes.metrics.PathsCompiler
+import spock.lang.Shared
 import spock.lang.Specification
 
 class OffsetCommitterTest extends Specification {
+
+    @Shared
+    SubscriptionName SUBSCRIPTION_NAME = SubscriptionName.fromString('group.topic$sub')
+
+    @Shared
+    KafkaTopicName KAFKA_TOPIC_NAME = KafkaTopicName.valueOf("group_topic")
 
     private OffsetQueue queue = new OffsetQueue(
             new HermesMetrics(new MetricRegistry(), new PathsCompiler("host")),
@@ -16,12 +24,20 @@ class OffsetCommitterTest extends Specification {
 
     private MockMessageCommitter messageCommitter = new MockMessageCommitter()
 
-    private OffsetCommitter committer = new OffsetCommitter(
-            queue, messageCommitter, 10, new HermesMetrics(new MetricRegistry(), new PathsCompiler("host"))
-    )
+    private ConsumerPartitionAssignmentState state
+
+    private OffsetCommitter committer
+
+    def setup() {
+        state = new ConsumerPartitionAssignmentState()
+        def commitInterval = 10
+        committer = new OffsetCommitter(queue, state, messageCommitter, commitInterval,
+                new HermesMetrics(new MetricRegistry(), new PathsCompiler("host")))
+    }
 
     def "should commit smallest offset of uncommitted message"() {
         given:
+        assignPartitions(1)
         queue.offerInflightOffset(offset(1, 1))
         queue.offerInflightOffset(offset(1, 2))
         queue.offerInflightOffset(offset(1, 3))
@@ -39,6 +55,7 @@ class OffsetCommitterTest extends Specification {
 
     def "should increment offset by 1 only if it comes from committed offsets to match Kafka offset definition"() {
         given:
+        assignPartitions(1, 2)
         queue.offerInflightOffset(offset(1, 1))
         queue.offerCommittedOffset(offset(1, 1))
 
@@ -53,6 +70,7 @@ class OffsetCommitterTest extends Specification {
 
     def "should commit max offset of committed offsets when no smaller inflights exist"() {
         given:
+        assignPartitions(1)
         queue.offerInflightOffset(offset(1, 3))
         queue.offerInflightOffset(offset(1, 4))
 
@@ -68,6 +86,7 @@ class OffsetCommitterTest extends Specification {
 
     def "should commit same offset twice when there are no new offsets to commit"() {
         given:
+        assignPartitions(1)
         queue.offerInflightOffset(offset(1, 5))
 
         when:
@@ -85,6 +104,8 @@ class OffsetCommitterTest extends Specification {
 
     def "should not mix offsets from different partitions and topics"() {
         given:
+        assignPartitions(1, 2)
+
         queue.offerInflightOffset(offset(1, 3))
         queue.offerInflightOffset(offset(1, 4))
 
@@ -102,25 +123,150 @@ class OffsetCommitterTest extends Specification {
         messageCommitter.wereCommitted(1, offset(1, 5), offset(2, 10))
     }
 
-    def "should get rid of leftover inflight offset commits on second iteration when removing subscription"() {
+    def "should get rid of leftover inflight offsets when revoked from topic partitions"() {
         given:
+        assignPartitions(1)
         queue.offerInflightOffset(offset(1, 3))
 
         when:
-        committer.removeUncommittedOffsets(SubscriptionName.fromString('group.topic$sub'))
+        revokeAllPartitions()
+        committer.run()
+
+        then:
+        messageCommitter.nothingCommitted(1)
+    }
+
+    def "should get rid of inflight offsets from revoked partitions"() {
+        given:
+        assignPartitions(1, 2)
+        queue.offerInflightOffset(offset(1, 3))
+        queue.offerInflightOffset(offset(2, 3))
+
+        when:
+        revokePartitions(1)
+        committer.run()
+
+        then:
+        messageCommitter.wereCommitted(1, offset(2, 3))
+    }
+
+    def "should get rid of committed offsets from revoked partitions"() {
+        given:
+        assignPartitions(1)
+        queue.offerCommittedOffset(offset(1, 3))
+
+        when:
+        revokePartitions(1)
+        committer.run()
+
+        then:
+        messageCommitter.nothingCommitted(1)
+    }
+
+    def "should get rid of leftover committed offsets when revoked from topic partitions"() {
+        given:
+        assignPartitions(1)
+        queue.offerInflightOffset(offset(1, 3))
+        queue.offerCommittedOffset(offset(1, 3))
+
+        when:
+        committer.run()
+
+        then:
+        messageCommitter.wereCommitted(1, offset(1, 4))
+
+        when:
+        queue.offerInflightOffset(offset(1, 4))
+        queue.offerCommittedOffset(offset(1, 4))
+
+        and:
+        revokeAllPartitions()
+
+        and:
+        committer.run()
+
+        then:
+        messageCommitter.nothingCommitted(2)
+    }
+
+    def "should not commit offsets in next iteration after reassigning partition"() {
+        given:
+        assignPartitions(1)
+        queue.offerInflightOffset(offset(1, 3))
+
+        when:
         committer.run()
 
         then:
         messageCommitter.wereCommitted(1, offset(1, 3))
 
         when:
+        revokePartitions(1)
         committer.run()
 
         then:
-        messageCommitter.wereCommitted(2)
+        messageCommitter.nothingCommitted(2)
+
+        when:
+        assignPartitions(1)
+        committer.run()
+
+        then:
+        messageCommitter.nothingCommitted(3)
+    }
+
+    def "should commit only offsets from current term"() {
+        given:
+        assignPartitions(1)
+        queue.offerInflightOffset(offset(1, 3))
+
+        when:
+        committer.run()
+
+        then:
+        messageCommitter.wereCommitted(1, offset(1, 3))
+
+        when:
+        queue.offerCommittedOffset(offset(1, 3))
+        queue.offerInflightOffset(offset(1, 4))
+        queue.offerCommittedOffset(offset(1, 4))
+        revokePartitions(1)
+        assignPartitions(1)
+
+        and:
+        committer.run()
+
+        then:
+        messageCommitter.nothingCommitted(2)
+
+        when:
+        queue.offerCommittedOffset(offsetFromTerm(1, 4, 0)) // message from previous term=0
+
+        and:
+        committer.run()
+
+        then:
+        messageCommitter.nothingCommitted(3)
     }
 
     private SubscriptionPartitionOffset offset(int partition, long offset) {
-        return SubscriptionPartitionOffset.subscriptionPartitionOffset("group_topic", 'group.topic$sub', partition, offset)
+        offsetFromTerm(partition, offset, state.currentTerm(SUBSCRIPTION_NAME))
+    }
+
+    private SubscriptionPartitionOffset offsetFromTerm(int partition, long offset, long term) {
+        def partitionOffset = new SubscriptionPartition(KAFKA_TOPIC_NAME, SUBSCRIPTION_NAME, partition, term)
+        return new SubscriptionPartitionOffset(partitionOffset, offset)
+    }
+
+    private assignPartitions(int... partitions) {
+        state.assign(SUBSCRIPTION_NAME, [*partitions])
+    }
+
+    private revokePartitions(int... partitions) {
+        state.revoke(SUBSCRIPTION_NAME, [*partitions])
+    }
+
+    private revokeAllPartitions() {
+        state.revokeAll(SUBSCRIPTION_NAME)
     }
 }

--- a/hermes-consumers/src/test/groovy/pl/allegro/tech/hermes/consumers/supervisor/process/ConsumerStub.groovy
+++ b/hermes-consumers/src/test/groovy/pl/allegro/tech/hermes/consumers/supervisor/process/ConsumerStub.groovy
@@ -2,6 +2,7 @@ package pl.allegro.tech.hermes.consumers.supervisor.process
 
 import pl.allegro.tech.hermes.api.Subscription
 import pl.allegro.tech.hermes.api.Topic
+import pl.allegro.tech.hermes.common.kafka.offset.PartitionOffset
 import pl.allegro.tech.hermes.consumers.consumer.Consumer
 import pl.allegro.tech.hermes.consumers.consumer.offset.SubscriptionPartitionOffset
 
@@ -72,7 +73,7 @@ class ConsumerStub implements Consumer {
     }
 
     @Override
-    boolean moveOffset(SubscriptionPartitionOffset subscriptionPartitionOffset) {
+    boolean moveOffset(PartitionOffset partitionOffset) {
         return true
     }
 

--- a/hermes-consumers/src/test/groovy/pl/allegro/tech/hermes/consumers/supervisor/process/SignalsFilterTest.groovy
+++ b/hermes-consumers/src/test/groovy/pl/allegro/tech/hermes/consumers/supervisor/process/SignalsFilterTest.groovy
@@ -1,6 +1,8 @@
 package pl.allegro.tech.hermes.consumers.supervisor.process
 
 import pl.allegro.tech.hermes.api.SubscriptionName
+import pl.allegro.tech.hermes.common.kafka.KafkaTopicName
+import pl.allegro.tech.hermes.common.kafka.offset.PartitionOffset
 import pl.allegro.tech.hermes.consumers.consumer.offset.SubscriptionPartitionOffset
 import pl.allegro.tech.hermes.consumers.queue.MpscQueue
 import pl.allegro.tech.hermes.consumers.queue.WaitFreeDrainMpscQueue
@@ -113,6 +115,7 @@ class SignalsFilterTest extends Specification {
     }
 
     private static SubscriptionPartitionOffset offset(int partition, long offset) {
-        return subscriptionPartitionOffset("group_topic", 'group.topic$sub', partition, offset)
+        return subscriptionPartitionOffset(fromString('group.topic$sub'),
+                new PartitionOffset(KafkaTopicName.valueOf('group_topic'), offset, partition), -1)
     }
 }

--- a/hermes-consumers/src/test/java/pl/allegro/tech/hermes/consumers/supervisor/workload/ConsumerTestRuntimeEnvironment.java
+++ b/hermes-consumers/src/test/java/pl/allegro/tech/hermes/consumers/supervisor/workload/ConsumerTestRuntimeEnvironment.java
@@ -13,6 +13,7 @@ import pl.allegro.tech.hermes.common.config.ConfigFactory;
 import pl.allegro.tech.hermes.common.di.factories.ModelAwareZookeeperNotifyingCacheFactory;
 import pl.allegro.tech.hermes.common.exception.InternalProcessingException;
 import pl.allegro.tech.hermes.common.metric.HermesMetrics;
+import pl.allegro.tech.hermes.consumers.consumer.offset.ConsumerPartitionAssignmentState;
 import pl.allegro.tech.hermes.consumers.consumer.offset.OffsetQueue;
 import pl.allegro.tech.hermes.consumers.health.ConsumerMonitor;
 import pl.allegro.tech.hermes.consumers.message.undelivered.UndeliveredMessageLogPersister;
@@ -80,6 +81,7 @@ class ConsumerTestRuntimeEnvironment {
     private Supplier<HermesMetrics> metricsSupplier;
     private ConsumerNodesRegistry consumersRegistry;
     private CuratorFramework curator;
+    private final ConsumerPartitionAssignmentState partitionAssignmentState;
 
     private Map<String, CuratorFramework> consumerZookeeperConnections = Maps.newHashMap();
     private List<SubscriptionsCache> subscriptionsCaches = new ArrayList<>();
@@ -88,6 +90,7 @@ class ConsumerTestRuntimeEnvironment {
         this.paths = new ZookeeperPaths("/hermes");
         this.curatorSupplier = curatorSupplier;
         this.curator = curatorSupplier.get();
+        this.partitionAssignmentState = new ConsumerPartitionAssignmentState();
         this.groupRepository = new ZookeeperGroupRepository(curator, objectMapper, paths);
         this.topicRepository = new ZookeeperTopicRepository(curator, objectMapper, paths, groupRepository);
         this.subscriptionRepository = new ZookeeperSubscriptionRepository(
@@ -170,6 +173,7 @@ class ConsumerTestRuntimeEnvironment {
                 new ConsumersExecutorService(configFactory, metrics),
                 consumerFactory,
                 mock(OffsetQueue.class),
+                partitionAssignmentState,
                 mock(Retransmitter.class),
                 mock(UndeliveredMessageLogPersister.class),
                 subscriptionRepository,

--- a/hermes-consumers/src/test/java/pl/allegro/tech/hermes/consumers/test/MessageBuilder.java
+++ b/hermes-consumers/src/test/java/pl/allegro/tech/hermes/consumers/test/MessageBuilder.java
@@ -28,6 +28,7 @@ public final class MessageBuilder {
     private long publishingTimestamp;
     private long readingTimestamp;
     private PartitionOffset partitionOffset;
+    private long partitionAssignmentTerm = -1L;
     private byte[] content;
     private Map<String, String> externalMetadata;
     private List<Header> additionalHeaders;
@@ -59,7 +60,7 @@ public final class MessageBuilder {
 
     public Message build() {
         return new Message(id, topic, content, contentType, schema, publishingTimestamp,
-                readingTimestamp, partitionOffset, externalMetadata, additionalHeaders,
+                readingTimestamp, partitionOffset, partitionAssignmentTerm, externalMetadata, additionalHeaders,
                 subscription, hasSubscriptionIdentityHeaders);
     }
 
@@ -105,6 +106,11 @@ public final class MessageBuilder {
 
     public MessageBuilder withPartitionOffset(PartitionOffset partitionOffset) {
         this.partitionOffset = partitionOffset;
+        return this;
+    }
+
+    public MessageBuilder withPartitionAssignmentTerm(long term) {
+        this.partitionAssignmentTerm = term;
         return this;
     }
 

--- a/hermes-management/src/main/resources/application.yaml
+++ b/hermes-management/src/main/resources/application.yaml
@@ -7,6 +7,7 @@ kafka:
       clusterName: primary
       connectionString: localhost:2181
       connectionTimeout: 3000
+      bootstrapKafkaServer: localhost:9092
 
 storage:
   connectionString: localhost:2181

--- a/hermes-mock/src/test/groovy/pl/allegro/tech/hermes/mock/HermesMockAvroTest.groovy
+++ b/hermes-mock/src/test/groovy/pl/allegro/tech/hermes/mock/HermesMockAvroTest.groovy
@@ -6,20 +6,25 @@ import org.apache.avro.reflect.ReflectData
 import org.junit.ClassRule
 import pl.allegro.tech.hermes.test.helper.avro.AvroUserSchemaLoader
 import pl.allegro.tech.hermes.test.helper.endpoint.HermesPublisher
+import pl.allegro.tech.hermes.test.helper.util.Ports
 import spock.lang.Shared
 import spock.lang.Specification
 import tech.allegro.schema.json2avro.converter.JsonAvroConverter
 
 class HermesMockAvroTest extends Specification {
+
+    @Shared
+    int port = Ports.nextAvailable()
+
     @ClassRule
     @Shared
-    HermesMockRule hermes = new HermesMockRule(56789)
+    HermesMockRule hermes = new HermesMockRule(port)
 
     Schema schema = ReflectData.get().getSchema(TestMessage)
 
     JsonAvroConverter jsonAvroConverter = new JsonAvroConverter()
 
-    HermesPublisher publisher = new HermesPublisher("http://localhost:56789")
+    HermesPublisher publisher = new HermesPublisher("http://localhost:$port")
 
     def setup() {
         hermes.resetReceivedRequest()

--- a/hermes-mock/src/test/groovy/pl/allegro/tech/hermes/mock/HermesMockExtensionTest.groovy
+++ b/hermes-mock/src/test/groovy/pl/allegro/tech/hermes/mock/HermesMockExtensionTest.groovy
@@ -2,14 +2,19 @@ package pl.allegro.tech.hermes.mock
 
 import org.junit.jupiter.api.extension.RegisterExtension
 import pl.allegro.tech.hermes.test.helper.endpoint.HermesPublisher
+import pl.allegro.tech.hermes.test.helper.util.Ports
+import spock.lang.Shared
 import spock.lang.Specification
 
 class HermesMockExtensionTest extends Specification {
 
-    @RegisterExtension
-    HermesMockExtension hermes = new HermesMockExtension(56789)
+    @Shared
+    int port = Ports.nextAvailable()
 
-    HermesPublisher publisher = new HermesPublisher("http://localhost:56789")
+    @RegisterExtension
+    HermesMockExtension hermes = new HermesMockExtension(port)
+
+    HermesPublisher publisher = new HermesPublisher("http://localhost:$port")
 
     def 'simple publish-expect test'() {
         given:

--- a/hermes-mock/src/test/groovy/pl/allegro/tech/hermes/mock/HermesMockRuleTest.groovy
+++ b/hermes-mock/src/test/groovy/pl/allegro/tech/hermes/mock/HermesMockRuleTest.groovy
@@ -2,13 +2,19 @@ package pl.allegro.tech.hermes.mock
 
 import org.junit.Rule
 import pl.allegro.tech.hermes.test.helper.endpoint.HermesPublisher
+import pl.allegro.tech.hermes.test.helper.util.Ports
+import spock.lang.Shared
 import spock.lang.Specification
 
 class HermesMockRuleTest extends Specification {
-    @Rule
-    HermesMockRule hermes = new HermesMockRule(5679)
 
-    HermesPublisher publisher = new HermesPublisher("http://localhost:5679")
+    @Shared
+    int port = Ports.nextAvailable()
+
+    @Rule
+    HermesMockRule hermes = new HermesMockRule(port)
+
+    HermesPublisher publisher = new HermesPublisher("http://localhost:$port")
 
     def 'simple publish-expect test'() {
         given:

--- a/hermes-mock/src/test/groovy/pl/allegro/tech/hermes/mock/HermesMockTest.groovy
+++ b/hermes-mock/src/test/groovy/pl/allegro/tech/hermes/mock/HermesMockTest.groovy
@@ -2,15 +2,20 @@ package pl.allegro.tech.hermes.mock
 
 import org.junit.ClassRule
 import pl.allegro.tech.hermes.test.helper.endpoint.HermesPublisher
+import pl.allegro.tech.hermes.test.helper.util.Ports
 import spock.lang.Shared
 import spock.lang.Specification
 
 class HermesMockTest extends Specification {
+
+    @Shared
+    int port = Ports.nextAvailable()
+
     @ClassRule
     @Shared
-    HermesMockRule hermes = new HermesMockRule(5678)
+    HermesMockRule hermes = new HermesMockRule(port)
 
-    HermesPublisher publisher = new HermesPublisher("http://localhost:5678")
+    HermesPublisher publisher = new HermesPublisher("http://localhost:$port")
 
     def setup() {
         hermes.resetReceivedRequest()

--- a/hermes-tracker/src/main/java/pl/allegro/tech/hermes/tracker/consumers/MessageMetadata.java
+++ b/hermes-tracker/src/main/java/pl/allegro/tech/hermes/tracker/consumers/MessageMetadata.java
@@ -6,23 +6,25 @@ public class MessageMetadata {
     private final String batchId;
     private final long offset;
     private final int partition;
+    private final long partitionAssignmentTerm;
     private final String topic;
     private final String kafkaTopic;
     private final String subscription;
     private final long publishingTimestamp;
     private final long readingTimestamp;
 
-    public MessageMetadata(String messageId, long offset, int partition, String topic, String subscription,
+    public MessageMetadata(String messageId, long offset, int partition, long partitionAssignmentTerm, String topic, String subscription,
                            String kafkaTopic, long publishingTimestamp, long readingTimestamp) {
-        this(messageId, "", offset, partition, topic, subscription, kafkaTopic, publishingTimestamp, readingTimestamp);
+        this(messageId, "", offset, partition, partitionAssignmentTerm, topic, subscription, kafkaTopic, publishingTimestamp, readingTimestamp);
     }
 
-    public MessageMetadata(String messageId, String batchId, long offset, int partition, String topic, String subscription,
+    public MessageMetadata(String messageId, String batchId, long offset, int partition, long partitionAssignmentTerm, String topic, String subscription,
                            String kafkaTopic, long publishingTimestamp, long readingTimestamp) {
         this.messageId = messageId;
         this.batchId = batchId;
         this.offset = offset;
         this.partition = partition;
+        this.partitionAssignmentTerm = partitionAssignmentTerm;
         this.topic = topic;
         this.subscription = subscription;
         this.kafkaTopic = kafkaTopic;
@@ -40,6 +42,10 @@ public class MessageMetadata {
 
     public int getPartition() {
         return partition;
+    }
+
+    public long getPartitionAssignmentTerm() {
+        return partitionAssignmentTerm;
     }
 
     public String getTopic() {

--- a/hermes-tracker/src/test/java/pl/allegro/tech/hermes/tracker/consumers/TestMessageMetadata.java
+++ b/hermes-tracker/src/test/java/pl/allegro/tech/hermes/tracker/consumers/TestMessageMetadata.java
@@ -7,7 +7,7 @@ public class TestMessageMetadata {
     }
 
     public static MessageMetadata of(String messageId, String topic, String subscription, long offset, int partition) {
-        return new MessageMetadata(messageId, offset, partition, topic, subscription, topic, 123456L, 123456L);
+        return new MessageMetadata(messageId, offset, partition, 123L, topic, subscription, topic, 123456L, 123456L);
     }
 
     public static MessageMetadata of(String messageId,String batchId, String topic, String subscription) {
@@ -15,6 +15,6 @@ public class TestMessageMetadata {
     }
 
     public static MessageMetadata of(String messageId, String batchId, String topic, String subscription, long offset, int partition) {
-        return new MessageMetadata(messageId, batchId, offset, partition, topic, subscription, topic, 123456L, 123456L);
+        return new MessageMetadata(messageId, batchId, offset, partition, 123L, topic, subscription, topic, 123456L, 123456L);
     }
 }


### PR DESCRIPTION
This PR introduces a thing called `partition assignment term` which is basically a monotonically incremented counter of a kafka consumer group (a subscription) rebalances that happened during lifespan of the consumer process. We use `ConsumerRebalanceListener` interface for listening on consumer group changes. Each message that flows through hermes-consumer has a `term` linked to it.
The `term` is used by offset committer - now we can easily remove some stale offsets that are kept in memory but cannot be committed because the consumer is not owning the particular partition anymore.

Btw:
* added `bootstrapKafkaServer` line to management config, it is needed by the admin client and consumer groups endpoint
* added `Ports.nextAvailable()` to hermes-mock tests, cause they were flapping locally on my machine