### PR TITLE
Maximum possible offset to be committed for partition

### DIFF
--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/offset/OffsetCommitter.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/offset/OffsetCommitter.java
@@ -34,18 +34,19 @@ import java.util.function.Function;
  * * inflightOffsets: message offsets that are currently being sent (inflight)
  * * committedOffsets: message offsets that are ready to get committed
  * <p>
- * This committer class holds internal state in form of inflightOffsets and failedToCommitOffsets set.
- * inlfightOffsets are all offsets that are currently in inflight state.
- * failedToCommitOffsets are offsets that could not be committed in previous algorithm iteration
+ * This committer class holds internal state in form of inflightOffsets and maxCommittedOffsets collections.
+ * * inlfightOffsets are all offsets that are currently in inflight state.
+ * * maxCommittedOffsets are offsets (maximum per partition) of already committed messages that could not yet be committed
+ * to kafka due to an existing inflight offset on the same partition
+ *
  * <p>
  * In scheduled periods, commit algorithm is run. It has three phases. First one is draining the queues and performing
  * reductions:
  * * drain committedOffsets queue to collection - it needs to be done before draining inflights, so this collection
  * will not grow anymore, resulting in having inflights unmatched by commits; commits are incremented by 1 to match
  * Kafka commit definition
- * * add all previously uncommitted offsets from failedToCommitOffsets collection to committedOffsets and clear
- * failedToCommitOffsets collection
- * * drain inflightOffset
+ * * update the maxCommittedOffsets map with largest committed offsets
+ * * drain inflightOffsets
  * <p>
  * Second phase is calculating the offsets:
  * <p>
