### PR TITLE
resolves #1116 | Add sorting by name and search for constraints UI

### DIFF
--- a/hermes-console/static/partials/constraints.html
+++ b/hermes-console/static/partials/constraints.html
@@ -5,7 +5,11 @@
     <div class="row">
         <div class="list-group">
             <div class="list-group-item">
-                <div class="pull-right">
+                <div class="form-inline pull-right">
+                    <div class="input-group">
+                        <span class="input-group-addon"><span class="glyphicon glyphicon-search"></span></span>
+                        <input class="form-control" ng-model="search.topicName" placeholder="search...">
+                    </div>
                     <button class="btn btn-primary" ng-click="addTopicConstraints()">
                         <span class="glyphicon glyphicon-plus"></span>
                     </button>
@@ -14,7 +18,7 @@
                     Topic constraints
                 </h4>
             </div>
-            <a class="list-group-item" ng-repeat="item in topicConstraints" ng-click="edit(item)">
+            <a class="list-group-item" ng-repeat="item in topicConstraints | filter:search:strict | orderBy:'topicName'" ng-click="edit(item)">
                 <small>{{$index + 1}}</small>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
                 <strong>{{item.topicName}}</strong>
                 <div class="pull-right">
@@ -28,7 +32,11 @@
     <div class="row">
         <div class="list-group">
             <div class="list-group-item">
-                <div class="pull-right">
+                <div class="form-inline pull-right">
+                    <div class="input-group">
+                        <span class="input-group-addon"><span class="glyphicon glyphicon-search"></span></span>
+                        <input class="form-control" ng-model="search.subscriptionName" placeholder="search...">
+                    </div>
                     <button class="btn btn-primary" ng-click="addSubscriptionConstraints()">
                         <span class="glyphicon glyphicon-plus"></span>
                     </button>
@@ -37,7 +45,7 @@
                     Subscription constraints
                 </h4>
             </div>
-            <a class="list-group-item" ng-repeat="item in subscriptionConstraints" ng-click="edit(item)">
+            <a class="list-group-item" ng-repeat="item in subscriptionConstraints | filter:search:strict | orderBy:'subscriptionName'" ng-click="edit(item)">
                 <small>{{$index + 1}}</small>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
                 <strong>{{item.subscriptionName}}</strong>
                 <div class="pull-right">


### PR DESCRIPTION
- [x] alphabetical order of entries displayed
- [ ] link to the exact topic/subscription on each constraint
- [x] filter/search box

Adding link to the exact topic/subscription is impossible as the whole row acts as a trigger for modal. For now the only solution is to wrap topic/subscription name with a link, but I think it would be not intuitive.

If you still want this behavior I can update PR.