### PR TITLE
Subscription ids cache removed expire after specified time

### DIFF
--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/common/config/Configs.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/common/config/Configs.java
@@ -236,6 +236,7 @@ public enum Configs {
     CONSUMER_BATCH_CONNECTION_TIMEOUT("consumer.batch.connection.timeout", 500),
     CONSUMER_BATCH_CONNECTION_REQUEST_TIMEOUT("consumer.batch.connection.request.timeout", 500),
     CONSUMER_FILTERING_ENABLED("consumer.filtering.enabled", true),
+    CONSUMER_SUBSCRIPTION_IDS_CACHE_REMOVED_EXPIRE_AFTER_ACCESS_SECONDS("consumer.subscription.ids.cache.removed.expire.after.access.seconds", 60L),
 
     CONSUMER_BACKGROUND_SUPERVISOR_INTERVAL("consumer.supervisor.background.interval", 20_000),
     CONSUMER_BACKGROUND_SUPERVISOR_UNHEALTHY_AFTER("consumer.supervisor.background.unhealty.after", 600_000),

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/subscription/id/NotificationAwareSubscriptionIdsCache.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/subscription/id/NotificationAwareSubscriptionIdsCache.java
@@ -1,5 +1,11 @@
 package pl.allegro.tech.hermes.consumers.subscription.id;
 
+import com.google.common.base.Ticker;
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.RemovalListener;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import pl.allegro.tech.hermes.api.Subscription;
 import pl.allegro.tech.hermes.api.SubscriptionName;
 import pl.allegro.tech.hermes.consumers.subscription.cache.SubscriptionsCache;
@@ -9,21 +15,48 @@ import pl.allegro.tech.hermes.domain.notifications.SubscriptionCallback;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
 
 public class NotificationAwareSubscriptionIdsCache implements SubscriptionIds, SubscriptionCallback {
+
+    private static final Logger logger = LoggerFactory.getLogger(NotificationAwareSubscriptionIdsCache.class);
 
     private final SubscriptionsCache subscriptionsCache;
     private final SubscriptionIdProvider subscriptionIdProvider;
     private final Map<SubscriptionName, SubscriptionId> nameToIdMap = new ConcurrentHashMap<>();
     private final Map<Long, SubscriptionId> valueToIdMap = new ConcurrentHashMap<>();
+    private final Cache<SubscriptionName, SubscriptionId> nameToIdMapOfRemoved;
+    private final Cache<Long, SubscriptionId> valueToIdMapOfRemoved;
 
     public NotificationAwareSubscriptionIdsCache(InternalNotificationsBus notificationsBus,
                                                  SubscriptionsCache subscriptionsCache,
-                                                 SubscriptionIdProvider subscriptionIdProvider) {
+                                                 SubscriptionIdProvider subscriptionIdProvider,
+                                                 long removedSubscriptionsExpireAfterAccessSeconds,
+                                                 Ticker ticker) {
         this.subscriptionsCache = subscriptionsCache;
         this.subscriptionIdProvider = subscriptionIdProvider;
 
+        this.nameToIdMapOfRemoved = createExpiringCache(
+                removedSubscriptionsExpireAfterAccessSeconds, ticker,
+                notification -> logger.info("Removing expired subscription {} id from name->id cache",
+                        notification.getKey().getQualifiedName())
+        );
+
+        this.valueToIdMapOfRemoved = createExpiringCache(
+                removedSubscriptionsExpireAfterAccessSeconds, ticker,
+                notification -> logger.info("Removing expired subscription {} id from value->id cache",
+                        notification.getValue().getSubscriptionName().getQualifiedName())
+        );
+
         notificationsBus.registerSubscriptionCallback(this);
+    }
+
+    private <K, V> Cache<K, V> createExpiringCache(long expireAfterSeconds, Ticker ticker, RemovalListener<K, V> removalListener) {
+        CacheBuilder<K, V> cacheBuilder = CacheBuilder.newBuilder()
+                .expireAfterAccess(expireAfterSeconds, TimeUnit.SECONDS)
+                .ticker(ticker)
+                .removalListener(removalListener);
+        return cacheBuilder.build();
     }
 
     @Override
@@ -40,12 +73,14 @@ public class NotificationAwareSubscriptionIdsCache implements SubscriptionIds, S
 
     @Override
     public Optional<SubscriptionId> getSubscriptionId(SubscriptionName subscriptionName) {
-        return Optional.ofNullable(nameToIdMap.get(subscriptionName));
+        return Optional.ofNullable(Optional.ofNullable(nameToIdMap.get(subscriptionName))
+                .orElseGet(() -> nameToIdMapOfRemoved.getIfPresent(subscriptionName)));
     }
 
     @Override
     public Optional<SubscriptionId> getSubscriptionId(long id) {
-        return Optional.ofNullable(valueToIdMap.get(id));
+        return Optional.ofNullable(Optional.ofNullable(valueToIdMap.get(id))
+                .orElseGet(() -> valueToIdMapOfRemoved.getIfPresent(id)));
     }
 
     @Override
@@ -61,7 +96,11 @@ public class NotificationAwareSubscriptionIdsCache implements SubscriptionIds, S
     @Override
     public void onSubscriptionRemoved(Subscription subscription) {
         Optional.ofNullable(nameToIdMap.remove(subscription.getQualifiedName()))
-                .map(SubscriptionId::getValue)
-                .ifPresent(valueToIdMap::remove);
+                .ifPresent(id -> {
+                    valueToIdMap.remove(id.getValue());
+
+                    nameToIdMapOfRemoved.put(subscription.getQualifiedName(), id);
+                    valueToIdMapOfRemoved.put(id.getValue(), id);
+                });
     }
 }

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/subscription/id/SubscriptionIdsCacheFactory.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/subscription/id/SubscriptionIdsCacheFactory.java
@@ -1,6 +1,9 @@
 package pl.allegro.tech.hermes.consumers.subscription.id;
 
+import com.google.common.base.Ticker;
 import org.glassfish.hk2.api.Factory;
+import pl.allegro.tech.hermes.common.config.ConfigFactory;
+import pl.allegro.tech.hermes.common.config.Configs;
 import pl.allegro.tech.hermes.consumers.subscription.cache.SubscriptionsCache;
 import pl.allegro.tech.hermes.domain.notifications.InternalNotificationsBus;
 
@@ -11,20 +14,25 @@ public class SubscriptionIdsCacheFactory implements Factory<SubscriptionIds> {
     private final InternalNotificationsBus internalNotificationsBus;
     private final SubscriptionsCache subscriptionsCache;
     private final SubscriptionIdProvider subscriptionIdProvider;
+    private final ConfigFactory configFactory;
 
     @Inject
     public SubscriptionIdsCacheFactory(InternalNotificationsBus internalNotificationsBus,
                                        SubscriptionsCache subscriptionsCache,
-                                       SubscriptionIdProvider subscriptionIdProvider) {
+                                       SubscriptionIdProvider subscriptionIdProvider,
+                                       ConfigFactory configFactory) {
         this.internalNotificationsBus = internalNotificationsBus;
         this.subscriptionsCache = subscriptionsCache;
         this.subscriptionIdProvider = subscriptionIdProvider;
+        this.configFactory = configFactory;
     }
 
     @Override
     public SubscriptionIds provide() {
+        long removedSubscriptionsExpireAfterAccessSeconds = configFactory.getLongProperty(Configs.CONSUMER_SUBSCRIPTION_IDS_CACHE_REMOVED_EXPIRE_AFTER_ACCESS_SECONDS);
         NotificationAwareSubscriptionIdsCache cache = new NotificationAwareSubscriptionIdsCache(
-                internalNotificationsBus, subscriptionsCache, subscriptionIdProvider);
+                internalNotificationsBus, subscriptionsCache, subscriptionIdProvider, removedSubscriptionsExpireAfterAccessSeconds, Ticker.systemTicker()
+        );
         cache.start();
         return cache;
     }

--- a/hermes-consumers/src/test/groovy/pl/allegro/tech/hermes/consumers/subscription/id/NotificationAwareSubscriptionIdsCacheTest.groovy
+++ b/hermes-consumers/src/test/groovy/pl/allegro/tech/hermes/consumers/subscription/id/NotificationAwareSubscriptionIdsCacheTest.groovy
@@ -4,9 +4,11 @@ package pl.allegro.tech.hermes.consumers.subscription.id
 import pl.allegro.tech.hermes.api.SubscriptionName
 import pl.allegro.tech.hermes.consumers.subscription.cache.SubscriptionsCache
 import pl.allegro.tech.hermes.domain.notifications.InternalNotificationsBus
+import pl.allegro.tech.hermes.test.helper.cache.FakeTicker
 import spock.lang.Shared
 import spock.lang.Specification
 
+import java.time.Duration
 import java.util.concurrent.atomic.AtomicInteger
 
 import static pl.allegro.tech.hermes.test.helper.builder.SubscriptionBuilder.subscription
@@ -23,8 +25,13 @@ class NotificationAwareSubscriptionIdsCacheTest extends Specification {
 
     NotificationAwareSubscriptionIdsCache subscriptionIds
 
+    @Shared
+    private FakeTicker ticker = new FakeTicker()
+
     def setup() {
-        subscriptionIds = new NotificationAwareSubscriptionIdsCache(notificationsBus, subscriptionCache, subscriptionIdProvider)
+        def evictAfterSeconds = 30
+        subscriptionIds = new NotificationAwareSubscriptionIdsCache(notificationsBus, subscriptionCache,
+                subscriptionIdProvider, evictAfterSeconds, ticker)
     }
 
     def "should match subscription by id"() {
@@ -97,10 +104,52 @@ class NotificationAwareSubscriptionIdsCacheTest extends Specification {
         subscriptionIds.onSubscriptionRemoved(subscription(sub1).build())
 
         then:
-        !subscriptionIds.getSubscriptionId(sub1).isPresent()
-        !subscriptionIds.getSubscriptionId(id1.value).isPresent()
+        subscriptionIds.getSubscriptionId(sub1).isPresent()
+        subscriptionIds.getSubscriptionId(id1.value).isPresent()
         subscriptionIds.getSubscriptionId(sub2).get() == id2
         subscriptionIds.getSubscriptionId(id2.value).get() == id2
+    }
+
+    def "should evict removed subscription ids after specified time"() {
+        given:
+        def sub1 = subscriptionNames.next()
+        def sub2 = subscriptionNames.next()
+
+        def id1 = SubscriptionId.from(sub1, 1L)
+        def id2 = SubscriptionId.from(sub2, 2L)
+
+        subscriptionIdProvider.getSubscriptionId(sub1) >> id1
+        subscriptionIdProvider.getSubscriptionId(sub2) >> id2
+
+        subscriptionCache.listActiveSubscriptionNames() >> [sub1, sub2]
+
+        when:
+        subscriptionIds.start()
+
+        then:
+        subscriptionIds.getSubscriptionId(sub1).isPresent()
+        subscriptionIds.getSubscriptionId(sub2).isPresent()
+        subscriptionIds.getSubscriptionId(id1.value).isPresent()
+        subscriptionIds.getSubscriptionId(id2.value).isPresent()
+
+        when:
+        subscriptionIds.onSubscriptionRemoved(subscription(sub1).build())
+        ticker.advance(Duration.ofSeconds(20))
+
+        then:
+        subscriptionIds.getSubscriptionId(sub1).isPresent() // still available
+        subscriptionIds.getSubscriptionId(id1.value).isPresent()
+        subscriptionIds.getSubscriptionId(sub2).isPresent()
+        subscriptionIds.getSubscriptionId(id2.value).isPresent()
+
+        when:
+        ticker.advance(Duration.ofSeconds(30))
+
+        then:
+        !subscriptionIds.getSubscriptionId(sub1).isPresent() // expires
+        !subscriptionIds.getSubscriptionId(id1.value).isPresent()
+        subscriptionIds.getSubscriptionId(sub2).isPresent()
+        subscriptionIds.getSubscriptionId(id2.value).isPresent()
     }
 
     private static class SubscriptionNames {

--- a/hermes-consumers/src/test/java/pl/allegro/tech/hermes/consumers/supervisor/workload/ConsumerTestRuntimeEnvironment.java
+++ b/hermes-consumers/src/test/java/pl/allegro/tech/hermes/consumers/supervisor/workload/ConsumerTestRuntimeEnvironment.java
@@ -163,7 +163,7 @@ class ConsumerTestRuntimeEnvironment {
         subscriptionsCaches.add(subscriptionsCache);
 
         SubscriptionIds subscriptionIds = new SubscriptionIdsCacheFactory(notificationsBus, subscriptionsCache,
-                new ZookeeperSubscriptionIdProvider(curator, zookeeperPaths)).provide();
+                new ZookeeperSubscriptionIdProvider(curator, zookeeperPaths), consumerConfig).provide();
 
         ConsumerAssignmentCache consumerAssignmentCache = new ConsumerAssignmentCacheFactory(
                 curator, consumerConfig, zookeeperPaths, subscriptionsCache, subscriptionIds


### PR DESCRIPTION
resolves #1145 

Ids of removed subscriptions should be still available for some time after the subscriptions are removed, due to the way selective workload algorithm works (it decodes them and should not filter them out in order to clean the mess properly). I'm introducing cache for removed subscriptions that is cleared after some specified time of inactivity (should be bigger than configured intervals for workload/max-rate computations).