### PR TITLE
Fix Hermes mock predicate

### DIFF
--- a/hermes-mock/src/main/java/pl/allegro/tech/hermes/mock/HermesMockExpect.java
+++ b/hermes-mock/src/main/java/pl/allegro/tech/hermes/mock/HermesMockExpect.java
@@ -54,7 +54,6 @@ public class HermesMockExpect {
     }
 
     private <T> void assertMessages(String topicName, int count, Supplier<List<T>> messages) {
-        expectMessages(topicName, count);
         expectSpecificMessages(count, messages.get());
     }
 

--- a/hermes-mock/src/test/groovy/pl/allegro/tech/hermes/mock/HermesMockAvroTest.groovy
+++ b/hermes-mock/src/test/groovy/pl/allegro/tech/hermes/mock/HermesMockAvroTest.groovy
@@ -12,8 +12,6 @@ import spock.lang.Shared
 import spock.lang.Specification
 import tech.allegro.schema.json2avro.converter.JsonAvroConverter
 
-import javax.ws.rs.core.Response
-
 class HermesMockAvroTest extends Specification {
 
     @Shared
@@ -206,16 +204,15 @@ class HermesMockAvroTest extends Specification {
         given:
             def topicName = "my-topic"
             hermes.define().jsonTopic(topicName)
-            def count = 3
-            def messages = (1..count).collect { new TestMessage("key-" + it, "value-" + it) }
-            def filter = { TestMessage m -> m.key.startsWith("key-") }
+            def messages = (1..3).collect { new TestMessage("key-" + it, "value-" + it) }
+            def filter = { TestMessage m -> m.key.startsWith("key-1") }
 
         when:
             messages.each { publish(topicName, it) }
             5.times { publish(topicName) }
 
         then:
-            count == hermes.query().countMatchingAvroMessages(topicName, schema, TestMessage, filter)
+            1 == hermes.query().countMatchingAvroMessages(topicName, schema, TestMessage, filter)
     }
 
     def asAvro(TestMessage message) {

--- a/hermes-mock/src/test/groovy/pl/allegro/tech/hermes/mock/HermesMockAvroTest.groovy
+++ b/hermes-mock/src/test/groovy/pl/allegro/tech/hermes/mock/HermesMockAvroTest.groovy
@@ -67,13 +67,13 @@ class HermesMockAvroTest extends Specification {
             hermes.define().avroTopic(topicName)
 
             def messages = (1..5).collect { new TestMessage("key-" + it, "value-" + it) }
-            def filter = { TestMessage m -> m.key.startsWith("key-") }
+            def filter = { TestMessage m -> m.key.startsWith("key-1") || m.key.startsWith("key-3") }
 
         when:
             messages.each { publish(topicName, it) }
 
         then:
-            hermes.expect().avroMessagesOnTopic(topicName, 5, schema, TestMessage, filter)
+            hermes.expect().avroMessagesOnTopic(topicName, 2, schema, TestMessage, filter)
     }
 
     def "should get messages with schema from file"() {

--- a/hermes-mock/src/test/groovy/pl/allegro/tech/hermes/mock/HermesMockTest.groovy
+++ b/hermes-mock/src/test/groovy/pl/allegro/tech/hermes/mock/HermesMockTest.groovy
@@ -7,8 +7,6 @@ import pl.allegro.tech.hermes.test.helper.util.Ports
 import spock.lang.Shared
 import spock.lang.Specification
 
-import javax.ws.rs.core.Response
-
 class HermesMockTest extends Specification {
 
     @Shared
@@ -95,16 +93,15 @@ class HermesMockTest extends Specification {
         given:
             def topicName = "my-test-filtered-topic"
             hermes.define().jsonTopic(topicName)
-            def count = 5
-            def messages = (1..count).collect { new TestMessage("key-" + it, "value-" + it) }
-            def filter = { TestMessage m -> m.key.startsWith("key-") }
+            def messages = (1..5).collect { new TestMessage("key-" + it, "value-" + it) }
+            def filter = { TestMessage m -> m.key.startsWith("key-1") || m.key.startsWith("key-3") }
 
         when:
             messages.each { publish(topicName, it.asJson()) }
             3.times { publish("whatever") }
 
         then:
-            hermes.expect().jsonMessagesOnTopicAs(topicName, count, TestMessage, filter)
+            hermes.expect().jsonMessagesOnTopicAs(topicName, 2, TestMessage, filter)
     }
 
     def "should throw on more than 1 message"() {
@@ -268,16 +265,15 @@ class HermesMockTest extends Specification {
         given:
             def topicName = "my-topic"
             hermes.define().jsonTopic(topicName)
-            def count = 3
-            def messages = (1..count).collect { new TestMessage("key-" + it, "value-" + it) }
-            def filter = { TestMessage m -> m.key.startsWith("key-") }
+            def messages = (1..3).collect { new TestMessage("key-" + it, "value-" + it) }
+            def filter = { TestMessage m -> m.key.startsWith("key-1") }
 
         when:
             messages.each { publish(topicName, it.asJson()) }
             5.times { publish(topicName) }
 
         then:
-            count == hermes.query().countMatchingJsonMessages(topicName, TestMessage, filter)
+            1 == hermes.query().countMatchingJsonMessages(topicName, TestMessage, filter)
     }
 
     def publish(String topic) {

--- a/hermes-mock/src/test/groovy/pl/allegro/tech/hermes/mock/HermesMockTest.groovy
+++ b/hermes-mock/src/test/groovy/pl/allegro/tech/hermes/mock/HermesMockTest.groovy
@@ -136,7 +136,7 @@ class HermesMockTest extends Specification {
 
         then:
             def ex = thrown(HermesMockException)
-            ex.message == "Hermes mock did not receive 1 messages."
+            ex.message == "Hermes mock did not receive 1 messages, got 2"
     }
 
     def "should get all messages"() {


### PR DESCRIPTION
The problem lies in `HermesMockExpect.assertMessages`.

`expectMessages` and `expectSpecificMessages` are orthogonal, 'cause they assert different behaviour, total number of events vs specific events respectively.

Such behaviour was caused by a too generic predicate in tests.

Fixes #1152 