### PR TITLE
Catching all Throwables when consuming messages

### DIFF
--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/process/ConsumerProcess.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/process/ConsumerProcess.java
@@ -62,8 +62,8 @@ public class ConsumerProcess implements Runnable {
             while (running && !Thread.currentThread().isInterrupted()) {
                 consumer.consume(this::processSignals);
             }
-        } catch (Exception ex) {
-            logger.error("Consumer process of subscription {} failed", getSubscriptionName(), ex);
+        } catch (Throwable throwable) {
+            logger.error("Consumer process of subscription {} failed", getSubscriptionName(), throwable);
         } finally {
             logger.info("Releasing consumer process thread of subscription {}", getSubscriptionName());
             refreshHealthcheck();


### PR DESCRIPTION
Changing `Exception` to `Throwable` so we log not only exceptions but all other errors, including OOM that could be thrown somewhere. 