### PR TITLE
#1093 hermes-mock matches content-type header

### DIFF
--- a/hermes-mock/src/main/java/pl/allegro/tech/hermes/mock/HermesMockHelper.java
+++ b/hermes-mock/src/main/java/pl/allegro/tech/hermes/mock/HermesMockHelper.java
@@ -3,6 +3,7 @@ package pl.allegro.tech.hermes.mock;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.tomakehurst.wiremock.WireMockServer;
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
@@ -68,9 +69,9 @@ public class HermesMockHelper {
 
     public void addStub(String topicName, int statusCode, String contentType) {
         wireMockServer.stubFor(post(urlEqualTo("/topics/" + topicName))
+                .withHeader("Content-Type", equalTo(contentType))
                 .willReturn(aResponse()
                         .withStatus(statusCode)
-                        .withHeader("Content-Type", contentType)
                         .withHeader("Hermes-Message-Id", UUID.randomUUID().toString())
                 )
         );

--- a/hermes-mock/src/test/groovy/pl/allegro/tech/hermes/mock/HermesMockAvroTest.groovy
+++ b/hermes-mock/src/test/groovy/pl/allegro/tech/hermes/mock/HermesMockAvroTest.groovy
@@ -44,7 +44,7 @@ class HermesMockAvroTest extends Specification {
         then: "check for any single message on the topic and check for single specific avro message"
             hermes.expect().singleMessageOnTopic(topicName)
             hermes.expect().singleAvroMessageOnTopic(topicName, schema)
-            response.getStatus() == HttpStatus.SC_CREATED
+            response.status == HttpStatus.SC_CREATED
     }
 
     def "should get all messages as avro"() {

--- a/hermes-mock/src/test/groovy/pl/allegro/tech/hermes/mock/HermesMockAvroTest.groovy
+++ b/hermes-mock/src/test/groovy/pl/allegro/tech/hermes/mock/HermesMockAvroTest.groovy
@@ -3,6 +3,7 @@ package pl.allegro.tech.hermes.mock
 import com.fasterxml.jackson.databind.ObjectMapper
 import org.apache.avro.Schema
 import org.apache.avro.reflect.ReflectData
+import org.apache.http.HttpStatus
 import org.junit.ClassRule
 import pl.allegro.tech.hermes.test.helper.avro.AvroUserSchemaLoader
 import pl.allegro.tech.hermes.test.helper.endpoint.HermesPublisher
@@ -10,6 +11,8 @@ import pl.allegro.tech.hermes.test.helper.util.Ports
 import spock.lang.Shared
 import spock.lang.Specification
 import tech.allegro.schema.json2avro.converter.JsonAvroConverter
+
+import javax.ws.rs.core.Response
 
 class HermesMockAvroTest extends Specification {
 
@@ -36,11 +39,12 @@ class HermesMockAvroTest extends Specification {
             hermes.define().avroTopic(topicName)
 
         when:
-            publish(topicName)
+            def response = publish(topicName)
 
         then: "check for any single message on the topic and check for single specific avro message"
             hermes.expect().singleMessageOnTopic(topicName)
             hermes.expect().singleAvroMessageOnTopic(topicName, schema)
+            response.getStatus() == HttpStatus.SC_CREATED
     }
 
     def "should get all messages as avro"() {

--- a/hermes-mock/src/test/groovy/pl/allegro/tech/hermes/mock/HermesMockTest.groovy
+++ b/hermes-mock/src/test/groovy/pl/allegro/tech/hermes/mock/HermesMockTest.groovy
@@ -1,10 +1,13 @@
 package pl.allegro.tech.hermes.mock
 
+import org.apache.http.HttpStatus
 import org.junit.ClassRule
 import pl.allegro.tech.hermes.test.helper.endpoint.HermesPublisher
 import pl.allegro.tech.hermes.test.helper.util.Ports
 import spock.lang.Shared
 import spock.lang.Specification
+
+import javax.ws.rs.core.Response
 
 class HermesMockTest extends Specification {
 
@@ -27,10 +30,11 @@ class HermesMockTest extends Specification {
             hermes.define().jsonTopic(topicName)
 
         when:
-            publish(topicName)
+            def response = publish(topicName)
 
         then:
             hermes.expect().singleMessageOnTopic(topicName)
+            response.status == HttpStatus.SC_CREATED
     }
 
     def "should receive 3 messages"() {


### PR DESCRIPTION
I found that response from `wireMockServer.stubFor` was never verified in test, so I also added status code verification to base tests in `HermesMockAvroTest` and `HermesMockTest`.
This was mostly done to ensure that `WireMock` still matches request after addition of `.withHeader("Content-Type", equalTo(contentType))`.