### PR TITLE
[DO NOT REVIEW] Make tests independent

### DIFF
--- a/hermes-common/src/test/groovy/pl/allegro/tech/hermes/infrastructure/logback/AggregatingTurboFilterTest.groovy
+++ b/hermes-common/src/test/groovy/pl/allegro/tech/hermes/infrastructure/logback/AggregatingTurboFilterTest.groovy
@@ -19,7 +19,7 @@ class AggregatingTurboFilterTest extends Specification {
 
     def "should pass through messages from loggers without aggregation enabled"() {
         given:
-        def filter = createFilter("some-aggregated-logger")
+        def filter = createFilter("some-aggregated-logger-1")
         def notAggregatedLogger = getLogger("not-aggregated")
 
         when:
@@ -31,11 +31,11 @@ class AggregatingTurboFilterTest extends Specification {
 
     def "should report aggregated messages for configured logger"() {
         given:
-        def filter = createFilter("some-aggregated-logger")
+        def filter = createFilter("some-aggregated-logger-2")
         filter.reportingIntervalMillis = 50
         filter.start()
 
-        def aggregatedLogger = getLogger("some-aggregated-logger")
+        def aggregatedLogger = getLogger("some-aggregated-logger-2")
         def appenderCalled = new BlockingVariable<Boolean>(200, TimeUnit.MILLISECONDS)
         LoggingEvent capturedEvent = null
 
@@ -64,12 +64,12 @@ class AggregatingTurboFilterTest extends Specification {
 
     def "should report aggregated messages grouping by params"() {
         given:
-        def filter = createFilter("some-aggregated-logger")
+        def filter = createFilter("some-aggregated-logger-3")
         filter.reportingIntervalMillis = 50
         filter.start()
 
         def appender = Mock(Appender)
-        def aggregatedLogger = getLogger("some-aggregated-logger")
+        def aggregatedLogger = getLogger("some-aggregated-logger-3")
         aggregatedLogger.addAppender(appender)
         List<LoggingEvent> capturedEvents = []
 
@@ -94,10 +94,10 @@ class AggregatingTurboFilterTest extends Specification {
 
     def "should log aggregates with the same log level as original messages"() {
         given:
-        def filter = createFilter("some-aggregated-logger")
+        def filter = createFilter("some-aggregated-logger-4")
 
         def appender = Mock(Appender)
-        def aggregatedLogger = getLogger("some-aggregated-logger")
+        def aggregatedLogger = getLogger("some-aggregated-logger-4")
         aggregatedLogger.addAppender(appender)
         List<LoggingEvent> capturedEvents = []
 
@@ -119,10 +119,10 @@ class AggregatingTurboFilterTest extends Specification {
 
     def "should log aggregates with the same marker as for original messages"() {
         given:
-        def filter = createFilter("some-aggregated-logger")
+        def filter = createFilter("some-aggregated-logger-5")
 
         def appender = Mock(Appender)
-        def aggregatedLogger = getLogger("some-aggregated-logger")
+        def aggregatedLogger = getLogger("some-aggregated-logger-5")
         aggregatedLogger.addAppender(appender)
         List<LoggingEvent> capturedEvents = []
         def myMarker = MarkerFactory.getMarker("abc")
@@ -145,9 +145,9 @@ class AggregatingTurboFilterTest extends Specification {
 
     def "should log last exception"() {
         given:
-        def filter = createFilter("some-aggregated-logger")
+        def filter = createFilter("some-aggregated-logger-6")
 
-        def aggregatedLogger = getLogger("some-aggregated-logger")
+        def aggregatedLogger = getLogger("some-aggregated-logger-6")
         def appender = Mock(Appender)
         aggregatedLogger.addAppender(appender)
 
@@ -169,9 +169,9 @@ class AggregatingTurboFilterTest extends Specification {
 
     def "should not report when there are no more logs"() {
         given:
-        def filter = createFilter("some-aggregated-logger")
+        def filter = createFilter("some-aggregated-logger-7")
 
-        def aggregatedLogger = getLogger("some-aggregated-logger")
+        def aggregatedLogger = getLogger("some-aggregated-logger-7")
         def appender = Mock(Appender)
         aggregatedLogger.addAppender(appender)
 
@@ -196,9 +196,9 @@ class AggregatingTurboFilterTest extends Specification {
 
     def "should create aggregates properly when last param is an exception"() {
         given:
-        def filter = createFilter("some-aggregated-logger")
+        def filter = createFilter("some-aggregated-logger-8")
 
-        def aggregatedLogger = getLogger("some-aggregated-logger")
+        def aggregatedLogger = getLogger("some-aggregated-logger-8")
         def appender = Mock(Appender)
         aggregatedLogger.addAppender(appender)
         List<LoggingEvent> capturedEvents = []
@@ -231,8 +231,8 @@ class AggregatingTurboFilterTest extends Specification {
         def logsPerThread = 1_000
         def executor = Executors.newFixedThreadPool(threadsCount)
 
-        def filter = createFilter("some-aggregated-logger")
-        def aggregatedLogger = getLogger("some-aggregated-logger")
+        def filter = createFilter("some-aggregated-logger-9")
+        def aggregatedLogger = getLogger("some-aggregated-logger-9")
         def appender = Mock(Appender)
         aggregatedLogger.addAppender(appender)
 
@@ -269,11 +269,11 @@ class AggregatingTurboFilterTest extends Specification {
         def logsPerThread = 10_000
         def executor = Executors.newFixedThreadPool(threadsCount)
 
-        def filter = createFilter("some-aggregated-logger")
+        def filter = createFilter("some-aggregated-logger-10")
         filter.setReportingIntervalMillis(10) // small reporting interval
         filter.start()
 
-        def aggregatedLogger = getLogger("some-aggregated-logger")
+        def aggregatedLogger = getLogger("some-aggregated-logger-10")
         def appender = [doAppend: { LoggingEvent event ->
             loggerCalls.incrementAndGet()
             def matcher = (event.message =~ countRegexp) // we need to parse the number of occurrences


### PR DESCRIPTION
In some rare builds we can see failures like:

```
pl.allegro.tech.hermes.infrastructure.logback.AggregatingTurboFilterTest > should allow multithreaded access while reporting simultaneously FAILED
    Too many invocations for:

    2 * appender.doAppend(_) >> { LoggingEvent event ->
                capturedEvents << event
            }   (12 invocations)

    Matching invocations (ordered by last occurrence):
```

Probably this is caused by using same name for a logger.

See full build log attached
[log-aggr-log-fail.txt](https://github.com/allegro/hermes/files/3782591/log-aggr-log-fail.txt)
