### PR TITLE
HttpClients can have additional headers set

### DIFF
--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/sender/http/EmptyHttpHeadersProvidersFactory.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/sender/http/EmptyHttpHeadersProvidersFactory.java
@@ -1,0 +1,15 @@
+package pl.allegro.tech.hermes.consumers.consumer.sender.http;
+
+import pl.allegro.tech.hermes.consumers.consumer.sender.http.headers.HttpHeadersProvider;
+
+import java.util.Collection;
+
+import static java.util.Collections.emptySet;
+
+public class EmptyHttpHeadersProvidersFactory implements HttpHeadersProvidersFactory {
+
+    @Override
+    public Collection<HttpHeadersProvider> createAll() {
+        return emptySet();
+    }
+}

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/sender/http/HttpHeadersProvidersFactory.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/sender/http/HttpHeadersProvidersFactory.java
@@ -1,0 +1,10 @@
+package pl.allegro.tech.hermes.consumers.consumer.sender.http;
+
+import pl.allegro.tech.hermes.consumers.consumer.sender.http.headers.HttpHeadersProvider;
+
+import java.util.Collection;
+
+public interface HttpHeadersProvidersFactory {
+
+    Collection<HttpHeadersProvider> createAll();
+}

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/sender/http/HttpRequestData.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/sender/http/HttpRequestData.java
@@ -1,0 +1,29 @@
+package pl.allegro.tech.hermes.consumers.consumer.sender.http;
+
+import pl.allegro.tech.hermes.api.EndpointAddress;
+
+public class HttpRequestData {
+
+    private EndpointAddress rawAddress;
+
+    public HttpRequestData(EndpointAddress rawAddress) {
+        this.rawAddress = rawAddress;
+    }
+
+    public EndpointAddress getRawAddress() {
+        return rawAddress;
+    }
+
+    public static class HttpRequestDataBuilder {
+        private EndpointAddress rawAddress;
+
+        public HttpRequestDataBuilder withRawAddress(EndpointAddress rawAddress) {
+            this.rawAddress = rawAddress;
+            return this;
+        }
+
+        public HttpRequestData build() {
+            return new HttpRequestData(rawAddress);
+        }
+    }
+}

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/sender/http/HttpRequestFactory.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/sender/http/HttpRequestFactory.java
@@ -5,7 +5,7 @@ import org.eclipse.jetty.client.api.Request;
 import org.eclipse.jetty.client.util.BytesContentProvider;
 import org.eclipse.jetty.http.HttpMethod;
 import pl.allegro.tech.hermes.consumers.consumer.Message;
-import pl.allegro.tech.hermes.consumers.consumer.sender.http.headers.HttpHeadersProvider;
+import pl.allegro.tech.hermes.consumers.consumer.sender.http.headers.HttpRequestHeaders;
 import pl.allegro.tech.hermes.consumers.consumer.trace.MetadataAppender;
 
 import java.net.URI;
