### PR TITLE
Catch exceptions thrown while stopping kafka consumers

### DIFF
--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/process/ConsumerProcess.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/process/ConsumerProcess.java
@@ -67,9 +67,15 @@ public class ConsumerProcess implements Runnable {
         } finally {
             logger.info("Releasing consumer process thread of subscription {}", getSubscriptionName());
             refreshHealthcheck();
-            stop();
-            onConsumerStopped.accept(getSubscriptionName());
-            Thread.currentThread().setName("consumer-released-thread");
+            try {
+                stop();
+            } catch (Exception exceptionWhileStopping) {
+                logger.error("An error occurred while stopping consumer process of subscription {}",
+                        getSubscriptionName(), exceptionWhileStopping);
+            } finally {
+                onConsumerStopped.accept(getSubscriptionName());
+                Thread.currentThread().setName("consumer-released-thread");
+            }
         }
     }
 


### PR DESCRIPTION
While stopping consumer process there might be an exception thrown by underlying kafka consumer which is not catched and logged anywhere. 
This exception as a consequence will cause `dyingConsumerProcesses.remove(subscriptionName);` not be called at all - so we have a process dying forever and we will not be able to start another one for particular subscription without a jvm restart.