### PR TITLE
Added check for subscription existence during it’s creation

### DIFF
--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/domain/subscription/SubscriptionAlreadyExistsException.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/domain/subscription/SubscriptionAlreadyExistsException.java
@@ -7,12 +7,20 @@ import pl.allegro.tech.hermes.common.exception.HermesException;
 public class SubscriptionAlreadyExistsException extends HermesException {
 
     public SubscriptionAlreadyExistsException(Subscription subscription, Throwable cause) {
-        super(String.format("Subscription %s for topic %s does not exist.",
-                subscription.getName(), subscription.getQualifiedTopicName()), cause);
+        super(message(subscription), cause);
+    }
+
+    public SubscriptionAlreadyExistsException(Subscription subscription) {
+        super(message(subscription));
     }
 
     @Override
     public ErrorCode getCode() {
         return ErrorCode.SUBSCRIPTION_ALREADY_EXISTS;
+    }
+
+    private static String message(Subscription subscription) {
+        return String.format("Subscription %s for topic %s already exists.",
+                subscription.getName(), subscription.getQualifiedTopicName());
     }
 }

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/domain/subscription/SubscriptionService.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/domain/subscription/SubscriptionService.java
@@ -33,18 +33,18 @@ import pl.allegro.tech.hermes.management.domain.subscription.validator.Subscript
 import pl.allegro.tech.hermes.management.domain.topic.TopicService;
 import pl.allegro.tech.hermes.tracker.management.LogRepository;
 
-import java.util.Collection;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Stream.empty;
 import static java.util.stream.Stream.of;
 import static pl.allegro.tech.hermes.api.SubscriptionHealth.Status;
-import java.util.Set;
 
 @Component
 public class SubscriptionService {

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/domain/subscription/validator/SubscriptionValidator.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/domain/subscription/validator/SubscriptionValidator.java
@@ -3,6 +3,8 @@ package pl.allegro.tech.hermes.management.domain.subscription.validator;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import pl.allegro.tech.hermes.api.Subscription;
+import pl.allegro.tech.hermes.domain.subscription.SubscriptionAlreadyExistsException;
+import pl.allegro.tech.hermes.domain.subscription.SubscriptionRepository;
 import pl.allegro.tech.hermes.management.api.validator.ApiPreconditions;
 import pl.allegro.tech.hermes.management.domain.PermissionDeniedException;
 import pl.allegro.tech.hermes.management.domain.owner.validator.OwnerIdValidator;
@@ -16,16 +18,19 @@ public class SubscriptionValidator {
     private final ApiPreconditions apiPreconditions;
     private final MessageFilterTypeValidator messageFilterTypeValidator;
     private final TopicService topicService;
+    private final SubscriptionRepository subscriptionRepository;
 
     @Autowired
     public SubscriptionValidator(OwnerIdValidator ownerIdValidator,
                                  ApiPreconditions apiPreconditions,
                                  MessageFilterTypeValidator messageFilterTypeValidator,
-                                 TopicService topicService) {
+                                 TopicService topicService,
+                                 SubscriptionRepository subscriptionRepository) {
         this.ownerIdValidator = ownerIdValidator;
         this.apiPreconditions = apiPreconditions;
         this.messageFilterTypeValidator = messageFilterTypeValidator;
         this.topicService = topicService;
+        this.subscriptionRepository = subscriptionRepository;
     }
 
     public void checkCreation(Subscription toCheck, CreatorRights creatorRights) {
@@ -39,12 +44,16 @@ public class SubscriptionValidator {
         if (!creatorRights.allowedToManage(toCheck)) {
             throw new SubscriptionValidationException("Provide an owner that includes you, you would not be able to manage this subscription later");
         }
+        if (subscriptionRepository.subscriptionExists(toCheck.getTopicName(), toCheck.getName())) {
+            throw new SubscriptionAlreadyExistsException(toCheck);
+        }
     }
 
     public void checkModification(Subscription toCheck) {
         apiPreconditions.checkConstraints(toCheck);
         ownerIdValidator.check(toCheck.getOwner());
         messageFilterTypeValidator.check(toCheck, topicService.getTopicDetails(toCheck.getTopicName()));
+        subscriptionRepository.ensureSubscriptionExists(toCheck.getTopicName(), toCheck.getName());
     }
 
 }

--- a/integration/src/integration/java/pl/allegro/tech/hermes/integration/management/SubscriptionManagementTest.java
+++ b/integration/src/integration/java/pl/allegro/tech/hermes/integration/management/SubscriptionManagementTest.java
@@ -83,6 +83,24 @@ public class SubscriptionManagementTest extends IntegrationTest {
     }
 
     @Test
+    public void shouldNotRemoveSubscriptionAfterItsRecreation() {
+        // given
+        Topic topic = operations.buildTopic(randomTopic("subscribeGroup", "topic").build());
+        Subscription subscription = subscription(topic, "sub").build();
+        Response response = management.subscription().create(topic.getQualifiedName(), subscription);
+        assertThat(response).hasStatus(Response.Status.CREATED);
+
+        // when
+        Response errorResponse = management.subscription().create(topic.getQualifiedName(), subscription);
+
+        // then
+        assertThat(errorResponse).hasStatus(Response.Status.BAD_REQUEST);
+        assertThat(
+                management.subscription().get(topic.getQualifiedName(), subscription.getName()).getName()
+        ).isEqualTo("sub");
+    }
+
+    @Test
     public void shouldNotCreateSubscriptionWithoutTopicName() {
         // given
         operations.buildTopic("invalidGroup", "topic");


### PR DESCRIPTION
One of Hermes users discovered that when we click on a `Clone` button on a subscription view, next save copied subscription without changing it’s name then the subscription is removed. The problem is related to rollback policy in `CreateSubscriptionRepositoryCommand`. To solve it I’ve added additional check for subscription existence before `CreateSubscriptionRepositoryCommand` is executed. Topic creation already have this kind of check.