@@ -17,38 +17,37 @@ class HttpRequestFactory {
     private final long timeout;
     private final long socketTimeout;
     private final MetadataAppender<Request> metadataAppender;
-    private final HttpHeadersProvider requestHeadersProvider;
 
     HttpRequestFactory(HttpClient client,
                        long timeout,
                        long socketTimeout,
-                       MetadataAppender<Request> metadataAppender,
-                       HttpHeadersProvider requestHeadersProvider) {
+                       MetadataAppender<Request> metadataAppender) {
         this.client = client;
         this.timeout = timeout;
         this.socketTimeout = socketTimeout;
         this.metadataAppender = metadataAppender;
-        this.requestHeadersProvider = requestHeadersProvider;
     }
 
-    Request buildRequest(Message message, URI uri) {
-        return new HttpRequestBuilder(message, uri).build();
+    Request buildRequest(Message message, URI uri, HttpRequestHeaders headers) {
+        return new HttpRequestBuilder(message, uri, headers).build();
     }
 
     private class HttpRequestBuilder {
 
         private final Message message;
         private final URI uri;
+        private final HttpRequestHeaders headers;
 
-        HttpRequestBuilder(Message message, URI uri) {
+        HttpRequestBuilder(Message message, URI uri, HttpRequestHeaders headers) {
             this.message = message;
             this.uri = uri;
+            this.headers = headers;
         }
 
         Request build() {
             Request request = baseRequest();
-            requestHeadersProvider.getHeaders(message)
-                    .asMap()
+
+            headers.asMap()
                     .forEach(request::header);
 
             return request;

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/sender/http/JettyBroadCastMessageSender.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/sender/http/JettyBroadCastMessageSender.java
@@ -8,12 +8,12 @@ import pl.allegro.tech.hermes.consumers.consumer.sender.MessageSender;
 import pl.allegro.tech.hermes.consumers.consumer.sender.MessageSendingResult;
 import pl.allegro.tech.hermes.consumers.consumer.sender.MultiMessageSendingResult;
 import pl.allegro.tech.hermes.consumers.consumer.sender.SingleMessageSendingResult;
+import pl.allegro.tech.hermes.consumers.consumer.sender.http.HttpRequestData.HttpRequestDataBuilder;
 import pl.allegro.tech.hermes.consumers.consumer.sender.http.headers.HttpHeadersProvider;
 import pl.allegro.tech.hermes.consumers.consumer.sender.http.headers.HttpRequestHeaders;
 import pl.allegro.tech.hermes.consumers.consumer.sender.resolver.EndpointAddressResolutionException;
 import pl.allegro.tech.hermes.consumers.consumer.sender.resolver.ResolvableEndpointAddress;
 
-import java.net.URI;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -52,8 +52,12 @@ public class JettyBroadCastMessageSender implements MessageSender {
     }
 
     private List<CompletableFuture<SingleMessageSendingResult>> collectResults(Message message) throws EndpointAddressResolutionException {
-        String rawAddress = endpoint.getRawAddress();
-        HttpRequestHeaders headers = requestHeadersProvider.getHeaders(message, rawAddress);
+
+        final HttpRequestData requestData = new HttpRequestDataBuilder()
+                .withRawAddress(endpoint.getRawAddress())
+                .build();
+
+        HttpRequestHeaders headers = requestHeadersProvider.getHeaders(message, requestData);
 
         return endpoint.resolveAllFor(message).stream()
                 .filter(uri -> message.hasNotBeenSentTo(uri.toString()))

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/sender/http/JettyMessageSender.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/sender/http/JettyMessageSender.java
@@ -4,6 +4,7 @@ import org.eclipse.jetty.client.api.Request;
 import pl.allegro.tech.hermes.consumers.consumer.Message;
 import pl.allegro.tech.hermes.consumers.consumer.sender.CompletableFutureAwareMessageSender;
 import pl.allegro.tech.hermes.consumers.consumer.sender.MessageSendingResult;
+import pl.allegro.tech.hermes.consumers.consumer.sender.http.HttpRequestData.HttpRequestDataBuilder;
 import pl.allegro.tech.hermes.consumers.consumer.sender.http.headers.HttpHeadersProvider;
 import pl.allegro.tech.hermes.consumers.consumer.sender.http.headers.HttpRequestHeaders;
 import pl.allegro.tech.hermes.consumers.consumer.sender.resolver.EndpointAddressResolutionException;
@@ -29,8 +30,11 @@ public class JettyMessageSender extends CompletableFutureAwareMessageSender {
     @Override
     protected void sendMessage(Message message, final CompletableFuture<MessageSendingResult> resultFuture) {
         try {
-            String rawAddress = addressResolver.getRawAddress();
-            HttpRequestHeaders headers = requestHeadersProvider.getHeaders(message, rawAddress);
+            final HttpRequestData requestData = new HttpRequestDataBuilder()
+                    .withRawAddress(addressResolver.getRawAddress())
+                    .build();
+
+            HttpRequestHeaders headers = requestHeadersProvider.getHeaders(message, requestData);
 
             URI resolvedUri = addressResolver.resolveFor(message);
             Request request = requestFactory.buildRequest(message, resolvedUri, headers);

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/sender/http/JettyMessageSender.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/sender/http/JettyMessageSender.java
@@ -1,28 +1,41 @@
 package pl.allegro.tech.hermes.consumers.consumer.sender.http;
 
+import org.eclipse.jetty.client.api.Request;
 import pl.allegro.tech.hermes.consumers.consumer.Message;
 import pl.allegro.tech.hermes.consumers.consumer.sender.CompletableFutureAwareMessageSender;
 import pl.allegro.tech.hermes.consumers.consumer.sender.MessageSendingResult;
+import pl.allegro.tech.hermes.consumers.consumer.sender.http.headers.HttpHeadersProvider;
+import pl.allegro.tech.hermes.consumers.consumer.sender.http.headers.HttpRequestHeaders;
 import pl.allegro.tech.hermes.consumers.consumer.sender.resolver.EndpointAddressResolutionException;
 import pl.allegro.tech.hermes.consumers.consumer.sender.resolver.ResolvableEndpointAddress;
 
+import java.net.URI;
 import java.util.concurrent.CompletableFuture;
 
 public class JettyMessageSender extends CompletableFutureAwareMessageSender {
 
     private final HttpRequestFactory requestFactory;
-    private final ResolvableEndpointAddress endpoint;
+    private final ResolvableEndpointAddress addressResolver;
+    private final HttpHeadersProvider requestHeadersProvider;
 
-    public JettyMessageSender(HttpRequestFactory requestFactory, ResolvableEndpointAddress endpoint) {
+    public JettyMessageSender(HttpRequestFactory requestFactory,
+                              ResolvableEndpointAddress addressResolver,
+                              HttpHeadersProvider headersProvider) {
         this.requestFactory = requestFactory;
-        this.endpoint = endpoint;
+        this.addressResolver = addressResolver;
+        this.requestHeadersProvider = headersProvider;
     }
 
     @Override
     protected void sendMessage(Message message, final CompletableFuture<MessageSendingResult> resultFuture) {
         try {
-            requestFactory.buildRequest(message, endpoint.resolveFor(message))
-                .send(result -> resultFuture.complete(MessageSendingResult.of(result)));
+            String rawAddress = addressResolver.getRawAddress();
+            HttpRequestHeaders headers = requestHeadersProvider.getHeaders(message, rawAddress);
+
+            URI resolvedUri = addressResolver.resolveFor(message);
+            Request request = requestFactory.buildRequest(message, resolvedUri, headers);
+
+            request.send(result -> resultFuture.complete(MessageSendingResult.of(result)));
         } catch (EndpointAddressResolutionException exception) {
             resultFuture.complete(MessageSendingResult.failedResult(exception));
         }

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/sender/http/headers/AuthHeadersProvider.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/sender/http/headers/AuthHeadersProvider.java
@@ -3,9 +3,9 @@ package pl.allegro.tech.hermes.consumers.consumer.sender.http.headers;
 import com.google.common.collect.ImmutableMap;
 import org.eclipse.jetty.http.HttpHeader;
 import pl.allegro.tech.hermes.consumers.consumer.Message;
+import pl.allegro.tech.hermes.consumers.consumer.sender.http.HttpRequestData;
 import pl.allegro.tech.hermes.consumers.consumer.sender.http.auth.HttpAuthorizationProvider;
 
-import java.net.URI;
 import java.util.Optional;
 
 public final class AuthHeadersProvider implements HttpHeadersProvider {
@@ -19,11 +19,11 @@ public final class AuthHeadersProvider implements HttpHeadersProvider {
     }
 
     @Override
-    public HttpRequestHeaders getHeaders(Message message, String rawAddress) {
+    public HttpRequestHeaders getHeaders(Message message, HttpRequestData requestData) {
         ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
 
         if (headersProvider != null) {
-            builder.putAll(headersProvider.getHeaders(message, rawAddress).asMap());
+            builder.putAll(headersProvider.getHeaders(message, requestData).asMap());
         }
 
         if (authorizationProvider != null) {

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/sender/http/headers/AuthHeadersProvider.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/sender/http/headers/AuthHeadersProvider.java
@@ -5,6 +5,7 @@ import org.eclipse.jetty.http.HttpHeader;
 import pl.allegro.tech.hermes.consumers.consumer.Message;
 import pl.allegro.tech.hermes.consumers.consumer.sender.http.auth.HttpAuthorizationProvider;
 
+import java.net.URI;
 import java.util.Optional;
 
 public final class AuthHeadersProvider implements HttpHeadersProvider {
@@ -18,11 +19,11 @@ public final class AuthHeadersProvider implements HttpHeadersProvider {
     }
 
     @Override
-    public HttpRequestHeaders getHeaders(Message message) {
+    public HttpRequestHeaders getHeaders(Message message, String rawAddress) {
         ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
 
         if (headersProvider != null) {
-            builder.putAll(headersProvider.getHeaders(message).asMap());
+            builder.putAll(headersProvider.getHeaders(message, rawAddress).asMap());
         }
 
         if (authorizationProvider != null) {

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/sender/http/headers/HermesHeadersProvider.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/sender/http/headers/HermesHeadersProvider.java
@@ -2,8 +2,8 @@ package pl.allegro.tech.hermes.consumers.consumer.sender.http.headers;
 
 import com.google.common.collect.ImmutableMap;
 import pl.allegro.tech.hermes.consumers.consumer.Message;
+import pl.allegro.tech.hermes.consumers.consumer.sender.http.HttpRequestData;
 
-import java.net.URI;
 import java.util.Collection;
 
 import static java.lang.String.valueOf;
@@ -22,10 +22,10 @@ public final class HermesHeadersProvider implements HttpHeadersProvider {
     }
 
     @Override
-    public HttpRequestHeaders getHeaders(Message message, String rawAddress) {
+    public HttpRequestHeaders getHeaders(Message message, HttpRequestData requestData) {
         ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
 
-        headersProvider.forEach(provider -> builder.putAll(provider.getHeaders(message, rawAddress).asMap()));
+        headersProvider.forEach(provider -> builder.putAll(provider.getHeaders(message, requestData).asMap()));
 
         builder.put(MESSAGE_ID.getName(), message.getId());
         builder.put(RETRY_COUNT.getName(), Integer.toString(message.getRetryCounter()));

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/sender/http/headers/HermesHeadersProvider.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/sender/http/headers/HermesHeadersProvider.java
@@ -3,6 +3,9 @@ package pl.allegro.tech.hermes.consumers.consumer.sender.http.headers;
 import com.google.common.collect.ImmutableMap;
 import pl.allegro.tech.hermes.consumers.consumer.Message;
 
+import java.net.URI;
+import java.util.Collection;
+
 import static java.lang.String.valueOf;
 import static pl.allegro.tech.hermes.common.http.MessageMetadataHeaders.MESSAGE_ID;
 import static pl.allegro.tech.hermes.common.http.MessageMetadataHeaders.RETRY_COUNT;
@@ -12,19 +15,17 @@ import static pl.allegro.tech.hermes.common.http.MessageMetadataHeaders.TOPIC_NA
 
 public final class HermesHeadersProvider implements HttpHeadersProvider {
 
-    private final HttpHeadersProvider headersProvider;
+    private final Collection<HttpHeadersProvider> headersProvider;
 
-    public HermesHeadersProvider(HttpHeadersProvider headersProvider) {
+    public HermesHeadersProvider(Collection<HttpHeadersProvider> headersProvider) {
         this.headersProvider = headersProvider;
     }
 
     @Override
-    public HttpRequestHeaders getHeaders(Message message) {
+    public HttpRequestHeaders getHeaders(Message message, String rawAddress) {
         ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
 
-        if (headersProvider != null) {
-            builder.putAll(headersProvider.getHeaders(message).asMap());
-        }
+        headersProvider.forEach(provider -> builder.putAll(provider.getHeaders(message, rawAddress).asMap()));
 
         builder.put(MESSAGE_ID.getName(), message.getId());
         builder.put(RETRY_COUNT.getName(), Integer.toString(message.getRetryCounter()));

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/sender/http/headers/Http1HeadersProvider.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/sender/http/headers/Http1HeadersProvider.java
@@ -5,6 +5,7 @@ import org.eclipse.jetty.http.HttpHeader;
 import pl.allegro.tech.hermes.api.ContentType;
 import pl.allegro.tech.hermes.consumers.consumer.Message;
 
+import java.net.URI;
 import java.util.function.Function;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
@@ -17,7 +18,7 @@ public final class Http1HeadersProvider implements HttpHeadersProvider {
             AVRO.equals(contentType) ? AVRO_BINARY : APPLICATION_JSON;
 
     @Override
-    public HttpRequestHeaders getHeaders(Message message) {
+    public HttpRequestHeaders getHeaders(Message message, String rawAddress) {
         return new HttpRequestHeaders(
                 ImmutableMap.of(
                         HttpHeader.CONTENT_TYPE.toString(), contentTypeToMediaType.apply(message.getContentType()),

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/sender/http/headers/Http1HeadersProvider.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/sender/http/headers/Http1HeadersProvider.java
@@ -4,8 +4,8 @@ import com.google.common.collect.ImmutableMap;
 import org.eclipse.jetty.http.HttpHeader;
 import pl.allegro.tech.hermes.api.ContentType;
 import pl.allegro.tech.hermes.consumers.consumer.Message;
+import pl.allegro.tech.hermes.consumers.consumer.sender.http.HttpRequestData;
 
-import java.net.URI;
 import java.util.function.Function;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
@@ -18,7 +18,7 @@ public final class Http1HeadersProvider implements HttpHeadersProvider {
             AVRO.equals(contentType) ? AVRO_BINARY : APPLICATION_JSON;
 
     @Override
-    public HttpRequestHeaders getHeaders(Message message, String rawAddress) {
+    public HttpRequestHeaders getHeaders(Message message, HttpRequestData requestData) {
         return new HttpRequestHeaders(
                 ImmutableMap.of(
                         HttpHeader.CONTENT_TYPE.toString(), contentTypeToMediaType.apply(message.getContentType()),

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/sender/http/headers/Http2HeadersProvider.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/sender/http/headers/Http2HeadersProvider.java
@@ -5,6 +5,7 @@ import org.eclipse.jetty.http.HttpHeader;
 import pl.allegro.tech.hermes.api.ContentType;
 import pl.allegro.tech.hermes.consumers.consumer.Message;
 
+import java.net.URI;
 import java.util.function.Function;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
@@ -17,7 +18,7 @@ public final class Http2HeadersProvider implements HttpHeadersProvider {
             AVRO.equals(contentType) ? AVRO_BINARY : APPLICATION_JSON;
 
     @Override
-    public HttpRequestHeaders getHeaders(Message message) {
+    public HttpRequestHeaders getHeaders(Message message, String rawAddress) {
         return new HttpRequestHeaders(
                 ImmutableMap.of(HttpHeader.CONTENT_TYPE.toString(), contentTypeToMediaType.apply(message.getContentType()))
         );

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/sender/http/headers/Http2HeadersProvider.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/sender/http/headers/Http2HeadersProvider.java
@@ -4,8 +4,8 @@ import com.google.common.collect.ImmutableMap;
 import org.eclipse.jetty.http.HttpHeader;
 import pl.allegro.tech.hermes.api.ContentType;
 import pl.allegro.tech.hermes.consumers.consumer.Message;
+import pl.allegro.tech.hermes.consumers.consumer.sender.http.HttpRequestData;
 
-import java.net.URI;
 import java.util.function.Function;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
@@ -18,7 +18,7 @@ public final class Http2HeadersProvider implements HttpHeadersProvider {
             AVRO.equals(contentType) ? AVRO_BINARY : APPLICATION_JSON;
 
     @Override
-    public HttpRequestHeaders getHeaders(Message message, String rawAddress) {
+    public HttpRequestHeaders getHeaders(Message message, HttpRequestData requestData) {
         return new HttpRequestHeaders(
                 ImmutableMap.of(HttpHeader.CONTENT_TYPE.toString(), contentTypeToMediaType.apply(message.getContentType()))
         );

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/sender/http/headers/HttpHeadersProvider.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/sender/http/headers/HttpHeadersProvider.java
@@ -1,9 +1,10 @@
 package pl.allegro.tech.hermes.consumers.consumer.sender.http.headers;
 
 import pl.allegro.tech.hermes.consumers.consumer.Message;
+import pl.allegro.tech.hermes.consumers.consumer.sender.http.HttpRequestData;
 
 public interface HttpHeadersProvider {
 
-    HttpRequestHeaders getHeaders(Message message, String rawAddress);
+    HttpRequestHeaders getHeaders(Message message, HttpRequestData requestData);
 
 }

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/sender/http/headers/HttpHeadersProvider.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/sender/http/headers/HttpHeadersProvider.java
@@ -4,6 +4,6 @@ import pl.allegro.tech.hermes.consumers.consumer.Message;
 
 public interface HttpHeadersProvider {
 
-    HttpRequestHeaders getHeaders(Message message);
+    HttpRequestHeaders getHeaders(Message message, String rawAddress);
 
 }

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/sender/http/headers/HttpRequestHeaders.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/sender/http/headers/HttpRequestHeaders.java
@@ -8,7 +8,7 @@ public final class HttpRequestHeaders {
 
     private final Map<String, String> headers;
 
-    HttpRequestHeaders(Map<String, String> headers) {
+    public HttpRequestHeaders(Map<String, String> headers) {
         this.headers = headers;
     }
 

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/sender/resolver/ResolvableEndpointAddress.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/sender/resolver/ResolvableEndpointAddress.java
@@ -29,8 +29,8 @@ public class ResolvableEndpointAddress {
         return resolver.resolveAll(address, message, metadata);
     }
 
-    public String getRawAddress() {
-        return address.getEndpoint();
+    public EndpointAddress getRawAddress() {
+        return address;
     }
 
     public String toString() {

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/sender/resolver/ResolvableEndpointAddress.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/sender/resolver/ResolvableEndpointAddress.java
@@ -29,6 +29,10 @@ public class ResolvableEndpointAddress {
         return resolver.resolveAll(address, message, metadata);
     }
 
+    public String getRawAddress() {
+        return address.getEndpoint();
+    }
+
     public String toString() {
         return address.toString();
     }

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/sender/resolver/SimpleEndpointAddressResolver.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/sender/resolver/SimpleEndpointAddressResolver.java
@@ -1,6 +1,5 @@
 package pl.allegro.tech.hermes.consumers.consumer.sender.resolver;
 
-
 public class SimpleEndpointAddressResolver implements EndpointAddressResolver {
 
 }

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/di/ConsumersBinder.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/di/ConsumersBinder.java
@@ -49,11 +49,13 @@ import pl.allegro.tech.hermes.consumers.consumer.sender.MessageSenderFactory;
 import pl.allegro.tech.hermes.consumers.consumer.sender.MessageSendingResult;
 import pl.allegro.tech.hermes.consumers.consumer.sender.ProtocolMessageSenderProvider;
 import pl.allegro.tech.hermes.consumers.consumer.sender.http.DefaultHttpMetadataAppender;
+import pl.allegro.tech.hermes.consumers.consumer.sender.http.EmptyHttpHeadersProvidersFactory;
 import pl.allegro.tech.hermes.consumers.consumer.sender.http.Http2ClientFactory;
 import pl.allegro.tech.hermes.consumers.consumer.sender.http.Http2ClientHolder;
 import pl.allegro.tech.hermes.consumers.consumer.sender.http.HttpClientFactory;
 import pl.allegro.tech.hermes.consumers.consumer.sender.http.HttpClientsFactory;
 import pl.allegro.tech.hermes.consumers.consumer.sender.http.HttpClientsWorkloadReporter;
+import pl.allegro.tech.hermes.consumers.consumer.sender.http.HttpHeadersProvidersFactory;
 import pl.allegro.tech.hermes.consumers.consumer.sender.http.JettyHttpMessageSenderProvider;
 import pl.allegro.tech.hermes.consumers.consumer.sender.http.SslContextFactoryProvider;
 import pl.allegro.tech.hermes.consumers.consumer.sender.http.auth.HttpAuthorizationProviderFactory;
@@ -108,6 +110,7 @@ public class ConsumersBinder extends AbstractBinder {
                 .in(Singleton.class).named("defaultJmsMessageSenderProvider");
         bind(JettyHttpMessageSenderProvider.class).to(ProtocolMessageSenderProvider.class)
                 .in(Singleton.class).named("defaultHttpMessageSenderProvider");
+        bind(EmptyHttpHeadersProvidersFactory.class).to(HttpHeadersProvidersFactory.class).in(Singleton.class);
 
         bind("consumer").named("moduleName").to(String.class);
 

--- a/hermes-consumers/src/test/groovy/pl/allegro/tech/hermes/consumers/consumer/sender/http/JettyBroadCastMessageSenderTest.groovy
+++ b/hermes-consumers/src/test/groovy/pl/allegro/tech/hermes/consumers/consumer/sender/http/JettyBroadCastMessageSenderTest.groovy
@@ -126,8 +126,9 @@ class JettyBroadCastMessageSenderTest extends Specification {
         def address = Stub(ResolvableEndpointAddress) {
             resolveAllFor(_ as Message) >> []
 
-            getRawAddress() >> endpoint.getUri()
+            getRawAddress() >> endpoint
         }
+
         def httpRequestFactory = new HttpRequestFactory(client, 1000, 1000, new DefaultHttpMetadataAppender())
         messageSender = new JettyBroadCastMessageSender(httpRequestFactory, address,
                 requestHeadersProvider)

--- a/hermes-consumers/src/test/groovy/pl/allegro/tech/hermes/consumers/consumer/sender/http/headers/AuthHeadersProviderTest.groovy
+++ b/hermes-consumers/src/test/groovy/pl/allegro/tech/hermes/consumers/consumer/sender/http/headers/AuthHeadersProviderTest.groovy
@@ -1,11 +1,12 @@
 package pl.allegro.tech.hermes.consumers.consumer.sender.http.headers
 
 import pl.allegro.tech.hermes.consumers.consumer.Message
+import pl.allegro.tech.hermes.consumers.consumer.sender.http.HttpRequestData
 import pl.allegro.tech.hermes.consumers.consumer.sender.http.auth.HttpAuthorizationProvider
 import spock.lang.Specification
 
+import static pl.allegro.tech.hermes.consumers.consumer.sender.http.headers.TestHttpRequestData.requestData
 import static pl.allegro.tech.hermes.consumers.consumer.sender.http.headers.TestMessages.message
-import static pl.allegro.tech.hermes.consumers.consumer.sender.http.headers.TestUris.rawAddress
 
 class AuthHeadersProviderTest extends Specification {
 
@@ -13,10 +14,12 @@ class AuthHeadersProviderTest extends Specification {
 
     def "should produce authorization header when authorization provider is present"() {
         given:
-        HttpHeadersProvider authHeadersProvider = new AuthHeadersProvider(null, authorizationProvider)
+        HttpHeadersProvider authHeadersProvider = new AuthHeadersProvider(null,
+                authorizationProvider)
 
         when:
-        Map<String, String> headers = authHeadersProvider.getHeaders(message(), rawAddress()).asMap()
+        Map<String, String> headers =
+                authHeadersProvider.getHeaders(message(), requestData()).asMap()
 
         then:
         headers.size() == 1
@@ -28,7 +31,8 @@ class AuthHeadersProviderTest extends Specification {
         HttpHeadersProvider authHeadersProvider = new AuthHeadersProvider(null, null)
 
         when:
-        Map<String, String> headers = authHeadersProvider.getHeaders(message(), rawAddress()).asMap()
+        Map<String, String> headers =
+                authHeadersProvider.getHeaders(message(), requestData()).asMap()
 
         then:
         headers.size() == 0
@@ -37,16 +41,19 @@ class AuthHeadersProviderTest extends Specification {
     def "should forward headers from nested provider"() {
         given:
         HttpHeadersProvider nestedHeadersProvider = new HttpHeadersProvider() {
+
             @Override
-            HttpRequestHeaders getHeaders(Message message, String rawAddress) {
+            HttpRequestHeaders getHeaders(Message message, HttpRequestData requestData) {
                 return new HttpRequestHeaders(Collections.singletonMap("k", "v"))
             }
         }
 
-        HttpHeadersProvider authHeadersProvider = new AuthHeadersProvider(nestedHeadersProvider, null)
+        HttpHeadersProvider authHeadersProvider = new AuthHeadersProvider(nestedHeadersProvider,
+                null)
 
         when:
-        Map<String, String> headers = authHeadersProvider.getHeaders(message(), rawAddress()).asMap()
+        Map<String, String> headers =
+                authHeadersProvider.getHeaders(message(), requestData()).asMap()
 
         then:
         headers.size() == 1

--- a/hermes-consumers/src/test/groovy/pl/allegro/tech/hermes/consumers/consumer/sender/http/headers/AuthHeadersProviderTest.groovy
+++ b/hermes-consumers/src/test/groovy/pl/allegro/tech/hermes/consumers/consumer/sender/http/headers/AuthHeadersProviderTest.groovy
@@ -5,6 +5,7 @@ import pl.allegro.tech.hermes.consumers.consumer.sender.http.auth.HttpAuthorizat
 import spock.lang.Specification
 
 import static pl.allegro.tech.hermes.consumers.consumer.sender.http.headers.TestMessages.message
+import static pl.allegro.tech.hermes.consumers.consumer.sender.http.headers.TestUris.rawAddress
 
 class AuthHeadersProviderTest extends Specification {
 
@@ -15,7 +16,7 @@ class AuthHeadersProviderTest extends Specification {
         HttpHeadersProvider authHeadersProvider = new AuthHeadersProvider(null, authorizationProvider)
 
         when:
-        Map<String, String> headers = authHeadersProvider.getHeaders(message()).asMap()
+        Map<String, String> headers = authHeadersProvider.getHeaders(message(), rawAddress()).asMap()
 
         then:
         headers.size() == 1
@@ -27,7 +28,7 @@ class AuthHeadersProviderTest extends Specification {
         HttpHeadersProvider authHeadersProvider = new AuthHeadersProvider(null, null)
 
         when:
-        Map<String, String> headers = authHeadersProvider.getHeaders(message()).asMap()
+        Map<String, String> headers = authHeadersProvider.getHeaders(message(), rawAddress()).asMap()
 
         then:
         headers.size() == 0
@@ -37,7 +38,7 @@ class AuthHeadersProviderTest extends Specification {
         given:
         HttpHeadersProvider nestedHeadersProvider = new HttpHeadersProvider() {
             @Override
-            HttpRequestHeaders getHeaders(Message message) {
+            HttpRequestHeaders getHeaders(Message message, String rawAddress) {
                 return new HttpRequestHeaders(Collections.singletonMap("k", "v"))
             }
         }
@@ -45,7 +46,7 @@ class AuthHeadersProviderTest extends Specification {
         HttpHeadersProvider authHeadersProvider = new AuthHeadersProvider(nestedHeadersProvider, null)
 
         when:
-        Map<String, String> headers = authHeadersProvider.getHeaders(message()).asMap()
+        Map<String, String> headers = authHeadersProvider.getHeaders(message(), rawAddress()).asMap()
 
         then:
         headers.size() == 1

--- a/hermes-consumers/src/test/groovy/pl/allegro/tech/hermes/consumers/consumer/sender/http/headers/HermesHeadersProviderTest.groovy
+++ b/hermes-consumers/src/test/groovy/pl/allegro/tech/hermes/consumers/consumer/sender/http/headers/HermesHeadersProviderTest.groovy
@@ -1,23 +1,26 @@
 package pl.allegro.tech.hermes.consumers.consumer.sender.http.headers
 
+import com.google.common.collect.ImmutableSet
 import pl.allegro.tech.hermes.consumers.consumer.Message
 import spock.lang.Specification
-import spock.lang.Unroll
 
+import static java.util.Collections.emptyList
+import static java.util.Collections.singleton
+import static java.util.Collections.singletonMap
 import static pl.allegro.tech.hermes.consumers.consumer.sender.http.headers.TestMessages.message
 import static pl.allegro.tech.hermes.consumers.consumer.sender.http.headers.TestMessages.messageWithAdditionalHeaders
 import static pl.allegro.tech.hermes.consumers.consumer.sender.http.headers.TestMessages.messageWithSchemaVersion
 import static pl.allegro.tech.hermes.consumers.consumer.sender.http.headers.TestMessages.messageWithSubscriptionData
+import static pl.allegro.tech.hermes.consumers.consumer.sender.http.headers.TestUris.rawAddress
 
 class HermesHeadersProviderTest extends Specification {
 
-    @Unroll
     def "should produce #header header with correct value"() {
         given:
-        HttpHeadersProvider hermesHeadersProvider = new HermesHeadersProvider(null)
+        HttpHeadersProvider hermesHeadersProvider = new HermesHeadersProvider(emptyList())
 
         when:
-        Map<String, String> headers = hermesHeadersProvider.getHeaders(message()).asMap()
+        Map<String, String> headers = hermesHeadersProvider.getHeaders(message(), rawAddress()).asMap()
 
         then:
         headers.size() == 2
@@ -27,10 +30,11 @@ class HermesHeadersProviderTest extends Specification {
 
     def "should contain subscription-specific headers when message has subscription identity headers"() {
         given:
-        HttpHeadersProvider hermesHeadersProvider = new HermesHeadersProvider(null)
+        HttpHeadersProvider hermesHeadersProvider = new HermesHeadersProvider(emptyList())
 
         when:
-        Map<String, String> headers = hermesHeadersProvider.getHeaders(messageWithSubscriptionData()).asMap()
+        Map<String, String> headers =
+                hermesHeadersProvider.getHeaders(messageWithSubscriptionData(), rawAddress()).asMap()
 
         then:
         headers.size() == 4
@@ -40,10 +44,11 @@ class HermesHeadersProviderTest extends Specification {
 
     def "should contain schema version header when schema is present"() {
         given:
-        HttpHeadersProvider hermesHeadersProvider = new HermesHeadersProvider(null)
+        HttpHeadersProvider hermesHeadersProvider = new HermesHeadersProvider(emptyList())
 
         when:
-        Map<String, String> headers = hermesHeadersProvider.getHeaders(messageWithSchemaVersion()).asMap()
+        Map<String, String> headers =
+                hermesHeadersProvider.getHeaders(messageWithSchemaVersion(), rawAddress()).asMap()
 
         then:
         headers.size() == 3
@@ -52,10 +57,11 @@ class HermesHeadersProviderTest extends Specification {
 
     def "should contain additional headers when they are present"() {
         given:
-        HttpHeadersProvider hermesHeadersProvider = new HermesHeadersProvider(null)
+        HttpHeadersProvider hermesHeadersProvider = new HermesHeadersProvider(emptyList())
 
         when:
-        Map<String, String> headers = hermesHeadersProvider.getHeaders(messageWithAdditionalHeaders()).asMap()
+        Map<String, String> headers =
+                hermesHeadersProvider.getHeaders(messageWithAdditionalHeaders(), rawAddress()).asMap()
 
         then:
         headers.size() == 3
@@ -65,19 +71,51 @@ class HermesHeadersProviderTest extends Specification {
     def "should forward headers from nested provider"() {
         given:
         HttpHeadersProvider nestedHeadersProvider = new HttpHeadersProvider() {
+
             @Override
-            HttpRequestHeaders getHeaders(Message message) {
-                return new HttpRequestHeaders(Collections.singletonMap("k", "v"))
+            HttpRequestHeaders getHeaders(Message message, String rawAddress) {
+                return new HttpRequestHeaders(singletonMap("k", "v"))
             }
         }
 
-        HttpHeadersProvider hermesHeadersProvider = new HermesHeadersProvider(nestedHeadersProvider)
+        HttpHeadersProvider hermesHeadersProvider = new HermesHeadersProvider(
+                singleton(nestedHeadersProvider))
 
         when:
-        Map<String, String> headers = hermesHeadersProvider.getHeaders(message()).asMap()
+        Map<String, String> headers = hermesHeadersProvider.getHeaders(message(), rawAddress()).asMap()
 
         then:
         headers.get("k") == "v"
+    }
+
+    def "should produce headers appending headers with additional providers"() {
+        def additionalProviderOne = new HttpHeadersProvider() {
+
+            @Override
+            HttpRequestHeaders getHeaders(Message message, String rawAddress) {
+                return new HttpRequestHeaders(singletonMap("header-1", "header-1-value"))
+            }
+        }
+
+        def additionalProviderTwo = new HttpHeadersProvider() {
+
+            @Override
+            HttpRequestHeaders getHeaders(Message message, String rawAddress) {
+                return new HttpRequestHeaders(singletonMap("header-2", "header-2-value"))
+            }
+        }
+
+        given:
+        HttpHeadersProvider hermesHeadersProvider = new HermesHeadersProvider(
+                ImmutableSet.of(additionalProviderOne, additionalProviderTwo)
+        )
+
+        when:
+        Map<String, String> headers = hermesHeadersProvider.getHeaders(message(), rawAddress()).asMap()
+
+        then:
+        headers.get("header-1") == "header-1-value"
+        headers.get("header-2") == "header-2-value"
     }
 
 }

--- a/hermes-consumers/src/test/groovy/pl/allegro/tech/hermes/consumers/consumer/sender/http/headers/HermesHeadersProviderTest.groovy
+++ b/hermes-consumers/src/test/groovy/pl/allegro/tech/hermes/consumers/consumer/sender/http/headers/HermesHeadersProviderTest.groovy
@@ -2,16 +2,17 @@ package pl.allegro.tech.hermes.consumers.consumer.sender.http.headers
 
 import com.google.common.collect.ImmutableSet
 import pl.allegro.tech.hermes.consumers.consumer.Message
+import pl.allegro.tech.hermes.consumers.consumer.sender.http.HttpRequestData
 import spock.lang.Specification
 
 import static java.util.Collections.emptyList
 import static java.util.Collections.singleton
 import static java.util.Collections.singletonMap
+import static pl.allegro.tech.hermes.consumers.consumer.sender.http.headers.TestHttpRequestData.requestData
 import static pl.allegro.tech.hermes.consumers.consumer.sender.http.headers.TestMessages.message
 import static pl.allegro.tech.hermes.consumers.consumer.sender.http.headers.TestMessages.messageWithAdditionalHeaders
 import static pl.allegro.tech.hermes.consumers.consumer.sender.http.headers.TestMessages.messageWithSchemaVersion
 import static pl.allegro.tech.hermes.consumers.consumer.sender.http.headers.TestMessages.messageWithSubscriptionData
-import static pl.allegro.tech.hermes.consumers.consumer.sender.http.headers.TestUris.rawAddress
 
 class HermesHeadersProviderTest extends Specification {
 
@@ -20,7 +21,8 @@ class HermesHeadersProviderTest extends Specification {
         HttpHeadersProvider hermesHeadersProvider = new HermesHeadersProvider(emptyList())
 
         when:
-        Map<String, String> headers = hermesHeadersProvider.getHeaders(message(), rawAddress()).asMap()
+        Map<String, String> headers =
+                hermesHeadersProvider.getHeaders(message(), requestData()).asMap()
 
         then:
         headers.size() == 2
@@ -34,7 +36,8 @@ class HermesHeadersProviderTest extends Specification {
 
         when:
         Map<String, String> headers =
-                hermesHeadersProvider.getHeaders(messageWithSubscriptionData(), rawAddress()).asMap()
+                hermesHeadersProvider.getHeaders(messageWithSubscriptionData(), requestData()).
+                        asMap()
 
         then:
         headers.size() == 4
@@ -48,7 +51,7 @@ class HermesHeadersProviderTest extends Specification {
 
         when:
         Map<String, String> headers =
-                hermesHeadersProvider.getHeaders(messageWithSchemaVersion(), rawAddress()).asMap()
+                hermesHeadersProvider.getHeaders(messageWithSchemaVersion(), requestData()).asMap()
 
         then:
         headers.size() == 3
@@ -61,7 +64,8 @@ class HermesHeadersProviderTest extends Specification {
 
         when:
         Map<String, String> headers =
-                hermesHeadersProvider.getHeaders(messageWithAdditionalHeaders(), rawAddress()).asMap()
+                hermesHeadersProvider.getHeaders(messageWithAdditionalHeaders(), requestData()).
+                        asMap()
 
         then:
         headers.size() == 3
@@ -73,7 +77,7 @@ class HermesHeadersProviderTest extends Specification {
         HttpHeadersProvider nestedHeadersProvider = new HttpHeadersProvider() {
 
             @Override
-            HttpRequestHeaders getHeaders(Message message, String rawAddress) {
+            HttpRequestHeaders getHeaders(Message message, HttpRequestData requestData) {
                 return new HttpRequestHeaders(singletonMap("k", "v"))
             }
         }
@@ -82,17 +86,19 @@ class HermesHeadersProviderTest extends Specification {
                 singleton(nestedHeadersProvider))
 
         when:
-        Map<String, String> headers = hermesHeadersProvider.getHeaders(message(), rawAddress()).asMap()
+        Map<String, String> headers =
+                hermesHeadersProvider.getHeaders(message(), requestData()).asMap()
 
         then:
         headers.get("k") == "v"
     }
 
     def "should produce headers appending headers with additional providers"() {
+        given:
         def additionalProviderOne = new HttpHeadersProvider() {
 
             @Override
-            HttpRequestHeaders getHeaders(Message message, String rawAddress) {
+            HttpRequestHeaders getHeaders(Message message, HttpRequestData requestData) {
                 return new HttpRequestHeaders(singletonMap("header-1", "header-1-value"))
             }
         }
@@ -100,18 +106,18 @@ class HermesHeadersProviderTest extends Specification {
         def additionalProviderTwo = new HttpHeadersProvider() {
 
             @Override
-            HttpRequestHeaders getHeaders(Message message, String rawAddress) {
+            HttpRequestHeaders getHeaders(Message message, HttpRequestData requestData) {
                 return new HttpRequestHeaders(singletonMap("header-2", "header-2-value"))
             }
         }
 
-        given:
         HttpHeadersProvider hermesHeadersProvider = new HermesHeadersProvider(
                 ImmutableSet.of(additionalProviderOne, additionalProviderTwo)
         )
 
         when:
-        Map<String, String> headers = hermesHeadersProvider.getHeaders(message(), rawAddress()).asMap()
+        Map<String, String> headers =
+                hermesHeadersProvider.getHeaders(message(), requestData()).asMap()
 
         then:
         headers.get("header-1") == "header-1-value"

--- a/hermes-consumers/src/test/groovy/pl/allegro/tech/hermes/consumers/consumer/sender/http/headers/Http1HermesHeadersProviderTest.groovy
+++ b/hermes-consumers/src/test/groovy/pl/allegro/tech/hermes/consumers/consumer/sender/http/headers/Http1HermesHeadersProviderTest.groovy
@@ -3,8 +3,8 @@ package pl.allegro.tech.hermes.consumers.consumer.sender.http.headers
 import spock.lang.Specification
 import spock.lang.Unroll
 
+import static pl.allegro.tech.hermes.consumers.consumer.sender.http.headers.TestHttpRequestData.requestData
 import static pl.allegro.tech.hermes.consumers.consumer.sender.http.headers.TestMessages.message
-import static pl.allegro.tech.hermes.consumers.consumer.sender.http.headers.TestUris.rawAddress
 
 class Http1HermesHeadersProviderTest extends Specification {
 
@@ -13,7 +13,7 @@ class Http1HermesHeadersProviderTest extends Specification {
     @Unroll
     def "should contain #header header with correct value for http1"() {
         expect:
-        def headers = http1HeadersProvider.getHeaders(message(), rawAddress()).asMap()
+        def headers = http1HeadersProvider.getHeaders(message(), requestData()).asMap()
         headers.get(header) == value
 
         where:

--- a/hermes-consumers/src/test/groovy/pl/allegro/tech/hermes/consumers/consumer/sender/http/headers/Http1HermesHeadersProviderTest.groovy
+++ b/hermes-consumers/src/test/groovy/pl/allegro/tech/hermes/consumers/consumer/sender/http/headers/Http1HermesHeadersProviderTest.groovy
@@ -4,6 +4,7 @@ import spock.lang.Specification
 import spock.lang.Unroll
 
 import static pl.allegro.tech.hermes.consumers.consumer.sender.http.headers.TestMessages.message
+import static pl.allegro.tech.hermes.consumers.consumer.sender.http.headers.TestUris.rawAddress
 
 class Http1HermesHeadersProviderTest extends Specification {
 
@@ -12,7 +13,7 @@ class Http1HermesHeadersProviderTest extends Specification {
     @Unroll
     def "should contain #header header with correct value for http1"() {
         expect:
-        def headers = http1HeadersProvider.getHeaders(message()).asMap()
+        def headers = http1HeadersProvider.getHeaders(message(), rawAddress()).asMap()
         headers.get(header) == value
 
         where:

--- a/hermes-consumers/src/test/groovy/pl/allegro/tech/hermes/consumers/consumer/sender/http/headers/Http2HermesHeadersProviderTest.groovy
+++ b/hermes-consumers/src/test/groovy/pl/allegro/tech/hermes/consumers/consumer/sender/http/headers/Http2HermesHeadersProviderTest.groovy
@@ -4,8 +4,8 @@ import pl.allegro.tech.hermes.consumers.consumer.Message
 import spock.lang.Specification
 import spock.lang.Unroll
 
+import static pl.allegro.tech.hermes.consumers.consumer.sender.http.headers.TestHttpRequestData.requestData
 import static pl.allegro.tech.hermes.consumers.consumer.sender.http.headers.TestMessages.message
-import static pl.allegro.tech.hermes.consumers.consumer.sender.http.headers.TestUris.rawAddress
 
 class Http2HermesHeadersProviderTest extends Specification {
 
@@ -14,7 +14,7 @@ class Http2HermesHeadersProviderTest extends Specification {
     @Unroll
     def "should contain #header header with correct value for http1"() {
         when:
-        def headers = http2HeadersProvider.getHeaders(message(), rawAddress()).asMap()
+        def headers = http2HeadersProvider.getHeaders(message(), requestData()).asMap()
 
         then:
         headers.get( "Content-Type") == "application/json"
@@ -25,7 +25,7 @@ class Http2HermesHeadersProviderTest extends Specification {
         Message message = message()
 
         when:
-        HttpRequestHeaders headers = http2HeadersProvider.getHeaders(message, rawAddress())
+        HttpRequestHeaders headers = http2HeadersProvider.getHeaders(message, requestData())
 
         then:
         !headers.asMap().containsKey("Keep-Alive")

--- a/hermes-consumers/src/test/groovy/pl/allegro/tech/hermes/consumers/consumer/sender/http/headers/Http2HermesHeadersProviderTest.groovy
+++ b/hermes-consumers/src/test/groovy/pl/allegro/tech/hermes/consumers/consumer/sender/http/headers/Http2HermesHeadersProviderTest.groovy
@@ -5,6 +5,7 @@ import spock.lang.Specification
 import spock.lang.Unroll
 
 import static pl.allegro.tech.hermes.consumers.consumer.sender.http.headers.TestMessages.message
+import static pl.allegro.tech.hermes.consumers.consumer.sender.http.headers.TestUris.rawAddress
 
 class Http2HermesHeadersProviderTest extends Specification {
 
@@ -13,7 +14,7 @@ class Http2HermesHeadersProviderTest extends Specification {
     @Unroll
     def "should contain #header header with correct value for http1"() {
         when:
-        def headers = http2HeadersProvider.getHeaders(message()).asMap()
+        def headers = http2HeadersProvider.getHeaders(message(), rawAddress()).asMap()
 
         then:
         headers.get( "Content-Type") == "application/json"
@@ -24,7 +25,7 @@ class Http2HermesHeadersProviderTest extends Specification {
         Message message = message()
 
         when:
-        HttpRequestHeaders headers = http2HeadersProvider.getHeaders(message)
+        HttpRequestHeaders headers = http2HeadersProvider.getHeaders(message, rawAddress())
 
         then:
         !headers.asMap().containsKey("Keep-Alive")

--- a/hermes-consumers/src/test/groovy/pl/allegro/tech/hermes/consumers/consumer/sender/http/headers/TestHttpRequestData.groovy
+++ b/hermes-consumers/src/test/groovy/pl/allegro/tech/hermes/consumers/consumer/sender/http/headers/TestHttpRequestData.groovy
@@ -1,0 +1,13 @@
+package pl.allegro.tech.hermes.consumers.consumer.sender.http.headers
+
+import pl.allegro.tech.hermes.api.EndpointAddress
+import pl.allegro.tech.hermes.consumers.consumer.sender.http.HttpRequestData
+
+class TestHttpRequestData {
+
+    static HttpRequestData requestData() {
+        return new HttpRequestData.HttpRequestDataBuilder().
+                withRawAddress(EndpointAddress.of("http://localhost:8080"))
+                .build();
+    }
+}

--- a/hermes-consumers/src/test/groovy/pl/allegro/tech/hermes/consumers/consumer/sender/http/headers/TestUris.groovy
+++ b/hermes-consumers/src/test/groovy/pl/allegro/tech/hermes/consumers/consumer/sender/http/headers/TestUris.groovy
@@ -1,8 +1,0 @@
-package pl.allegro.tech.hermes.consumers.consumer.sender.http.headers
-
-class TestUris {
-
-    static String rawAddress() {
-        return "http://localhost:8080";
-    }
-}

--- a/hermes-consumers/src/test/groovy/pl/allegro/tech/hermes/consumers/consumer/sender/http/headers/TestUris.groovy
+++ b/hermes-consumers/src/test/groovy/pl/allegro/tech/hermes/consumers/consumer/sender/http/headers/TestUris.groovy
@@ -1,0 +1,8 @@
+package pl.allegro.tech.hermes.consumers.consumer.sender.http.headers
+
+class TestUris {
+
+    static String rawAddress() {
+        return "http://localhost:8080";
+    }
+}


### PR DESCRIPTION
At the moment there is no way to add additional headers to consumer messages to subscribers without hacking and slashing.

This PR allows specifying additional header providers to be used by consumer during message request creation. 

Other than that, each provider can now use raw (not-yet-resolved-by-address-resolvers) address to be used when resolving such additional headers.

That can be useful in a scenario when one want to send headers like `Host` or other that rely on the information stored in the address.