### PR TITLE
Fixing integration tests

### DIFF
--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/infrastructure/zookeeper/cache/HierarchicalCache.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/infrastructure/zookeeper/cache/HierarchicalCache.java
@@ -23,6 +23,7 @@ public class HierarchicalCache {
     private final ExecutorService executorService;
 
     private final String basePath;
+    private final boolean removeNodesWithNoData;
 
     private final List<String> levelPrefixes = new ArrayList<>();
 
@@ -36,10 +37,12 @@ public class HierarchicalCache {
                              ExecutorService executorService,
                              String basePath,
                              int maxDepth,
-                             List<String> levelPrefixes) {
+                             List<String> levelPrefixes,
+                             boolean removeNodesWithNoData) {
         this.curatorFramework = curatorFramework;
         this.executorService = executorService;
         this.basePath = basePath;
+        this.removeNodesWithNoData = removeNodesWithNoData;
         this.levelPrefixes.addAll(levelPrefixes);
         this.maxDepth = maxDepth;
 
@@ -68,11 +71,13 @@ public class HierarchicalCache {
                 path(depth, path),
                 depth,
                 levelCallbacks.get(depth),
-                Optional.ofNullable(function));
+                Optional.ofNullable(function),
+                removeNodesWithNoData);
         try {
+            logger.debug("Starting hierarchical cache level for path  {} and depth {}", path, depth);
             levelCache.start();
         } catch (Exception e) {
-            logger.error("Failed to start hierarchical cache level {} for path {}", depth, path(depth, path), e);
+            logger.error("Failed to start hierarchical cache level for path {} and depth {}", path(depth, path), depth, e);
         }
         return levelCache;
     }

--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/infrastructure/zookeeper/cache/HierarchicalCacheLevel.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/infrastructure/zookeeper/cache/HierarchicalCacheLevel.java
@@ -121,7 +121,7 @@ class HierarchicalCacheLevel extends PathChildrenCache implements PathChildrenCa
                     path, children.stream().map(Object::toString).collect(Collectors.joining(",")));
             printChildrenWithEmptyParentRecursively(path, children);
         } catch (KeeperException.NoNodeException e) {
-            // probably already removed
+            logger.info("Could not receive list of children for path {} as the path does not exist", path);
         } catch (Exception e) {
             logger.warn("Could not receive list of children for path {} due to error", path, e);
         }
@@ -136,7 +136,7 @@ class HierarchicalCacheLevel extends PathChildrenCache implements PathChildrenCa
 
                 printChildrenWithEmptyParentRecursively(nextPath, nextChildren);
             } catch (KeeperException.NoNodeException e) {
-                // probably already removed
+                logger.info("Could not receive list of children for path {} as the path does not exist", pathWithEmptyParent);
             } catch (Exception e) {
                 logger.warn("Could not receive list of children for path {} due to error", pathWithEmptyParent, e);
             }

--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/infrastructure/zookeeper/cache/HierarchicalCacheLevel.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/infrastructure/zookeeper/cache/HierarchicalCacheLevel.java
@@ -160,7 +160,7 @@ class HierarchicalCacheLevel extends PathChildrenCache implements PathChildrenCa
         try {
             HierarchicalCacheLevel subcache = subcacheMap.remove(cacheName);
             if (subcache == null) {
-                logger.warn("Possible duplicate of removed entry for {}, ignoring", cacheName);
+                logger.debug("Possible duplicate of removed entry for {}, ignoring", cacheName);
                 return;
             }
             subcache.close();

--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/infrastructure/zookeeper/cache/HierarchicalCacheLevel.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/infrastructure/zookeeper/cache/HierarchicalCacheLevel.java
@@ -1,14 +1,17 @@
 package pl.allegro.tech.hermes.infrastructure.zookeeper.cache;
 
+import org.apache.commons.lang.ArrayUtils;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.recipes.cache.PathChildrenCache;
 import org.apache.curator.framework.recipes.cache.PathChildrenCacheEvent;
 import org.apache.curator.framework.recipes.cache.PathChildrenCacheListener;
+import org.apache.zookeeper.KeeperException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ExecutorService;
@@ -16,6 +19,7 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.BiFunction;
+import java.util.stream.Collectors;
 
 class HierarchicalCacheLevel extends PathChildrenCache implements PathChildrenCacheListener {
 
@@ -25,9 +29,11 @@ class HierarchicalCacheLevel extends PathChildrenCache implements PathChildrenCa
 
     private final CacheListeners consumer;
 
+    private final CuratorFramework curatorClient;
     private final int currentDepth;
 
     private final Optional<BiFunction<Integer, String, HierarchicalCacheLevel>> nextLevelFactory;
+    private final boolean removeNodesWithNoData;
 
     private final Map<String, HierarchicalCacheLevel> subcacheMap = new HashMap<>();
 
@@ -36,11 +42,14 @@ class HierarchicalCacheLevel extends PathChildrenCache implements PathChildrenCa
                            String path,
                            int depth,
                            CacheListeners eventConsumer,
-                           Optional<BiFunction<Integer, String, HierarchicalCacheLevel>> nextLevelFactory) {
+                           Optional<BiFunction<Integer, String, HierarchicalCacheLevel>> nextLevelFactory,
+                           boolean removeNodesWithNoData) {
         super(curatorClient, path, true, false, executorService);
+        this.curatorClient = curatorClient;
         this.currentDepth = depth;
         this.consumer = eventConsumer;
         this.nextLevelFactory = nextLevelFactory;
+        this.removeNodesWithNoData = removeNodesWithNoData;
         getListenable().addListener(this);
     }
 
@@ -56,10 +65,10 @@ class HierarchicalCacheLevel extends PathChildrenCache implements PathChildrenCa
 
         switch (event.getType()) {
             case CHILD_ADDED:
-                addSubcache(path, cacheName);
+                addSubcache(path, cacheName, event.getData().getData());
                 break;
             case CHILD_REMOVED:
-                removeSubcache(cacheName);
+                removeSubcache(path, cacheName);
                 break;
             default:
                 break;
@@ -82,10 +91,19 @@ class HierarchicalCacheLevel extends PathChildrenCache implements PathChildrenCa
         }
     }
 
