### PR TITLE
Single-schema generic datum reader

### DIFF
--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/common/message/converter/AvroBinaryDecoders.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/common/message/converter/AvroBinaryDecoders.java
@@ -1,7 +1,6 @@
 package pl.allegro.tech.hermes.common.message.converter;
 
 import org.apache.avro.Schema;
-import org.apache.avro.generic.GenericDatumReader;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.io.BinaryDecoder;
 import org.apache.avro.io.DecoderFactory;
@@ -23,7 +22,7 @@ public class AvroBinaryDecoders {
     static GenericRecord decodeReusingThreadLocalBinaryDecoder(byte[] message, Schema schema) {
         try (FlushableBinaryDecoderHolder holder = new FlushableBinaryDecoderHolder()){
             BinaryDecoder binaryDecoder = DecoderFactory.get().binaryDecoder(message, holder.getBinaryDecoder());
-            return new GenericDatumReader<GenericRecord>(schema).read(null, binaryDecoder);
+            return new SingleSchemaGenericDatumReader<GenericRecord>(schema).read(null, binaryDecoder);
         } catch (Exception e) {
             String reason = e.getMessage() == null ? ExceptionUtils.getRootCauseMessage(e) : e.getMessage();
             throw new AvroConversionException(String.format("Could not deserialize Avro message with provided schema, reason: %s", reason));

--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/common/message/converter/SingleSchemaGenericDatumReader.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/common/message/converter/SingleSchemaGenericDatumReader.java
@@ -1,0 +1,43 @@
+package pl.allegro.tech.hermes.common.message.converter;
+
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericDatumReader;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.io.DecoderFactory;
+import org.apache.avro.io.ResolvingDecoder;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+class SingleSchemaGenericDatumReader<D> extends GenericDatumReader<D> {
+
+    private static final ThreadLocal<Map<Schema, ResolvingDecoder>> resolvingDecoders = ThreadLocal.withInitial(HashMap::new);
+    private final Schema schema;
+
+    SingleSchemaGenericDatumReader(Schema schema) {
+        super(schema);
+        this.schema = schema;
+    }
+
+    @Override
+    public D read(D reuse, Decoder in) throws IOException {
+        ResolvingDecoder resolver = getResolvingDecoder();
+        resolver.configure(in);
+        D result = (D) read(reuse, schema, resolver);
+        resolver.drain();
+        resolver.configure(null);
+        return result;
+    }
+
+    private ResolvingDecoder getResolvingDecoder() throws IOException {
+        Map<Schema, ResolvingDecoder> decodersMap = resolvingDecoders.get();
+
+        ResolvingDecoder decoder = decodersMap.get(schema);
+        if (decoder == null) {
+            decoder = DecoderFactory.get().resolvingDecoder(Schema.applyAliases(schema, schema), schema, null);
+            decodersMap.put(schema, decoder);
+        }
+        return decoder;
+    }
+}


### PR DESCRIPTION
Changing the `GenericDatumReader` implementation used, so we have simpler storage for `ResolvingDecoder` instances that are used underneath. By default there is `ThreadLocal<Map<Schema, Map<Schema, ResolvingDecoder>>>` used, where each `Map` is a `WeakIdentityHashMap` (on both levels).
Because in our case writer schema == reader schema this structure may be simpler.