### PR TITLE
Enable caching for dependencies on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: java
 
+cache:
+  directories:
+    - $HOME/.m2
+
 env:
   - TEST_SUITE=check
   - TEST_SUITE=integrationTest

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ language: java
 cache:
   directories:
     - $HOME/.m2
+    - $HOME/.gradle/caches/
+    - $HOME/.gradle/wrapper/
 
 env:
   - TEST_SUITE=check


### PR DESCRIPTION
After yet another
```
Could not GET 'https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-annotations/2.9.4/jackson-annotations-2.9.4.pom'. Received status code 403 from server: Forbidden
```
I've decided to enable Maven and Gradle caching