-    private void addSubcache(String path, String cacheName) throws Exception {
+    private void addSubcache(String path, String cacheName, byte[] data) {
         Lock writeLock = subcacheLock.writeLock();
         writeLock.lock();
         try {
+            logger.debug("Adding cache for path {}; Cache name: {}; Depth: {}; InstanceId: {}",
+                    path, cacheName, currentDepth, Integer.toHexString(hashCode()));
+
+            if (ArrayUtils.isEmpty(data) && removeNodesWithNoData) {
+                logger.warn("Removing path {} due to no data in the znode", path);
+                printOrphanedChildren(path);
+                removeNodeRecursively(path);
+                return;
+            }
             if (subcacheMap.containsKey(cacheName)) {
                 logger.debug("Possible duplicate of new entry for {}, ignoring", cacheName);
                 return;
@@ -94,16 +112,55 @@ class HierarchicalCacheLevel extends PathChildrenCache implements PathChildrenCa
         } finally {
             writeLock.unlock();
         }
-
     }
 
-    private void removeSubcache(String cacheName) throws Exception {
+    private void printOrphanedChildren(String path) {
+        try {
+            List<String> children = curatorClient.getChildren().forPath(path);
+            logger.warn("Nodes with empty parent {}: {}",
+                    path, children.stream().map(Object::toString).collect(Collectors.joining(",")));
+            printChildrenWithEmptyParentRecursively(path, children);
+        } catch (KeeperException.NoNodeException e) {
+            // probably already removed
+        } catch (Exception e) {
+            logger.warn("Could not receive list of children for path {} due to error", path, e);
+        }
+    }
+
+    private void printChildrenWithEmptyParentRecursively(String pathWithEmptyParent, List<String> children) {
+        children.forEach( c -> {
+            try {
+                String nextPath = pathWithEmptyParent + "/" + c;
+                logger.warn("Node with empty parent: {}", nextPath);
+                List<String> nextChildren = curatorClient.getChildren().forPath(nextPath);
+
+                printChildrenWithEmptyParentRecursively(nextPath, nextChildren);
+            } catch (KeeperException.NoNodeException e) {
+                // probably already removed
+            } catch (Exception e) {
+                logger.warn("Could not receive list of children for path {} due to error", pathWithEmptyParent, e);
+            }
+        });
+    }
+
+    private void removeNodeRecursively(String path) {
+        try {
+            curatorClient.delete().deletingChildrenIfNeeded().forPath(path);
+            logger.warn("Removed recursively path {}", path);
+        } catch (Exception e) {
+            logger.warn("Error while deleting recursively path {}", path, e);
+        }
+    }
+
+    private void removeSubcache(String path, String cacheName) throws Exception {
         Lock writeLock = subcacheLock.writeLock();
         writeLock.lock();
+        logger.debug("Removing cache for path {}; Cache name: {}; Depth {}; InstanceId: {}",
+                path, cacheName, currentDepth, Integer.toHexString(hashCode()));
         try {
             HierarchicalCacheLevel subcache = subcacheMap.remove(cacheName);
             if (subcache == null) {
-                logger.debug("Possible duplicate of removed entry for {}, ignoring", cacheName);
+                logger.warn("Possible duplicate of removed entry for {}, ignoring", cacheName);
                 return;
             }
             subcache.close();

--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/infrastructure/zookeeper/cache/ModelAwareZookeeperNotifyingCache.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/infrastructure/zookeeper/cache/ModelAwareZookeeperNotifyingCache.java
@@ -36,7 +36,8 @@ public class ModelAwareZookeeperNotifyingCache {
                 executor,
                 rootPath,
                 3,
-                levelPrefixes
+                levelPrefixes,
+                true
         );
     }
 

--- a/hermes-common/src/test/resources/logback-test.xml
+++ b/hermes-common/src/test/resources/logback-test.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+            <Pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level %logger{36} - %msg%n</Pattern>
+        </encoder>
+    </appender>
+
+    <logger name="pl.allegro.tech.hermes.infrastructure.zookeeper.cache" level="DEBUG"></logger>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT"/>
+    </root>
+
+</configuration>

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/rate/maxrate/MaxRateRegistry.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/rate/maxrate/MaxRateRegistry.java
@@ -18,7 +18,6 @@ import pl.allegro.tech.hermes.infrastructure.zookeeper.cache.HierarchicalCache;
 import javax.inject.Inject;
 import java.time.Duration;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -28,6 +27,8 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
 import java.util.stream.Collectors;
+
+import static java.util.Collections.emptyList;
 
 public class MaxRateRegistry {
 
@@ -60,7 +61,7 @@ public class MaxRateRegistry {
         ThreadFactory cacheThreadFactory = new ThreadFactoryBuilder().setNameFormat("max-rate-registry-%d").build();
         this.cache = new HierarchicalCache(curator,
                 Executors.newSingleThreadExecutor(cacheThreadFactory),
-                zookeeperPaths.consumersRateRuntimePath(cluster), 3, Collections.emptyList()
+                zookeeperPaths.consumersRateRuntimePath(cluster), 3, emptyList(), false
         );
 
         handleContentUpdates();

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/workload/SubscriptionAssignmentCache.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/workload/SubscriptionAssignmentCache.java
@@ -22,6 +22,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
 import java.util.stream.Collectors;
 
+import static java.util.Collections.emptyList;
 import static pl.allegro.tech.hermes.common.config.Configs.KAFKA_CLUSTER_NAME;
 import static pl.allegro.tech.hermes.consumers.supervisor.workload.SubscriptionAssignmentRegistry.AUTO_ASSIGNED_MARKER;
 
@@ -60,7 +61,7 @@ public class SubscriptionAssignmentCache {
         this.pathSerializer = new SubscriptionAssignmentPathSerializer(basePath, AUTO_ASSIGNED_MARKER);
         ThreadFactory threadFactory = new ThreadFactoryBuilder().setNameFormat("subscription-assignment-cache-%d").build();
         this.cache = new HierarchicalCache(
-                curator, Executors.newSingleThreadScheduledExecutor(threadFactory), basePath, 2, Collections.emptyList()
+                curator, Executors.newSingleThreadScheduledExecutor(threadFactory), basePath, 2, emptyList(), false
         );
 
         cache.registerCallback(ASSIGNMENT_LEVEL, (e) -> {

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/config/SchemaRepositoryConfiguration.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/config/SchemaRepositoryConfiguration.java
@@ -64,7 +64,8 @@ public class SchemaRepositoryConfiguration {
             ObjectMapper objectMapper
     ) {
         return new SchemaRegistryRawSchemaClient(httpClient, URI.create(schemaRepositoryProperties.getServerUrl()),
-                objectMapper, schemaRepositoryProperties.isValidationEnabled());
+                objectMapper, schemaRepositoryProperties.isValidationEnabled(),
+                schemaRepositoryProperties.getDeleteSchemaPathSuffix());
     }
 
     @Bean

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/config/SchemaRepositoryProperties.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/config/SchemaRepositoryProperties.java
@@ -15,6 +15,7 @@ public class SchemaRepositoryProperties {
     private int connectionTimeoutMillis = 1000;
 
     private int socketTimeoutMillis = 3000;
+    private String deleteSchemaPathSuffix = "versions";
 
     public String getType() {
         return type;
@@ -50,5 +51,17 @@ public class SchemaRepositoryProperties {
 
     public int getSocketTimeoutMillis() {
         return socketTimeoutMillis;
+    }
+
+    public String getDeleteSchemaPathSuffix() {
+        return deleteSchemaPathSuffix;
+    }
+
+    public void setDeleteSchemaPathSuffix(String deleteSchemaPathSuffix) {
+        this.deleteSchemaPathSuffix = deleteSchemaPathSuffix;
+    }
+
+    public void setSocketTimeoutMillis(int socketTimeoutMillis) {
+        this.socketTimeoutMillis = socketTimeoutMillis;
     }
 }

--- a/hermes-schema/src/main/java/pl/allegro/tech/hermes/schema/confluent/SchemaRegistryRawSchemaClient.java
+++ b/hermes-schema/src/main/java/pl/allegro/tech/hermes/schema/confluent/SchemaRegistryRawSchemaClient.java
@@ -41,15 +41,17 @@ public class SchemaRegistryRawSchemaClient implements RawSchemaClient {
 
     private final ObjectMapper objectMapper;
     private final boolean validationEndpointEnabled;
+    private final String deleteSchemaPathSuffix;
 
     public SchemaRegistryRawSchemaClient(Client client, URI schemaRegistryUri, ObjectMapper objectMapper) {
-        this(client, schemaRegistryUri, objectMapper, false);
+        this(client, schemaRegistryUri, objectMapper, false, "versions");
     }
 
     public SchemaRegistryRawSchemaClient(Client client, URI schemaRegistryUri, ObjectMapper objectMapper,
-                                         boolean validationEndpointEnabled) {
+                                         boolean validationEndpointEnabled, String deleteSchemaPathSuffix) {
 
         this.validationEndpointEnabled = validationEndpointEnabled;
+        this.deleteSchemaPathSuffix = deleteSchemaPathSuffix;
         this.target = client.target(schemaRegistryUri);
         this.objectMapper = objectMapper;
     }
@@ -149,7 +151,7 @@ public class SchemaRegistryRawSchemaClient implements RawSchemaClient {
     public void deleteAllSchemaVersions(TopicName topic) {
         Response response = target.path("subjects")
                 .path(topic.qualifiedName())
-                .path("versions")
+                .path(deleteSchemaPathSuffix)
                 .request()
                 .delete();
         checkSchemaRemoval(topic.qualifiedName(), response);

--- a/hermes-schema/src/test/groovy/pl/allegro/tech/hermes/schema/confluent/SchemaRegistryRawSchemaClientTest.groovy
+++ b/hermes-schema/src/test/groovy/pl/allegro/tech/hermes/schema/confluent/SchemaRegistryRawSchemaClientTest.groovy
@@ -261,8 +261,9 @@ class SchemaRegistryRawSchemaClientTest extends Specification {
 
     def "should successfully validate schema against validation endpoint"() {
         boolean validationEnabled = true
+        String deleteSchemaPathSuffix = ""
         client = new SchemaRegistryRawSchemaClient(ClientBuilder.newClient(), URI.create("http://localhost:$port"),
-                new ObjectMapper(), validationEnabled)
+                new ObjectMapper(), validationEnabled, deleteSchemaPathSuffix)
 
         wireMock.stubFor(post(schemaCompatibilityUrl(topicName))
                 .willReturn(okResponse()
@@ -284,8 +285,9 @@ class SchemaRegistryRawSchemaClientTest extends Specification {
     def "should receive errors from validation endpoint"() {
         given:
         boolean validationEnabled = true
+        String deleteSchemaPathSuffix = ""
         client = new SchemaRegistryRawSchemaClient(ClientBuilder.newClient(), URI.create("http://localhost:$port"),
-                new ObjectMapper(), validationEnabled)
+                new ObjectMapper(), validationEnabled, deleteSchemaPathSuffix)
 
         wireMock.stubFor(post(schemaCompatibilityUrl(topicName))
                 .willReturn(okResponse()

--- a/hermes-test-helper/src/main/java/pl/allegro/tech/hermes/test/helper/endpoint/Waiter.java
+++ b/hermes-test-helper/src/main/java/pl/allegro/tech/hermes/test/helper/endpoint/Waiter.java
@@ -23,20 +23,31 @@ public class Waiter {
 
     public void untilSubscriptionCreated(Topic topic, String subscription, boolean isTracked) {
         waitAtMost(adjust(Duration.ONE_MINUTE)).until(() ->
-            endpoints.subscription().list(topic.getQualifiedName(), isTracked).contains(subscription)
+                endpoints.subscription().list(topic.getQualifiedName(), isTracked).contains(subscription)
+        );
+    }
+
+    public void untilSubscriptionRemoved(Subscription sub) {
+        waitAtMost(adjust(Duration.ONE_MINUTE)).until(() ->
+                !endpoints.subscription().list(sub.getQualifiedTopicName(), sub.isTrackingEnabled()).contains(sub.getName())
         );
     }
 
     public void untilGroupCreated(String group) {
         waitAtMost(adjust(Duration.ONE_MINUTE)).until(() ->
-            endpoints.group().list().contains(group)
+                endpoints.group().list().contains(group)
         );
     }
 
     public void untilTopicCreated(Topic topic) {
         waitAtMost(adjust(Duration.ONE_MINUTE)).until(() ->
-            endpoints.findTopics(topic, topic.isTrackingEnabled()).contains(topic.getQualifiedName())
+                endpoints.findTopics(topic, topic.isTrackingEnabled()).contains(topic.getQualifiedName())
         );
+    }
+
+    public void untilTopicRemoved(Topic topic) {
+        waitAtMost(adjust(Duration.ONE_MINUTE)).until(() ->
+                !endpoints.findTopics(topic, topic.isTrackingEnabled()).contains(topic.getQualifiedName()));
     }
 
     public void untilSchemaCreated(Topic topic) {

--- a/hermes-test-helper/src/main/java/pl/allegro/tech/hermes/test/helper/util/Ports.java
+++ b/hermes-test-helper/src/main/java/pl/allegro/tech/hermes/test/helper/util/Ports.java
@@ -1,19 +1,36 @@
 package pl.allegro.tech.hermes.test.helper.util;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.IOException;
+import java.net.ConnectException;
 import java.net.DatagramSocket;
 import java.net.ServerSocket;
+import java.net.Socket;
 
 public final class Ports {
+
+    private static final Logger logger = LoggerFactory.getLogger(Ports.class);
 
     private Ports() {
     }
 
     public static int nextAvailable() {
         try {
-            try (ServerSocket socket = new ServerSocket(0)) {
-                socket.setReuseAddress(true);
-                return socket.getLocalPort();
+            ServerSocket socket = new ServerSocket(0);
+            socket.setReuseAddress(true);
+            int port = socket.getLocalPort();
+            socket.getLocalSocketAddress();
+            socket.close();
+
+            // second check whether the port is available as on some dynamic environments it can be still in use
+            try (Socket ignore = new Socket("0.0.0.0", port)) {
+                logger.warn("Connected to randomly selected port {} meaning it is still in use. Drawing next port.", port);
+                return nextAvailable();
+            } catch (ConnectException ex) {
+                // expected exception as on provided port no one should listen
+                return port;
             }
         } catch (IOException exception) {
             throw new NoAvailablePortException(exception);

--- a/hermes-test-helper/src/main/java/pl/allegro/tech/hermes/test/helper/util/Ports.java
+++ b/hermes-test-helper/src/main/java/pl/allegro/tech/hermes/test/helper/util/Ports.java
@@ -12,6 +12,7 @@ public final class Ports {
     public static int nextAvailable() {
         try {
             try (ServerSocket socket = new ServerSocket(0)) {
+                socket.setReuseAddress(true);
                 return socket.getLocalPort();
             }
         } catch (IOException exception) {

--- a/integration/src/integration/java/pl/allegro/tech/hermes/integration/BatchRetryPolicyTest.java
+++ b/integration/src/integration/java/pl/allegro/tech/hermes/integration/BatchRetryPolicyTest.java
@@ -29,6 +29,7 @@ import static org.apache.http.HttpStatus.SC_BAD_REQUEST;
 import static org.apache.http.HttpStatus.SC_CREATED;
 import static org.apache.http.HttpStatus.SC_INTERNAL_SERVER_ERROR;
 import static pl.allegro.tech.hermes.integration.test.HermesAssertions.assertThat;
+import static pl.allegro.tech.hermes.test.helper.builder.TopicBuilder.randomTopic;
 
 public class BatchRetryPolicyTest extends IntegrationTest {
 
@@ -63,7 +64,7 @@ public class BatchRetryPolicyTest extends IntegrationTest {
     @Test
     public void shouldRetryUntilRequestSuccessfulAndSendRetryCounterInHeader() throws Throwable {
         //given
-        Topic topic = operations.buildTopic("group", "retryUntilRequestSuccessful");
+        Topic topic = operations.buildTopic(randomTopic("group", "retryUntilRequestSuccessful").build());
         createSingleMessageBatchSubscription(topic);
 
         wireMock.register(post(topicUrl(topic))
@@ -92,7 +93,7 @@ public class BatchRetryPolicyTest extends IntegrationTest {
     @Test
     public void shouldNotRetryIfRequestSuccessful() throws Throwable {
         //given
-        Topic topic = operations.buildTopic("group", "notRetryIfRequestSuccessful");
+        Topic topic = operations.buildTopic(randomTopic("group", "notRetryIfRequestSuccessful").build());
         createSingleMessageBatchSubscription(topic);
 
         wireMock.register(post(topicUrl(topic)).willReturn(aResponse().withStatus(SC_CREATED)));
@@ -107,7 +108,7 @@ public class BatchRetryPolicyTest extends IntegrationTest {
     @Test
     public void shouldRetryUntilTtlExceeded() throws Throwable {
         //given
-        Topic topic = operations.buildTopic("group", "retryUntilTtlExceeded");
+        Topic topic = operations.buildTopic(randomTopic("group", "retryUntilTtlExceeded").build());
         createSingleMessageBatchSubscription(topic, 1, 10);
 
         wireMock.register(post(topicUrl(topic))
@@ -138,7 +139,7 @@ public class BatchRetryPolicyTest extends IntegrationTest {
     @Test
     public void shouldRetryOnClientErrors() throws Throwable {
         //given
-        Topic topic = operations.buildTopic("group", "retryOnClientErrors");
+        Topic topic = operations.buildTopic(randomTopic("group", "retryOnClientErrors").build());
         createSingleMessageBatchSubscription(topic, true);
 
         wireMock.register(post(topicUrl(topic))
@@ -162,7 +163,7 @@ public class BatchRetryPolicyTest extends IntegrationTest {
     @Test
     public void shouldNotRetryOnClientErrors() throws Throwable {
         //given
-        Topic topic = operations.buildTopic("group", "notRetryOnClientErrors");
+        Topic topic = operations.buildTopic(randomTopic("group", "notRetryOnClientErrors").build());
         createSingleMessageBatchSubscription(topic, false);
 
         wireMock.register(post(topicUrl(topic))

--- a/integration/src/integration/java/pl/allegro/tech/hermes/integration/BroadcastDeliveryTest.java
+++ b/integration/src/integration/java/pl/allegro/tech/hermes/integration/BroadcastDeliveryTest.java
@@ -15,6 +15,7 @@ import java.util.stream.Stream;
 
 import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toList;
+import static pl.allegro.tech.hermes.test.helper.builder.TopicBuilder.randomTopic;
 
 public class BroadcastDeliveryTest extends IntegrationTest {
     private static final Logger logger = LoggerFactory.getLogger(BroadcastDeliveryTest.class);
@@ -37,7 +38,7 @@ public class BroadcastDeliveryTest extends IntegrationTest {
     public void shouldPublishAndConsumeMessageByAllServices() {
         // given
         String endpointUrl = setUpServicesAndGetEndpoint();
-        Topic topic = operations.buildTopic("publishAndConsumeGroup", "broadcastTopic");
+        Topic topic = operations.buildTopic(randomTopic("publishAndConsumeGroup", "broadcastTopic").build());
         operations.createBroadcastSubscription(topic, "broadcastSubscription", endpointUrl);
 
         TestMessage message = TestMessage.random();
@@ -54,7 +55,7 @@ public class BroadcastDeliveryTest extends IntegrationTest {
     public void shouldPublishAndRetryOnlyForUndeliveredConsumers() {
         // given
         String endpointUrl = setUpServicesAndGetEndpoint();
-        Topic topic = operations.buildTopic("publishAndConsumeGroup", "broadcastTopic2");
+        Topic topic = operations.buildTopic(randomTopic("publishAndConsumeGroup", "broadcastTopic2").build());
         operations.createBroadcastSubscription(topic, "broadcastSubscription2", endpointUrl);
 
         TestMessage message = TestMessage.random();
@@ -73,7 +74,7 @@ public class BroadcastDeliveryTest extends IntegrationTest {
     public void shouldNotRetryForBadRequestsFromConsumers() {
         // given
         String endpointUrl = setUpServicesAndGetEndpoint();
-        Topic topic = operations.buildTopic("publishAndConsumeGroup", "broadcastTopic3");
+        Topic topic = operations.buildTopic(randomTopic("publishAndConsumeGroup", "broadcastTopic3").build());
         operations.createBroadcastSubscription(topic, "broadcastSubscription3", endpointUrl);
 
         TestMessage message = TestMessage.random();

--- a/integration/src/integration/java/pl/allegro/tech/hermes/integration/ConsumingHttp2Test.java
+++ b/integration/src/integration/java/pl/allegro/tech/hermes/integration/ConsumingHttp2Test.java
@@ -21,6 +21,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import static io.undertow.UndertowOptions.ENABLE_HTTP2;
 import static javax.ws.rs.core.Response.Status.CREATED;
 import static pl.allegro.tech.hermes.integration.test.HermesAssertions.assertThat;
+import static pl.allegro.tech.hermes.test.helper.builder.TopicBuilder.randomTopic;
 
 public class ConsumingHttp2Test extends IntegrationTest {
     static final int HTTPS_PORT = Ports.nextAvailable();
@@ -32,7 +33,7 @@ public class ConsumingHttp2Test extends IntegrationTest {
     @Test
     public void shouldDeliverMessageUsingHttp2() throws InterruptedException {
         // given
-        Topic topic = operations.buildTopic("deliverHttp2", "topic");
+        Topic topic = operations.buildTopic(randomTopic("deliverHttp2", "topic").build());
 
         Subscription subscription = SubscriptionBuilder.subscription(topic, "subscription")
                 .withEndpoint(HTTPS_ENDPOINT)

--- a/integration/src/integration/java/pl/allegro/tech/hermes/integration/FilteringAvroTest.java
+++ b/integration/src/integration/java/pl/allegro/tech/hermes/integration/FilteringAvroTest.java
@@ -17,7 +17,7 @@ import static pl.allegro.tech.hermes.api.ContentType.AVRO;
 import static pl.allegro.tech.hermes.api.TopicWithSchema.topicWithSchema;
 import static pl.allegro.tech.hermes.integration.test.HermesAssertions.assertThat;
 import static pl.allegro.tech.hermes.test.helper.builder.SubscriptionBuilder.subscription;
-import static pl.allegro.tech.hermes.test.helper.builder.TopicBuilder.topic;
+import static pl.allegro.tech.hermes.test.helper.builder.TopicBuilder.randomTopic;
 
 public class FilteringAvroTest extends IntegrationTest {
 
@@ -43,7 +43,7 @@ public class FilteringAvroTest extends IntegrationTest {
     public void shouldFilterIncomingEvents() {
         // given
         final String schema = AvroUserSchemaLoader.load().toString();
-        final Topic topic = topic("filteredTopic.topic")
+        final Topic topic = randomTopic("filteredTopic", "topic")
                 .withContentType(AVRO).build();
         operations.buildTopicWithSchema(topicWithSchema(topic, schema));
 
@@ -69,7 +69,7 @@ public class FilteringAvroTest extends IntegrationTest {
     public void shouldChainMultipleFilters() {
         // given
         final String schema = AvroUserSchemaLoader.load().toString();
-        final Topic topic = topic("filteredChainTopic.topic")
+        final Topic topic = randomTopic("filteredChainTopic", "topic")
                 .withContentType(AVRO).build();
         operations.buildTopicWithSchema(topicWithSchema(topic, schema));
 

--- a/integration/src/integration/java/pl/allegro/tech/hermes/integration/FilteringHeadersTest.java
+++ b/integration/src/integration/java/pl/allegro/tech/hermes/integration/FilteringHeadersTest.java
@@ -15,7 +15,7 @@ import static javax.ws.rs.core.MediaType.TEXT_PLAIN;
 import static javax.ws.rs.core.Response.Status.CREATED;
 import static pl.allegro.tech.hermes.integration.test.HermesAssertions.assertThat;
 import static pl.allegro.tech.hermes.test.helper.builder.SubscriptionBuilder.subscription;
-import static pl.allegro.tech.hermes.test.helper.builder.TopicBuilder.topic;
+import static pl.allegro.tech.hermes.test.helper.builder.TopicBuilder.randomTopic;
 
 public class FilteringHeadersTest extends IntegrationTest {
 
@@ -38,7 +38,7 @@ public class FilteringHeadersTest extends IntegrationTest {
     @Test
     public void shouldFilterIncomingEventsByHeaders() {
         // given
-        Topic topic = topic("filteredHeaders.topic").build();
+        Topic topic = randomTopic("filteredHeaders", "topic").build();
         operations.buildTopic(topic);
 
         Subscription subscription = subscription(topic.getName(), "subscription")
@@ -53,13 +53,13 @@ public class FilteringHeadersTest extends IntegrationTest {
         remoteService.expectMessages(ALICE.asJson());
 
         // when
-        assertThat(publisher.publish("filteredHeaders.topic", ALICE.asJson(), of("Trace-Id", "vte12", "Span-Id", "my-span", "Content-Type", TEXT_PLAIN)))
+        assertThat(publisher.publish(topic.getQualifiedName(), ALICE.asJson(), of("Trace-Id", "vte12", "Span-Id", "my-span", "Content-Type", TEXT_PLAIN)))
                 .hasStatus(CREATED);
 
-        assertThat(publisher.publish("filteredHeaders.topic", BOB.asJson(), of("Trace-Id", "vte12"))).hasStatus(CREATED);
-        assertThat(publisher.publish("filteredHeaders.topic", BOB.asJson(), of("Span-Id", "my-span"))).hasStatus(CREATED);
-        assertThat(publisher.publish("filteredHeaders.topic", BOB.asJson(), of("Trace-Id", "vte12", "Span-Id", "span-1"))).hasStatus(CREATED);
-        assertThat(publisher.publish("filteredHeaders.topic", BOB.asJson(), of("Trace-Id", "invalid", "Span-Id", "my-span"))).hasStatus(CREATED);
+        assertThat(publisher.publish(topic.getQualifiedName(), BOB.asJson(), of("Trace-Id", "vte12"))).hasStatus(CREATED);
+        assertThat(publisher.publish(topic.getQualifiedName(), BOB.asJson(), of("Span-Id", "my-span"))).hasStatus(CREATED);
+        assertThat(publisher.publish(topic.getQualifiedName(), BOB.asJson(), of("Trace-Id", "vte12", "Span-Id", "span-1"))).hasStatus(CREATED);
+        assertThat(publisher.publish(topic.getQualifiedName(), BOB.asJson(), of("Trace-Id", "invalid", "Span-Id", "my-span"))).hasStatus(CREATED);
 
         // then
         remoteService.waitUntilReceived();

--- a/integration/src/integration/java/pl/allegro/tech/hermes/integration/FilteringJsonTest.java
+++ b/integration/src/integration/java/pl/allegro/tech/hermes/integration/FilteringJsonTest.java
@@ -15,6 +15,7 @@ import static com.google.common.collect.ImmutableMap.of;
 import static javax.ws.rs.core.Response.Status.CREATED;
 import static pl.allegro.tech.hermes.integration.test.HermesAssertions.assertThat;
 import static pl.allegro.tech.hermes.test.helper.builder.SubscriptionBuilder.subscription;
+import static pl.allegro.tech.hermes.test.helper.builder.TopicBuilder.randomTopic;
 
 public class FilteringJsonTest extends IntegrationTest {
     private RemoteServiceEndpoint remoteService;
@@ -41,7 +42,7 @@ public class FilteringJsonTest extends IntegrationTest {
     @Test
     public void shouldFilterIncomingEvents() {
         // given
-        Topic topic = operations.buildTopic("filteredTopicJson", "topic");
+        Topic topic = operations.buildTopic(randomTopic("filteredTopicJson", "topic").build());
         final Subscription subscription = subscription(topic.getName(), "subscription")
                 .withEndpoint(HTTP_ENDPOINT_URL)
                 .withContentType(ContentType.JSON)
@@ -63,7 +64,7 @@ public class FilteringJsonTest extends IntegrationTest {
     @Test
     public void shouldChainFilters() {
         // given
-        Topic topic = operations.buildTopic("filteredChainedTopicJson", "topic");
+        Topic topic = operations.buildTopic(randomTopic("filteredChainedTopicJson", "topic").build());
         final Subscription subscription = subscription(topic.getName(), "subscription")
                 .withEndpoint(HTTP_ENDPOINT_URL)
                 .withContentType(ContentType.JSON)
@@ -88,7 +89,7 @@ public class FilteringJsonTest extends IntegrationTest {
     @Test
     public void shouldPassSubscriptionHeadersWhenFilteringIsEnabledForIncomingEvents() {
         // given
-        Topic topic = operations.buildTopic("filteredJsonTopicHavingSubscriptionWithHeaders", "topic");
+        Topic topic = operations.buildTopic(randomTopic("filteredJsonTopicHavingSubscriptionWithHeaders", "topic").build());
         final Subscription subscription = subscription(topic.getName(), "subscription")
                 .withEndpoint(HTTP_ENDPOINT_URL)
                 .withContentType(ContentType.JSON)

--- a/integration/src/integration/java/pl/allegro/tech/hermes/integration/HermesClientPublishingTest.java
+++ b/integration/src/integration/java/pl/allegro/tech/hermes/integration/HermesClientPublishingTest.java
@@ -2,8 +2,9 @@ package pl.allegro.tech.hermes.integration;
 
 import okhttp3.OkHttpClient;
 import org.springframework.web.client.AsyncRestTemplate;
-import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
+import pl.allegro.tech.hermes.api.Topic;
 import pl.allegro.tech.hermes.api.TopicName;
 import pl.allegro.tech.hermes.client.HermesClient;
 import pl.allegro.tech.hermes.client.HermesResponse;
@@ -22,18 +23,21 @@ import static java.net.URI.create;
 import static javax.ws.rs.client.ClientBuilder.newClient;
 import static org.assertj.core.api.Assertions.assertThat;
 import static pl.allegro.tech.hermes.client.HermesClientBuilder.hermesClient;
+import static pl.allegro.tech.hermes.test.helper.builder.TopicBuilder.randomTopic;
 
 public class HermesClientPublishingTest extends IntegrationTest {
 
     private TestMessage message = TestMessage.of("hello", "world");
 
-    private TopicName topic = new TopicName("hermesClientGroup", "topic");
     private URI topicURI = create("http://localhost:" + FRONTEND_PORT);
     private URI sslTopicUri = create("https://localhost:" + FRONTEND_SSL_PORT);
 
-    @BeforeClass
-    public void initialize() throws InterruptedException {
-        operations.buildTopic(topic.getGroupName(), topic.getName());
+    private Topic topic;
+
+    @BeforeMethod
+    public void initialize() {
+        topic = randomTopic("hermesClientGroup", "topic").build();
+        operations.buildTopic(topic);
     }
 
     @Test
@@ -78,7 +82,7 @@ public class HermesClientPublishingTest extends IntegrationTest {
         HermesClient client = hermesClient(new OkHttpHermesSender(getOkHttpClientWithSslContextConfigured())).withURI(sslTopicUri).build();
 
         // when
-        HermesResponse response = client.publish(topic.qualifiedName(), message.body()).join();
+        HermesResponse response = client.publish(topic.getQualifiedName(), message.body()).join();
 
         // then
         assertThat(response.getProtocol()).isEqualTo("h2");
@@ -91,7 +95,7 @@ public class HermesClientPublishingTest extends IntegrationTest {
 
     private void shouldPublishUsingHermesClient(HermesClient client) {
         // when
-        HermesResponse response = client.publish(topic.qualifiedName(), message.body()).join();
+        HermesResponse response = client.publish(topic.getQualifiedName(), message.body()).join();
 
         // then
         assertThat(response.isSuccess()).isTrue();

--- a/integration/src/integration/java/pl/allegro/tech/hermes/integration/IntegrationTest.java
+++ b/integration/src/integration/java/pl/allegro/tech/hermes/integration/IntegrationTest.java
@@ -1,6 +1,8 @@
 package pl.allegro.tech.hermes.integration;
 
 import com.google.common.collect.ImmutableMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
 import pl.allegro.tech.hermes.integration.env.HermesIntegrationEnvironment;
@@ -10,9 +12,14 @@ import pl.allegro.tech.hermes.test.helper.endpoint.HermesAPIOperations;
 import pl.allegro.tech.hermes.test.helper.endpoint.HermesEndpoints;
 import pl.allegro.tech.hermes.test.helper.endpoint.HermesPublisher;
 
+import javax.ws.rs.core.Response;
+
+import static javax.ws.rs.core.Response.Status.OK;
 import static pl.allegro.tech.hermes.integration.env.SharedServices.services;
 
 public class IntegrationTest extends HermesIntegrationEnvironment {
+
+    private static final Logger logger = LoggerFactory.getLogger(IntegrationTest.class);
 
     protected HermesEndpoints management;
 
@@ -30,7 +37,7 @@ public class IntegrationTest extends HermesIntegrationEnvironment {
         this.publisher = new HermesPublisher(FRONTEND_URL);
         this.brokerOperations = new BrokerOperations(
                 ImmutableMap.of(PRIMARY_KAFKA_CLUSTER_NAME, PRIMARY_ZK_KAFKA_CONNECT,
-                                SECONDARY_KAFKA_CLUSTER_NAME, SECONDARY_ZK_KAFKA_CONNECT),
+                        SECONDARY_KAFKA_CLUSTER_NAME, SECONDARY_ZK_KAFKA_CONNECT),
                 CONFIG_FACTORY);
         this.wait = new Waiter(management, services().zookeeper(), brokerOperations, PRIMARY_KAFKA_CLUSTER_NAME, KAFKA_NAMESPACE);
         this.operations = new HermesAPIOperations(management, wait);
@@ -38,7 +45,35 @@ public class IntegrationTest extends HermesIntegrationEnvironment {
 
     @AfterMethod
     public void after() {
-        management.query().querySubscriptions("{\"query\": {}}").forEach(sub ->
-                management.subscription().remove(sub.getQualifiedTopicName(), sub.getName()));
+        try {
+            removeSubscriptions();
+            removeTopics();
+        } catch (RuntimeException e) {
+            logger.error("Error while removing topics and subscriptions", e);
+        }
+    }
+
+    private void removeSubscriptions() {
+        management.query().querySubscriptions("{\"query\": {}}").forEach(sub -> {
+            Response response = management.subscription().remove(sub.getQualifiedTopicName(), sub.getName());
+            if (response.getStatus() == OK.getStatusCode()) {
+                wait.untilSubscriptionRemoved(sub);
+            } else {
+                logger.warn("Could not remove subscription {}. Received {} http status. Reason {}",
+                        sub.getQualifiedName().getQualifiedName(), response.getStatus(), response.readEntity(String.class));
+            }
+        });
+    }
+
+    private void removeTopics() {
+        management.query().queryTopics("{\"query\": {}}").forEach(topic -> {
+            Response response = management.topic().remove(topic.getQualifiedName());
+            if (response.getStatus() == OK.getStatusCode()) {
+                wait.untilTopicRemoved(topic);
+            } else {
+                logger.warn("Could not remove topic {}. Received {} http status. Reason {}",
+                        topic.getQualifiedName(), response.getStatus(), response.readEntity(String.class));
+            }
+        });
     }
 }

--- a/integration/src/integration/java/pl/allegro/tech/hermes/integration/JmsConsumingTest.java
+++ b/integration/src/integration/java/pl/allegro/tech/hermes/integration/JmsConsumingTest.java
@@ -18,6 +18,7 @@ import java.util.UUID;
 
 import static pl.allegro.tech.hermes.integration.helper.ClientBuilderHelper.createRequestWithTraceHeaders;
 import static pl.allegro.tech.hermes.integration.test.HermesAssertions.assertThat;
+import static pl.allegro.tech.hermes.test.helper.builder.TopicBuilder.randomTopic;
 
 public class JmsConsumingTest extends IntegrationTest {
 
@@ -33,7 +34,7 @@ public class JmsConsumingTest extends IntegrationTest {
     @Test
     public void shouldConsumeMessageOnJMSEndpoint() {
         // given
-        Topic topic = operations.buildTopic("publishJmsGroup", "topic");
+        Topic topic = operations.buildTopic(randomTopic("publishJmsGroup", "topic").build());
         operations.createSubscription(topic, "subscription", jmsEndpointAddress(JMS_TOPIC_NAME));
         jmsEndpoint.expectMessages(TestMessage.of("hello", "world"));
 
@@ -45,14 +46,14 @@ public class JmsConsumingTest extends IntegrationTest {
     }
 
     @Test
-    public void shouldPublishAndConsumeJmsMessageWithTraceId() throws Exception {
+    public void shouldPublishAndConsumeJmsMessageWithTraceId() {
 
         // given
         String message = "{\"hello\": \"world\"}";
         String traceId = UUID.randomUUID().toString();
 
         // and
-        Topic topic = operations.buildTopic("publishJmsGroupWithTrace", "topic");
+        Topic topic = operations.buildTopic(randomTopic("publishJmsGroupWithTrace", "topic").build());
         operations.createSubscription(topic, "subscription", jmsEndpointAddress(JMS_TOPIC_NAME));
         WebTarget client = ClientBuilder.newClient().target(FRONTEND_URL).path("topics").path(topic.getQualifiedName());
         jmsEndpoint.expectMessages(TestMessage.of("hello", "world"));
@@ -69,14 +70,14 @@ public class JmsConsumingTest extends IntegrationTest {
     }
 
     @Test
-    public void shouldPublishAndConsumeJmsMessageWithTraceHeaders() throws Exception {
+    public void shouldPublishAndConsumeJmsMessageWithTraceHeaders() {
 
         // given
         String message = "{\"hello\": \"world\"}";
         TraceContext trace = TraceContext.random();
 
         // and
-        Topic topic = operations.buildTopic("publishJmsGroupWithTrace", "topic");
+        Topic topic = operations.buildTopic(randomTopic("publishJmsGroupWithTrace", "topic").build());
         operations.createSubscription(topic, "subscription", jmsEndpointAddress(JMS_TOPIC_NAME));
         jmsEndpoint.expectMessages(TestMessage.of("hello", "world"));
         Invocation.Builder request = createRequestWithTraceHeaders(FRONTEND_URL, topic.getQualifiedName(), trace);;

--- a/integration/src/integration/java/pl/allegro/tech/hermes/integration/KafkaRetransmissionServiceTest.java
+++ b/integration/src/integration/java/pl/allegro/tech/hermes/integration/KafkaRetransmissionServiceTest.java
@@ -2,8 +2,6 @@ package pl.allegro.tech.hermes.integration;
 
 import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.Multimaps;
-import org.testng.annotations.AfterClass;
-import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 import pl.allegro.tech.hermes.api.ContentType;
@@ -11,12 +9,8 @@ import pl.allegro.tech.hermes.api.PatchData;
 import pl.allegro.tech.hermes.api.Subscription;
 import pl.allegro.tech.hermes.api.Topic;
 import pl.allegro.tech.hermes.common.kafka.offset.PartitionOffset;
-import pl.allegro.tech.hermes.integration.env.ManagementStarter;
-import pl.allegro.tech.hermes.integration.helper.Waiter;
 import pl.allegro.tech.hermes.management.infrastructure.kafka.MultiDCOffsetChangeSummary;
 import pl.allegro.tech.hermes.test.helper.avro.AvroUser;
-import pl.allegro.tech.hermes.test.helper.endpoint.HermesAPIOperations;
-import pl.allegro.tech.hermes.test.helper.endpoint.HermesEndpoints;
 import pl.allegro.tech.hermes.test.helper.endpoint.RemoteServiceEndpoint;
 import pl.allegro.tech.hermes.test.helper.message.TestMessage;
 
@@ -41,27 +35,9 @@ public class KafkaRetransmissionServiceTest extends IntegrationTest {
     private final AvroUser user = new AvroUser();
     private Clock clock = Clock.systemDefaultZone();
 
-    private static String RETRANSMISSION_ENV = "retransmission";
-    private static int MANAGEMENT_PORT = 18083;
-    private static String MANAGEMENT_ENDPOINT_URL = "http://localhost:" + MANAGEMENT_PORT + "/";
-
-    private ManagementStarter managementStarter;
-    private HermesEndpoints management;
-    private HermesAPIOperations operations;
-    private Waiter wait;
-
     @BeforeMethod
     public void initializeAlways() {
         remoteService = new RemoteServiceEndpoint(services().serviceMock());
-    }
-
-    @BeforeClass
-    void beforeClass() throws Exception {
-        managementStarter = new ManagementStarter(MANAGEMENT_PORT, RETRANSMISSION_ENV);
-        managementStarter.start();
-        management = new HermesEndpoints(MANAGEMENT_ENDPOINT_URL, CONSUMER_ENDPOINT_URL);
-        wait = new Waiter(management, services().zookeeper(), brokerOperations, PRIMARY_KAFKA_CLUSTER_NAME, KAFKA_NAMESPACE);
-        operations = new HermesAPIOperations(management, wait);
     }
 
     @Test
@@ -161,11 +137,6 @@ public class KafkaRetransmissionServiceTest extends IntegrationTest {
 
         assertThat(offsets.jsonPartitionOffsets.stream().collect(summingLong(PartitionOffset::getOffset))).isEqualTo(1);
         assertThat(offsets.avroPartitionOffsets.stream().collect(summingLong(PartitionOffset::getOffset))).isEqualTo(0);
-    }
-
-    @AfterClass
-    public void afterClass() throws Exception {
-        managementStarter.stop();
     }
 
     private void sendAvroMessageOnTopic(Topic topic, TestMessage message) {

--- a/integration/src/integration/java/pl/allegro/tech/hermes/integration/MetricsTest.java
+++ b/integration/src/integration/java/pl/allegro/tech/hermes/integration/MetricsTest.java
@@ -102,16 +102,15 @@ public class MetricsTest extends IntegrationTest {
     @Test
     public void shouldNotCreateNewSubscriptionWhenAskedForNonExistingMetrics() {
         // given
-        TopicName topic = new TopicName("pl.group.sub.bug", "topic");
-        operations.buildTopic(topic.getGroupName(), topic.getName());
+        Topic topic = operations.buildTopic(randomTopic("pl.group.sub.bug", "topic").build());
         String randomSubscription = UUID.randomUUID().toString();
 
         // when
         catchException(management.subscription())
-                .getMetrics(topic.qualifiedName(), randomSubscription);
+                .getMetrics(topic.getQualifiedName(), randomSubscription);
 
         // then
-        assertThat(management.subscription().list(topic.qualifiedName(), false)).doesNotContain(randomSubscription);
+        assertThat(management.subscription().list(topic.getQualifiedName(), false)).doesNotContain(randomSubscription);
         assertThat(CatchException.<BadRequestException>caughtException())
                 .isInstanceOf(BadRequestException.class);
     }

--- a/integration/src/integration/java/pl/allegro/tech/hermes/integration/PublishingTest.java
+++ b/integration/src/integration/java/pl/allegro/tech/hermes/integration/PublishingTest.java
@@ -41,7 +41,7 @@ import static pl.allegro.tech.hermes.api.SubscriptionPolicy.Builder.subscription
 import static pl.allegro.tech.hermes.integration.helper.ClientBuilderHelper.createRequestWithTraceHeaders;
 import static pl.allegro.tech.hermes.integration.test.HermesAssertions.assertThat;
 import static pl.allegro.tech.hermes.test.helper.builder.SubscriptionBuilder.subscription;
-import static pl.allegro.tech.hermes.test.helper.builder.TopicBuilder.topic;
+import static pl.allegro.tech.hermes.test.helper.builder.TopicBuilder.randomTopic;
 
 public class PublishingTest extends IntegrationTest {
 
@@ -55,7 +55,7 @@ public class PublishingTest extends IntegrationTest {
     @Test
     public void shouldPublishAndConsumeMessage() {
         // given
-        Topic topic = operations.buildTopic("publishAndConsumeGroup", "topic");
+        Topic topic = operations.buildTopic(randomTopic("publishAndConsumeGroup", "topic").build());
         operations.createSubscription(topic, "subscription", HTTP_ENDPOINT_URL);
 
         TestMessage message = TestMessage.of("hello", "world");
@@ -72,7 +72,7 @@ public class PublishingTest extends IntegrationTest {
     @Test
     public void shouldReturn429ForQuotaViolation() {
         // given
-        Topic topic = operations.buildTopic("publishAndConsumeGroup", "topic");
+        Topic topic = operations.buildTopic(randomTopic("publishAndConsumeGroup", "topic").build());
 
         // Frontend is configured in integration test suite to block publisher after 50_000 kb/sec
         TestMessage message = TestMessage.of("content", StringUtils.repeat("X", 60_000));
@@ -89,7 +89,7 @@ public class PublishingTest extends IntegrationTest {
     @Test
     public void shouldReturn4xxForTooLargeContent() {
         // given
-        Topic topic = operations.buildTopic(topic("largeContent", "topic").withMaxMessageSize(2048).build());
+        Topic topic = operations.buildTopic(randomTopic("largeContent", "topic").withMaxMessageSize(2048).build());
 
         // when
         Response response = publisher.publish(topic.getQualifiedName(), StringUtils.repeat("X", 2555));
@@ -101,14 +101,14 @@ public class PublishingTest extends IntegrationTest {
     @Test
     public void shouldMarkSubscriptionAsActiveAfterReceivingFirstMessage() {
         // given
-        Topic topic = operations.buildTopic("markAsActiveGroup", "topic");
+        Topic topic = operations.buildTopic(randomTopic("markAsActiveGroup", "topic").build());
         operations.createSubscription(topic, "subscription", HTTP_ENDPOINT_URL);
 
         TestMessage message = TestMessage.of("hello", "world");
         remoteService.expectMessages(message.body());
 
         // when
-        Response r = publisher.publish("markAsActiveGroup.topic", message.body());
+        Response r = publisher.publish(topic.getQualifiedName(), message.body());
         assertThat(r).hasStatus(Response.Status.CREATED);
 
         // then
@@ -121,7 +121,7 @@ public class PublishingTest extends IntegrationTest {
         // given
         String subscription = "publishingTestSubscription";
 
-        Topic topic = operations.buildTopic("publishSuspendedGroup", "publishingTestTopic");
+        Topic topic = operations.buildTopic(randomTopic("publishSuspendedGroup", "publishingTestTopic").build());
         operations.createSubscription(topic, subscription, HTTP_ENDPOINT_URL);
         wait.untilSubscriptionIsActivated(topic, subscription);
         operations.suspendSubscription(topic, subscription);
@@ -138,7 +138,7 @@ public class PublishingTest extends IntegrationTest {
     @Test
     public void shouldConsumeMessagesOnMultipleSubscriptions() {
         // given
-        Topic topic = operations.buildTopic("publishMultipleGroup", "topic");
+        Topic topic = operations.buildTopic(randomTopic("publishMultipleGroup", "topic").build());
         operations.createSubscription(topic, "subscription1", HTTP_ENDPOINT_URL + "1/");
         operations.createSubscription(topic, "subscription2", HTTP_ENDPOINT_URL + "2/");
 
@@ -160,7 +160,7 @@ public class PublishingTest extends IntegrationTest {
     @Test
     public void shouldPublishMessageToEndpointWithInterpolatedURI() {
         // given
-        Topic topic = operations.buildTopic("publishInterpolatedGroup", "topic");
+        Topic topic = operations.buildTopic(randomTopic("publishInterpolatedGroup", "topic").build());
         operations.createSubscription(topic, "subscription", HTTP_ENDPOINT_URL + "{template}/");
 
         TestMessage message = TestMessage.of("template", "hello");
@@ -178,7 +178,7 @@ public class PublishingTest extends IntegrationTest {
     @Test
     public void shouldTreatMessageWithInvalidInterpolationAsUndelivered() {
         // given
-        Topic topic = operations.buildTopic("publishInvalidInterpolatedGroup", "topic");
+        Topic topic = operations.buildTopic(randomTopic("publishInvalidInterpolatedGroup", "topic").build());
         Subscription subscription = subscription(topic, "subscription")
                 .withEndpoint(EndpointAddress.of(HTTP_ENDPOINT_URL + "{template}/"))
                 .withSubscriptionPolicy(
@@ -194,7 +194,7 @@ public class PublishingTest extends IntegrationTest {
 
         // then
         wait.until(() -> {
-            long discarded = management.subscription().getMetrics("publishInvalidInterpolatedGroup.topic", "subscription").getDiscarded();
+            long discarded = management.subscription().getMetrics(topic.getQualifiedName(), "subscription").getDiscarded();
             assertThat(discarded).isEqualTo(1);
         });
         interpolatedEndpoint.makeSureNoneReceived();
@@ -203,7 +203,7 @@ public class PublishingTest extends IntegrationTest {
     @Test
     public void shouldNotPublishMessageIfContentLengthDoNotMatch() throws IOException, InterruptedException {
         // given
-        Topic topic = operations.buildTopic("invalidContentType", "topic");
+        Topic topic = operations.buildTopic(randomTopic("invalidContentType", "topic").build());
         operations.createSubscription(topic, "subscription", HTTP_ENDPOINT_URL);
 
         // when
@@ -232,7 +232,7 @@ public class PublishingTest extends IntegrationTest {
     @Test
     public void shouldPublishMessageUsingChunkedEncoding() throws UnsupportedEncodingException {
         // given
-        Topic topic = operations.buildTopic("chunked", "topic");
+        Topic topic = operations.buildTopic(randomTopic("chunked", "topic").build());
 
         // when
         Response response = newClient(new ClientConfig().property(REQUEST_ENTITY_PROCESSING, CHUNKED))
@@ -266,7 +266,7 @@ public class PublishingTest extends IntegrationTest {
         String traceId = UUID.randomUUID().toString();
 
         // and
-        Topic topic = operations.buildTopic("traceSendAndReceiveGroup", "topic");
+        Topic topic = operations.buildTopic(randomTopic("traceSendAndReceiveGroup", "topic").build());
         operations.createSubscription(topic, "subscription", HTTP_ENDPOINT_URL);
         remoteService.expectMessages(message);
         WebTarget client = ClientBuilder.newClient().target(FRONTEND_URL).path("topics").path(topic.getQualifiedName());
@@ -290,7 +290,7 @@ public class PublishingTest extends IntegrationTest {
         TraceContext trace = TraceContext.random();
 
         // and
-        Topic topic = operations.buildTopic("traceSendAndReceiveGroup", "topic2");
+        Topic topic = operations.buildTopic(randomTopic("traceSendAndReceiveGroup", "topic2").build());
         operations.createSubscription(topic, "subscription", HTTP_ENDPOINT_URL);
         remoteService.expectMessages(message);
         Invocation.Builder request = createRequestWithTraceHeaders(FRONTEND_URL, topic.getQualifiedName(), trace);
@@ -311,7 +311,7 @@ public class PublishingTest extends IntegrationTest {
         remoteService.retryMessage(message, retryAfterSeconds);
 
         // and
-        Topic topic = operations.buildTopic("retryAfterTopic", "topic");
+        Topic topic = operations.buildTopic(randomTopic("retryAfterTopic", "topic").build());
         operations.createSubscription(topic, "subscription", HTTP_ENDPOINT_URL);
 
         // when
@@ -329,7 +329,7 @@ public class PublishingTest extends IntegrationTest {
     public void shouldPassSubscriptionHeaders() {
         // given
         String message = "abcd";
-        Topic topic = operations.buildTopic("headersTestGroup", "topic");
+        Topic topic = operations.buildTopic(randomTopic("headersTestGroup", "topic").build());
 
         Subscription subscription = SubscriptionBuilder.subscription(topic, "subscription")
                 .withEndpoint(HTTP_ENDPOINT_URL)
@@ -353,7 +353,7 @@ public class PublishingTest extends IntegrationTest {
     public void shouldNotOverrideHeadersAddedByMetadataAppendersWithSubscriptionHeaders() {
         // given
         String message = "abcd";
-        Topic topic = operations.buildTopic("headersAndTracesTestGroup", "topic");
+        Topic topic = operations.buildTopic(randomTopic("headersAndTracesTestGroup", "topic").build());
 
         Subscription subscription = SubscriptionBuilder.subscription(topic, "subscription")
                 .withEndpoint(HTTP_ENDPOINT_URL)
@@ -378,7 +378,7 @@ public class PublishingTest extends IntegrationTest {
     public void shouldPublishWithDelayAndConsumeMessage() {
         // given
         int delay = 2000;
-        Topic topic = operations.buildTopic("publishWithDelay", "topic");
+        Topic topic = operations.buildTopic(randomTopic("publishWithDelay", "topic").build());
         Subscription subscriptionWithDelay = subscription(topic, "subscription")
                 .withEndpoint(HTTP_ENDPOINT_URL)
                 .withContentType(ContentType.JSON)
@@ -407,7 +407,7 @@ public class PublishingTest extends IntegrationTest {
     public void shouldAttachSubscriptionIdentityHeadersWhenItIsEnabled() {
         // given
         String message = "abcd";
-        Topic topic = operations.buildTopic("deliverWithSubscriptionIdentityHeaders", "topic");
+        Topic topic = operations.buildTopic(randomTopic("deliverWithSubscriptionIdentityHeaders", "topic").build());
         Subscription subscription = SubscriptionBuilder.subscription(topic, "subscription")
                 .withEndpoint(HTTP_ENDPOINT_URL)
                 .withAttachingIdentityHeadersEnabled(true)
@@ -420,7 +420,7 @@ public class PublishingTest extends IntegrationTest {
 
         // then
         remoteService.waitUntilRequestReceived(request -> {
-            assertThat(request.getHeader("Hermes-Topic-Name")).isEqualTo("deliverWithSubscriptionIdentityHeaders.topic");
+            assertThat(request.getHeader("Hermes-Topic-Name")).isEqualTo(topic.getQualifiedName());
             assertThat(request.getHeader("Hermes-Subscription-Name")).isEqualTo("subscription");
         });
     }
@@ -429,7 +429,7 @@ public class PublishingTest extends IntegrationTest {
     public void shouldNotAttachSubscriptionIdentityHeadersWhenItIsDisabled() {
         // given
         String message = "abcd";
-        Topic topic = operations.buildTopic("deliverWithoutSubscriptionIdentityHeaders", "topic");
+        Topic topic = operations.buildTopic(randomTopic("deliverWithoutSubscriptionIdentityHeaders", "topic").build());
         Subscription subscription = SubscriptionBuilder.subscription(topic, "subscription")
                 .withEndpoint(HTTP_ENDPOINT_URL)
                 .withAttachingIdentityHeadersEnabled(false)

--- a/integration/src/integration/java/pl/allegro/tech/hermes/integration/PublishingTimeoutTest.java
+++ b/integration/src/integration/java/pl/allegro/tech/hermes/integration/PublishingTimeoutTest.java
@@ -1,14 +1,17 @@
 package pl.allegro.tech.hermes.integration;
 
 import com.googlecode.catchexception.CatchException;
+import org.slf4j.LoggerFactory;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
+import pl.allegro.tech.hermes.api.Topic;
 import pl.allegro.tech.hermes.integration.client.SlowClient;
 
 import java.io.IOException;
 
 import static com.googlecode.catchexception.CatchException.catchException;
 import static org.assertj.core.api.Assertions.assertThat;
+import static pl.allegro.tech.hermes.test.helper.builder.TopicBuilder.randomTopic;
 
 public class PublishingTimeoutTest extends IntegrationTest {
 
@@ -22,7 +25,7 @@ public class PublishingTimeoutTest extends IntegrationTest {
     @Test
     public void shouldHandleRequestTimeout() throws IOException, InterruptedException {
         // given
-        operations.buildTopic("timeoutGroup", "timeoutTopic");
+        Topic topic = operations.buildTopic(randomTopic("timeoutGroup", "timeoutTopic").build());
         int clientTimeout = 5000;
         int pauseTimeBetweenChunks = 300;
         int delayBeforeSendingFirstData = 0;
@@ -30,7 +33,7 @@ public class PublishingTimeoutTest extends IntegrationTest {
         // when
         long start = System.currentTimeMillis();
         String response = client.slowEvent(
-            clientTimeout, pauseTimeBetweenChunks, delayBeforeSendingFirstData, "timeoutGroup.timeoutTopic"
+            clientTimeout, pauseTimeBetweenChunks, delayBeforeSendingFirstData, topic.getQualifiedName()
         );
         long elapsed = System.currentTimeMillis() - start;
 
@@ -42,24 +45,25 @@ public class PublishingTimeoutTest extends IntegrationTest {
     @Test
     public void shouldCloseConnectionAfterSendingDelayData() throws IOException, InterruptedException {
         //given
-        operations.buildTopic("timeoutGroup", "closeConnectionTopic");
+        Topic topic = operations.buildTopic(randomTopic("timeoutGroup", "closeConnectionTopic").build());
         int clientTimeout = 5000;
         int pauseTimeBetweenChunks = 0;
         int delayBeforeSendingFirstData = 3000;
 
         //when
         catchException(client).slowEvent(
-            clientTimeout, pauseTimeBetweenChunks, delayBeforeSendingFirstData, "timeoutGroup.closeConnectionTopic"
+            clientTimeout, pauseTimeBetweenChunks, delayBeforeSendingFirstData, topic.getQualifiedName()
         );
 
         //then
+        LoggerFactory.getLogger(PublishingTimeoutTest.class).error("Caught exception", CatchException.<Exception>caughtException());
         assertThat(CatchException.<Exception>caughtException()).hasMessageContaining("Broken pipe");
     }
 
     @Test
     public void shouldHandleTimeoutForSlowRequestWithChunkedEncoding() throws IOException, InterruptedException {
         // given
-        operations.buildTopic("slowGroup", "chunkedEncoding");
+        Topic topic = operations.buildTopic(randomTopic("slowGroup", "chunkedEncoding").build());
         int clientTimeout = 5000;
         int pauseTimeBetweenChunks = 300;
         int delayBeforeSendingFirstData = 0;
@@ -68,7 +72,7 @@ public class PublishingTimeoutTest extends IntegrationTest {
         // when
         long start = System.currentTimeMillis();
         String response = client.slowEvent(
-                clientTimeout, pauseTimeBetweenChunks, delayBeforeSendingFirstData, "slowGroup.chunkedEncoding", chunkedEncoding);
+                clientTimeout, pauseTimeBetweenChunks, delayBeforeSendingFirstData, topic.getQualifiedName(), chunkedEncoding);
         long elapsed = System.currentTimeMillis() - start;
 
         // then

--- a/integration/src/integration/java/pl/allegro/tech/hermes/integration/PublishingWithFailoverTest.java
+++ b/integration/src/integration/java/pl/allegro/tech/hermes/integration/PublishingWithFailoverTest.java
@@ -12,6 +12,7 @@ import pl.allegro.tech.hermes.test.helper.message.TestMessage;
 import javax.ws.rs.core.Response;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static pl.allegro.tech.hermes.test.helper.builder.TopicBuilder.randomTopic;
 
 public class PublishingWithFailoverTest extends IntegrationTest {
 
@@ -34,7 +35,7 @@ public class PublishingWithFailoverTest extends IntegrationTest {
         //given
         TestMessage message = TestMessage.of("hello", "world");
 
-        Topic topic = operations.buildTopic("inMemory", "topic");
+        Topic topic = operations.buildTopic(randomTopic("inMemory", "topic").build());
         operations.createSubscription(topic, "subscription", HTTP_ENDPOINT_URL);
         remoteService.expectMessages(message.body(), message.body());
         //we must send first message to a working kafka because producer need to fetch metadata

--- a/integration/src/integration/java/pl/allegro/tech/hermes/integration/UndeliveredLogTest.java
+++ b/integration/src/integration/java/pl/allegro/tech/hermes/integration/UndeliveredLogTest.java
@@ -12,6 +12,7 @@ import static javax.ws.rs.core.Response.Status.Family.SUCCESSFUL;
 import static org.assertj.core.api.Assertions.assertThat;
 import static pl.allegro.tech.hermes.api.SubscriptionPolicy.Builder.subscriptionPolicy;
 import static pl.allegro.tech.hermes.test.helper.builder.SubscriptionBuilder.subscription;
+import static pl.allegro.tech.hermes.test.helper.builder.TopicBuilder.randomTopic;
 
 public class UndeliveredLogTest extends IntegrationTest {
 
@@ -20,7 +21,7 @@ public class UndeliveredLogTest extends IntegrationTest {
     @Test
     public void shouldLogUndeliveredMessage() {
         // given
-        Topic topic = operations.buildTopic("logUndelivered", "topic");
+        Topic topic = operations.buildTopic(randomTopic("logUndelivered", "topic").build());
         Subscription subscription = subscription(topic, "subscription")
                 .withEndpoint(EndpointAddress.of(INVALID_ENDPOINT_URL))
                 .withSubscriptionPolicy(subscriptionPolicy().withRate(1).withMessageTtl(0).build())
@@ -29,11 +30,11 @@ public class UndeliveredLogTest extends IntegrationTest {
         operations.createSubscription(topic, subscription);
 
         // when
-        publisher.publish("logUndelivered.topic", TestMessage.simple().body());
+        publisher.publish(topic.getQualifiedName(), TestMessage.simple().body());
 
         // then
         wait.until(() -> {
-            Response response = management.subscription().getLatestUndeliveredMessage("logUndelivered.topic", "subscription");
+            Response response = management.subscription().getLatestUndeliveredMessage(topic.getQualifiedName(), "subscription");
             assertThat(response.getStatusInfo().getFamily()).isEqualTo(SUCCESSFUL);
         });
     }

--- a/integration/src/integration/java/pl/allegro/tech/hermes/integration/env/HermesIntegrationEnvironment.java
+++ b/integration/src/integration/java/pl/allegro/tech/hermes/integration/env/HermesIntegrationEnvironment.java
@@ -3,6 +3,8 @@ package pl.allegro.tech.hermes.integration.env;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.retry.ExponentialBackoffRetry;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.testng.ITestContext;
 import org.testng.ITestNGMethod;
 import org.testng.annotations.AfterSuite;
@@ -24,6 +26,8 @@ import java.util.Map;
 
 @Listeners({RetryListener.class})
 public class HermesIntegrationEnvironment implements EnvironmentAware {
+
+    private static final Logger logger = LoggerFactory.getLogger(HermesIntegrationEnvironment.class);
 
     private static final Map<Class<?>, Starter<?>> STARTERS = new LinkedHashMap<>();
 
@@ -47,18 +51,23 @@ public class HermesIntegrationEnvironment implements EnvironmentAware {
 
     @BeforeSuite
     public void prepareEnvironment(ITestContext context) throws Exception {
-        for (ITestNGMethod method : context.getAllTestMethods()) {
-            method.setRetryAnalyzer(new Retry());
+        try {
+            for (ITestNGMethod method : context.getAllTestMethods()) {
+                method.setRetryAnalyzer(new Retry());
+            }
+
+            for (Starter<?> starter : STARTERS.values()) {
+                starter.start();
+            }
+
+            this.zookeeper = startZookeeperClient();
+            CuratorFramework kafkaZookeeper = startKafkaZookeeperClient();
+
+            SharedServices.initialize(STARTERS, zookeeper, kafkaZookeeper);
+            logger.info("Environment was prepared");
+        } catch (Exception e) {
+            logger.error("Exception during environment preparation", e);
         }
-
-        for (Starter<?> starter : STARTERS.values()) {
-            starter.start();
-        }
-
-        this.zookeeper = startZookeeperClient();
-        CuratorFramework kafkaZookeeper = startKafkaZookeeperClient();
-
-        SharedServices.initialize(STARTERS, zookeeper, kafkaZookeeper);
     }
 
     private CuratorFramework startZookeeperClient() throws InterruptedException {
@@ -82,13 +91,18 @@ public class HermesIntegrationEnvironment implements EnvironmentAware {
 
     @AfterSuite(alwaysRun = true)
     public void cleanEnvironment() throws Exception {
-        ArrayList<Starter<?>> reversedStarters = new ArrayList<>(STARTERS.values());
-        Collections.reverse(reversedStarters);
+        try {
+            ArrayList<Starter<?>> reversedStarters = new ArrayList<>(STARTERS.values());
+            Collections.reverse(reversedStarters);
 
-        for (Starter<?> starter : reversedStarters) {
-            starter.stop();
+            for (Starter<?> starter : reversedStarters) {
+                starter.stop();
+            }
+            zookeeper.close();
+            logger.info("Environment cleaned");
+        } catch (Exception e) {
+            logger.error("Exception during environment cleaning", e);
         }
-        zookeeper.close();
     }
 
     @Test

--- a/integration/src/test/resources/application-retransmission.yaml
+++ b/integration/src/test/resources/application-retransmission.yaml
@@ -1,8 +1,0 @@
-kafka:
-  clusters:
-    -
-      datacenter: dc
-      clusterName: primary
-      connectionString: localhost:14192/kafka
-      connectionTimeout: 10000
-      namespace: 'itTest'

--- a/integration/src/test/resources/application.yaml
+++ b/integration/src/test/resources/application.yaml
@@ -19,17 +19,12 @@ kafka:
       connectionString: localhost:14192/kafka
       connectionTimeout: 10000
       namespace: 'itTest'
-    -
-      datacenter: dc
-      clusterName: secondary
-      connectionString: localhost:14192/secondaryKafka
-      connectionTimeout: 10000
-      namespace: 'itTest'
 
 topic:
   replicationFactor: 1
   partitions: 2
   allowRemoval: true
+  removeSchema: true
   defaultContentType: AVRO
   touchSchedulerEnabled: false
 
@@ -70,6 +65,7 @@ spring.groovy.template.check-template-location: false
 
 schema.repository:
   type: schema_registry
+  deleteSchemaPathSuffix:
 
 topicOwnerCache:
   refreshRateInSeconds: 300 # 5 minutes

--- a/integration/src/test/resources/logback-test.xml
+++ b/integration/src/test/resources/logback-test.xml
@@ -10,7 +10,12 @@
     <logger name="org.apache.zookeeper" level="warn" />
     <logger name="kafka" level="warn" />
     <logger name="org.apache.kafka.common.network.Selector" level="error"/>
+    <logger name="org.apache.kafka.clients.consumer.internals.ConsumerCoordinator" level="OFF"/>
     <logger name="org.eclipse.jetty.server.HttpChannel" level="error"/>
+    <logger name="pl.allegro.tech.hermes.consumers.supervisor.workload.selective.SelectiveWorkBalancer" level="warn" />
+    <logger name="pl.allegro.tech.hermes.consumers.supervisor.workload.selective.BalancingJob" level="warn" />
+    <logger name="pl.allegro.tech.hermes.consumers.supervisor.workload.selective.ConsumerNodesRegistry" level="warn" />
+    <logger name="pl.allegro.tech.hermes.consumers.consumer.rate.maxrate.MaxRateCalculator" level="warn" />
 
     <logger name="org.mortbay.log" level="info" />
 


### PR DESCRIPTION
Changes: 
* enabled reuse address flag in port randomization ([doc](https://docs.oracle.com/javase/8/docs/api/java/net/ServerSocket.html#setReuseAddress-boolean-)).
* `HierarchicalCacheLevel` removes detected empty nodes. Empty nodes can be created after topic/subscription deletion due to race for example in zookeeper metrics reporter. From now on no more topics/subscriptions leftovers are generated under tree `/groups/{groupName}/topics/{topicName}/subscriptions/{subscriptionName}`
* all topics and subscriptions after each integration test are removed. To do this schema removal had to be enabled.
* fixed integration test related to migration from json to avro by removing secondary zookeeper cluster from `hermes-management` configuration.
* used randomTopic() in integration tests. Thanks to `randomTopic()` test retry has much higher chance to pass.
* handled potential exception in `HermesIntegrationEnvironment.java`

Due to many changes in this PR I recommend to review them by commits.