@@ -76,6 +77,7 @@ public class OffsetCommitter implements Runnable {
     private final HermesMetrics metrics;
 
     private final Set<SubscriptionPartitionOffset> inflightOffsets = new HashSet<>();
+    private final Map<SubscriptionPartition, Long> maxCommittedOffsets = new HashMap<>();
 
     public OffsetCommitter(
             OffsetQueue offsetQueue,
@@ -97,7 +99,10 @@ public class OffsetCommitter implements Runnable {
             // committed offsets need to be drained first so that there is no possibility of new committed offsets
             // showing up after inflight queue is drained - this would lead to stall in committing offsets
             ReducingConsumer committedOffsetsReducer = processCommittedOffsets();
-            Map<SubscriptionPartition, Long> maxCommittedOffsets = committedOffsetsReducer.reduced;
+
+            // update stored max committed offsets with offsets drained from queue
+            Map<SubscriptionPartition, Long> maxDrainedCommittedOffsets = committedOffsetsReducer.reduced;
+            updateMaxCommittedOffsets(maxDrainedCommittedOffsets);
 
             ReducingConsumer inflightOffsetReducer = processInflightOffsets(committedOffsetsReducer.all);
             Map<SubscriptionPartition, Long> minInflightOffsets = inflightOffsetReducer.reduced;
@@ -105,28 +110,35 @@ public class OffsetCommitter implements Runnable {
             int scheduledToCommitCount = 0;
             int obsoleteCount = 0;
 
+            Set<SubscriptionPartition> committedOffsetToBeRemoved = new HashSet<>();
+
             OffsetsToCommit offsetsToCommit = new OffsetsToCommit();
             for (SubscriptionPartition partition : Sets.union(minInflightOffsets.keySet(), maxCommittedOffsets.keySet())) {
                 if (partitionAssignmentState.isAssignedPartitionAtCurrentTerm(partition)) {
-                    long offset = Math.min(
-                            minInflightOffsets.getOrDefault(partition, Long.MAX_VALUE),
-                            maxCommittedOffsets.getOrDefault(partition, Long.MAX_VALUE)
-                    );
-                    if (offset >= 0 && offset < Long.MAX_VALUE) {
+                    long minInflight = minInflightOffsets.getOrDefault(partition, Long.MAX_VALUE);
+                    long maxCommitted = maxCommittedOffsets.getOrDefault(partition, Long.MAX_VALUE);
+
+                    long offsetToBeCommitted = Math.min(minInflight, maxCommitted);
+                    if (offsetToBeCommitted >= 0 && offsetToBeCommitted < Long.MAX_VALUE) {
                         scheduledToCommitCount++;
-                        offsetsToCommit.add(new SubscriptionPartitionOffset(partition, offset));
+                        offsetsToCommit.add(new SubscriptionPartitionOffset(partition, offsetToBeCommitted));
+
+                        // if we just committed the maximum possible offset for partition, we can safely forget about it
+                        if (maxCommitted == offsetToBeCommitted) {
+                            committedOffsetToBeRemoved.add(partition);
+                        }
                     }
                 } else {
                     obsoleteCount++;
                 }
             }
-
+            committedOffsetToBeRemoved.forEach(maxCommittedOffsets::remove);
             messageCommitter.commitOffsets(offsetsToCommit);
 
             metrics.counter("offset-committer.obsolete").inc(obsoleteCount);
             metrics.counter("offset-committer.committed").inc(scheduledToCommitCount);
 
-            cleanupInflightOffsetsWithObsoleteTerms();
+            cleanupStoredOffsetsWithObsoleteTerms();
         } catch (Exception exception) {
             logger.error("Failed to run offset committer: {}", exception.getMessage(), exception);
         }
@@ -137,6 +149,13 @@ public class OffsetCommitter implements Runnable {
         offsetQueue.drainCommittedOffsets(committedOffsetsReducer);
         committedOffsetsReducer.resetModifierFunction();
         return committedOffsetsReducer;
+    }
+
+    private void updateMaxCommittedOffsets(Map<SubscriptionPartition, Long> maxDrainedCommittedOffsets) {
+        maxDrainedCommittedOffsets.forEach((partition, drainedOffset) ->
+                maxCommittedOffsets.compute(partition, (p, storedOffset) ->
+                        storedOffset == null || storedOffset < drainedOffset ? drainedOffset : storedOffset)
+        );
     }
 
     private ReducingConsumer processInflightOffsets(Set<SubscriptionPartitionOffset> committedOffsets) {
@@ -158,8 +177,9 @@ public class OffsetCommitter implements Runnable {
         }
     }
 
-    private void cleanupInflightOffsetsWithObsoleteTerms() {
+    private void cleanupStoredOffsetsWithObsoleteTerms() {
         inflightOffsets.removeIf(o -> !partitionAssignmentState.isAssignedPartitionAtCurrentTerm(o.getSubscriptionPartition()));
+        maxCommittedOffsets.entrySet().removeIf(entry -> !partitionAssignmentState.isAssignedPartitionAtCurrentTerm(entry.getKey()));
     }
 
     public void start() {

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/offset/OffsetCommitter.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/offset/OffsetCommitter.java
@@ -127,6 +127,9 @@ public class OffsetCommitter implements Runnable {
                         if (maxCommitted == offsetToBeCommitted) {
                             committedOffsetToBeRemoved.add(partition);
                         }
+                    } else {
+                        logger.warn("Skipping offset out of bounds for subscription {}: partition={}, offset={}",
+                                partition.getSubscriptionName(), partition.getPartition(), offsetToBeCommitted);
                     }
                 } else {
                     obsoleteCount++;


### PR DESCRIPTION
In our current approach the only state of `OffsetCommitter` that has been persisted for the use of upcoming algorithm runs were `inflightOffsets` that were used for preventing from skipping some messages that were currently inflight.
Turns out we should store maximum possible offsets as well. 

Imagine such scenario (just as in added test case):
* We have a partition with messages with offsets 1 and 2
* Consumer sends the messages:
  * message with offset=2 is delivered immediately
  * message with offset=1 is being retried for an hour and eventually discarded
* Before message with offset=1 is discarded the `OffsetCommitter` algorithm runs and loses the information about message with offset=2 being delivered (it remembers only offset=1 as the one that is still inflight at the time)
* No new messages arrive on the partition for some time, so we have a lag reported even though all messages are consumed.

This fix adds another collections which is persisted between algorithm runs: `maxCommittedOffsets` which stores maximum offsets that could not yet be committed because of `inflightOffsets`. 
In above case we would store offset=2 for later use. 