### PR TITLE
Management: Schema __metadata field validation

### DIFF
--- a/hermes-management/build.gradle
+++ b/hermes-management/build.gradle
@@ -26,6 +26,7 @@ dependencies {
     compile group: 'org.javers', name: 'javers-core', version: '5.2.5'
 
     compile group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: versions.jackson
+    compile group: 'commons-io', name: 'commons-io', version: '2.6'
 
     testCompile project(':hermes-test-helper')
     testCompile group: 'org.springframework.boot', name: 'spring-boot-starter-test', version: versions.spring

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/domain/topic/TopicService.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/domain/topic/TopicService.java
@@ -123,7 +123,7 @@ public class TopicService {
 
     private void validateSchema(boolean shouldValidate, TopicWithSchema topicWithSchema, Topic topic) {
         if (shouldValidate) {
-            schemaService.validateSchema(topic.getName(), topicWithSchema.getSchema());
+            schemaService.validateSchema(topic, topicWithSchema.getSchema());
             boolean schemaAlreadyRegistered = schemaService.getSchema(topic.getQualifiedName()).isPresent();
             if (schemaAlreadyRegistered) {
                 throw new TopicSchemaExistsException(topic.getQualifiedName());
@@ -134,7 +134,7 @@ public class TopicService {
     private void registerAvroSchema(boolean shouldRegister, TopicWithSchema topicWithSchema, String createdBy) {
         if (shouldRegister) {
             try {
-                schemaService.registerSchema(topicWithSchema.getTopic(), topicWithSchema.getSchema(), true);
+                schemaService.registerSchema(topicWithSchema.getTopic(), topicWithSchema.getSchema());
             } catch (Exception e) {
                 logger.error("Rolling back topic {} creation due to schema registration error", topicWithSchema.getQualifiedName(), e);
                 removeTopic(topicWithSchema.getTopic(), createdBy);
@@ -194,10 +194,9 @@ public class TopicService {
 
     public void updateTopicWithSchema(TopicName topicName, PatchData patch, String modifiedBy) {
         Topic topic = getTopicDetails(topicName);
-        boolean validateAvroSchema = AVRO.equals(topic.getContentType());
         extractSchema(patch)
                 .ifPresent(schema -> {
-                    schemaService.registerSchema(topic, schema, validateAvroSchema);
+                    schemaService.registerSchema(topic, schema);
                     scheduleTouchTopic(topicName);
                 });
         updateTopic(topicName, patch, modifiedBy);

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/infrastructure/schema/validator/AvroSchemaValidator.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/infrastructure/schema/validator/AvroSchemaValidator.java
@@ -1,8 +1,11 @@
 package pl.allegro.tech.hermes.management.infrastructure.schema.validator;
 
+import org.apache.commons.io.IOUtils;
 import org.apache.avro.Schema;
 import org.apache.avro.SchemaParseException;
 import org.springframework.stereotype.Component;
+
+import java.io.IOException;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Strings.isNullOrEmpty;
@@ -10,15 +13,50 @@ import static com.google.common.base.Strings.isNullOrEmpty;
 @Component
 public class AvroSchemaValidator implements SchemaValidator {
 
+    private static final Schema HERMES_METADATA_SCHEMA =
+            metadataFieldSchema(readAndParseResourceSchema("/avro-schema-metadata-field.avsc"));
+
     @Override
     public void check(String schema) throws InvalidSchemaException {
         checkArgument(!isNullOrEmpty(schema), "Message schema cannot be empty");
+        Schema parsedSchema = parseSchema(schema);
+        checkHermesMetadataField(parsedSchema);
+    }
 
+    private void checkHermesMetadataField(Schema parsedSchema) {
+        Schema metadata = metadataFieldSchema(parsedSchema);
+
+        boolean metadataTypeMatches = HERMES_METADATA_SCHEMA.getType().equals(metadata.getType());
+        boolean metadataNestedTypesMatch = HERMES_METADATA_SCHEMA.getTypes().equals(metadata.getTypes());
+        boolean valid = metadataTypeMatches && metadataNestedTypesMatch;
+
+        if (!valid) {
+            throw new InvalidSchemaException("Invalid types used in field __metadata");
+        }
+    }
+
+    private static Schema metadataFieldSchema(Schema schema) {
+        Schema.Field metadata = schema.getField("__metadata");
+        if (metadata == null) {
+            throw new InvalidSchemaException("Missing Hermes __metadata field");
+        }
+        return metadata.schema();
+    }
+
+    private static Schema readAndParseResourceSchema(String resourceFilePath) {
         try {
-            new Schema.Parser().parse(schema);
+            String schema = IOUtils.toString(AvroSchemaValidator.class.getResourceAsStream(resourceFilePath), "UTF-8");
+            return parseSchema(schema);
+        } catch (IOException e) {
+            throw new RuntimeException("Could not load schema with metadata");
+        }
+    }
+
+    private static Schema parseSchema(String schema) {
+        try {
+            return new Schema.Parser().parse(schema);
         } catch (SchemaParseException e) {
             throw new InvalidSchemaException(e);
         }
     }
-
 }

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/infrastructure/schema/validator/InvalidSchemaException.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/infrastructure/schema/validator/InvalidSchemaException.java
@@ -8,6 +8,10 @@ import static java.lang.String.format;
 
 public class InvalidSchemaException extends HermesException {
 
+    InvalidSchemaException(String cause) {
+        super(format("Error while trying to validate schema: %s", cause));
+    }
+
     InvalidSchemaException(SchemaParseException cause) {
         super(format("Error while trying to validate schema: %s", cause.getMessage()), cause);
     }

--- a/hermes-management/src/main/resources/avro-schema-metadata-field.avsc
+++ b/hermes-management/src/main/resources/avro-schema-metadata-field.avsc
@@ -1,0 +1,11 @@
+{
+  "type" : "record",
+  "name" : "minimalisticHermesSchema",
+  "fields" : [
+    {
+      "name": "__metadata", "default": null,
+      "type": ["null", {"type": "map", "values": "string"}],
+      "doc": "Field used in Hermes internals to propagate metadata like hermes-id"
+    }
+  ]
+}

--- a/hermes-management/src/test/groovy/pl/allegro/tech/hermes/management/infrastructure/schema/validator/AvroSchemaValidatorTest.groovy
+++ b/hermes-management/src/test/groovy/pl/allegro/tech/hermes/management/infrastructure/schema/validator/AvroSchemaValidatorTest.groovy
@@ -10,7 +10,7 @@ class AvroSchemaValidatorTest extends Specification {
 
     def "should accept valid schema"() {
         given:
-        def schema = IOUtils.toString(getClass().getResourceAsStream("/schema/user.avsc"), "UTF-8")
+        def schema = readSchema("/schema/user.avsc")
 
         expect:
         avroSchemaValidator.check(schema)
@@ -30,12 +30,48 @@ class AvroSchemaValidatorTest extends Specification {
         thrown(InvalidSchemaException)
     }
 
-
     def "should throw exception for invalid json"() {
         when:
         avroSchemaValidator.check('{')
 
         then:
         thrown(InvalidSchemaException)
+    }
+
+    def "should throw exception in case of empty schema"() {
+        when:
+        avroSchemaValidator.check("")
+
+        then:
+        def e = thrown IllegalArgumentException
+        e.message == "Message schema cannot be empty"
+    }
+
+    def "should throw exception in case of lack of __metadata field"() {
+        given:
+        def schema = readSchema("/schema/user_no_metadata.avsc")
+
+        when:
+        avroSchemaValidator.check(schema)
+
+        then:
+        def e = thrown InvalidSchemaException
+        e.message == "Error while trying to validate schema: Missing Hermes __metadata field"
+    }
+
+    def "should throw exception in case of incorrect types used in __metadata field"() {
+        given:
+        def schema = readSchema("/schema/user_metadata_with_avro_java_string.avsc")
+
+        when:
+        avroSchemaValidator.check(schema)
+
+        then:
+        def e = thrown InvalidSchemaException
+        e.message == "Error while trying to validate schema: Invalid types used in field __metadata"
+    }
+
+    private String readSchema(String path) {
+        IOUtils.toString(getClass().getResourceAsStream(path), "UTF-8")
     }
 }

--- a/hermes-test-helper/src/main/resources/schema/user_metadata_with_avro_java_string.avsc
+++ b/hermes-test-helper/src/main/resources/schema/user_metadata_with_avro_java_string.avsc
@@ -1,0 +1,15 @@
+{
+    "namespace": "pl.allegro",
+    "type": "record",
+    "name": "User",
+    "fields": [
+        {
+              "name": "__metadata",
+              "type": ["null", {"type": "map", "values": "string", "avro.java.string": "String"}],
+              "default": null
+        },
+        {"name": "name", "type": "string", "avro.java.string": "String"},
+        {"name": "age",  "type": "int"},
+        {"name": "favoriteColor", "type": ["null", "string"]}
+    ]
+}

--- a/integration/src/integration/java/pl/allegro/tech/hermes/integration/PublishingAvroTest.java
+++ b/integration/src/integration/java/pl/allegro/tech/hermes/integration/PublishingAvroTest.java
@@ -237,28 +237,6 @@ public class PublishingAvroTest extends IntegrationTest {
     }
 
     @Test
-    public void shouldReturnBadRequestResponseOnMissingMetadataFieldInSchema() {
-        // given
-        Schema schema = AvroUserSchemaLoader.load("/schema/user.avsc");
-        Topic topic = randomTopic("pl.allegro.test", "Topic")
-                .withContentType(AVRO)
-                .build();
-        operations.buildTopicWithSchema(topicWithSchema(topic, schema.toString()));
-
-        Schema schemaWithoutMetadata = AvroUserSchemaLoader.load("/schema/user_no_metadata.avsc");
-        management.schema().save(topic.getQualifiedName(), false, schemaWithoutMetadata.toString());
-
-        // when
-        Response response = publisher.publish(topic.getQualifiedName(), user.asJson());
-
-        // then
-        assertThat(response).hasStatus(BAD_REQUEST);
-        assertThat(response.readEntity(String.class))
-                .isEqualTo("{\"message\":\"Schema does not contain mandatory __metadata field for Hermes internal metadata. " +
-                        "Please fix topic schema.\",\"code\":\"AVRO_SCHEMA_INVALID_METADATA\"}");
-    }
-
-    @Test
     public void shouldPublishJsonIncompatibleWithSchemaWhileJsonToAvroDryRunModeIsEnabled() {
         // given
         Topic topic = randomTopic("jsonToAvroDryRun", "topic")

--- a/integration/src/integration/java/pl/allegro/tech/hermes/integration/PublishingAvroTest.java
+++ b/integration/src/integration/java/pl/allegro/tech/hermes/integration/PublishingAvroTest.java
@@ -196,24 +196,12 @@ public class PublishingAvroTest extends IntegrationTest {
     @Test
     public void shouldGetBadRequestForJsonNotMachingWithAvroSchema() {
         // given
-        Topic topic = topic("pl.allegro", "Foo").withContentType(AVRO).build();
-        String schema = "{\n" +
-                "    \"namespace\": \"pl.allegro\",\n" +
-                "    \"type\": \"record\",\n" +
-                "    \"name\": \"Foo\",\n" +
-                "    \"fields\": [\n" +
-                "        {\n" +
-                "              \"name\": \"__metadata\",\n" +
-                "              \"type\": [\"null\", {\"type\": \"map\", \"values\": \"string\"}],\n" +
-                "              \"default\": null\n" +
-                "        },\n" +
-                "        {\"name\": \"field_int\", \"type\": \"int\"}\n" +
-                "    ]\n" +
-                "}";
-        operations.buildTopicWithSchema(topicWithSchema(topic, schema));
+        Topic topic = topic("pl.allegro", "User").withContentType(AVRO).build();
+        Schema schema = AvroUserSchemaLoader.load("/schema/user.avsc");
+        operations.buildTopicWithSchema(topicWithSchema(topic, schema.toString()));
 
         // when
-        String message = "{\"__metadata\":null,\"field_int\":\"incorrect value\"}";
+        String message = "{\"__metadata\":null,\"name\":\"john\",\"age\":\"string instead of int\"}";
         Response response = publisher.publish(topic.getQualifiedName(), message, singletonMap("Content-Type", AVRO_JSON));
 
         // then

--- a/integration/src/integration/java/pl/allegro/tech/hermes/integration/PublishingAvroTest.java
+++ b/integration/src/integration/java/pl/allegro/tech/hermes/integration/PublishingAvroTest.java
@@ -15,7 +15,6 @@ import pl.allegro.tech.hermes.schema.CompiledSchema;
 import pl.allegro.tech.hermes.schema.SchemaVersion;
 import pl.allegro.tech.hermes.test.helper.avro.AvroUser;
 import pl.allegro.tech.hermes.test.helper.avro.AvroUserSchemaLoader;
-import pl.allegro.tech.hermes.test.helper.builder.TopicBuilder;
 import pl.allegro.tech.hermes.test.helper.endpoint.RemoteServiceEndpoint;
 import pl.allegro.tech.hermes.test.helper.message.TestMessage;
 
@@ -44,7 +43,6 @@ import static pl.allegro.tech.hermes.client.HermesMessage.hermesMessage;
 import static pl.allegro.tech.hermes.integration.test.HermesAssertions.assertThat;
 import static pl.allegro.tech.hermes.test.helper.avro.AvroUserSchemaLoader.load;
 import static pl.allegro.tech.hermes.test.helper.builder.TopicBuilder.randomTopic;
-import static pl.allegro.tech.hermes.test.helper.builder.TopicBuilder.topic;
 
 public class PublishingAvroTest extends IntegrationTest {
 
@@ -196,7 +194,7 @@ public class PublishingAvroTest extends IntegrationTest {
     @Test
     public void shouldGetBadRequestForJsonNotMachingWithAvroSchema() {
         // given
-        Topic topic = topic("pl.allegro", "User").withContentType(AVRO).build();
+        Topic topic = randomTopic("pl.allegro", "User").withContentType(AVRO).build();
         Schema schema = AvroUserSchemaLoader.load("/schema/user.avsc");
         operations.buildTopicWithSchema(topicWithSchema(topic, schema.toString()));
 
@@ -241,11 +239,14 @@ public class PublishingAvroTest extends IntegrationTest {
     @Test
     public void shouldReturnBadRequestResponseOnMissingMetadataFieldInSchema() {
         // given
-        Schema schema = AvroUserSchemaLoader.load("/schema/user_no_metadata.avsc");
+        Schema schema = AvroUserSchemaLoader.load("/schema/user.avsc");
         Topic topic = randomTopic("pl.allegro.test", "Topic")
                 .withContentType(AVRO)
                 .build();
         operations.buildTopicWithSchema(topicWithSchema(topic, schema.toString()));
+
+        Schema schemaWithoutMetadata = AvroUserSchemaLoader.load("/schema/user_no_metadata.avsc");
+        management.schema().save(topic.getQualifiedName(), false, schemaWithoutMetadata.toString());
 
         // when
         Response response = publisher.publish(topic.getQualifiedName(), user.asJson());

--- a/integration/src/integration/java/pl/allegro/tech/hermes/integration/management/SchemaManagementTest.java
+++ b/integration/src/integration/java/pl/allegro/tech/hermes/integration/management/SchemaManagementTest.java
@@ -14,8 +14,6 @@ import static pl.allegro.tech.hermes.test.helper.builder.TopicBuilder.randomTopi
 
 public class SchemaManagementTest extends IntegrationTest {
 
-    private static final String EXAMPLE_SCHEMA = "\"string\"";
-
     private static final String SCHEMA_V1 = AvroUserSchemaLoader.load().toString();
 
     private static final String SCHEMA_V2 = AvroUserSchemaLoader.load("/schema/user_v2.avsc").toString();
@@ -46,13 +44,13 @@ public class SchemaManagementTest extends IntegrationTest {
     public void shouldReturnSchemaForTopic() {
         // given
         Topic topic = randomTopic("schemaGroup2", "schemaTopic2").withContentType(AVRO).build();
-        operations.buildTopicWithSchema(topicWithSchema(topic, EXAMPLE_SCHEMA));
+        operations.buildTopicWithSchema(topicWithSchema(topic, SCHEMA_V1));
 
         // when
         Response response = management.schema().get(topic.getQualifiedName());
 
         // then
-        assertThat(response.readEntity(String.class)).isEqualTo(EXAMPLE_SCHEMA);
+        assertThat(response.readEntity(String.class)).isEqualTo(SCHEMA_V1);
     }
 
     @Test
@@ -68,7 +66,7 @@ public class SchemaManagementTest extends IntegrationTest {
     public void shouldSuccessfullyRemoveSchemaWhenSchemaRemovingIsEnabled() {
         // given
         Topic topic = randomTopic("avroGroup", "avroTopic").withContentType(AVRO).build();
-        operations.buildTopicWithSchema(topicWithSchema(topic, EXAMPLE_SCHEMA));
+        operations.buildTopicWithSchema(topicWithSchema(topic, SCHEMA_V1));
 
         // when
         Response response = management.schema().delete(topic.getQualifiedName());
@@ -81,7 +79,7 @@ public class SchemaManagementTest extends IntegrationTest {
     public void shouldNotSaveInvalidAvroSchema() {
         // given
         Topic topic = randomTopic("avroGroup", "avroTopic").withContentType(AVRO).build();
-        operations.buildTopicWithSchema(topicWithSchema(topic, EXAMPLE_SCHEMA));
+        operations.buildTopicWithSchema(topicWithSchema(topic, SCHEMA_V1));
 
         // when
         Response response = management.schema().save(topic.getQualifiedName(), "{");
@@ -96,7 +94,7 @@ public class SchemaManagementTest extends IntegrationTest {
         Topic topic = operations.buildTopic(randomTopic("someGroup", "jsonTopic").build());
 
         // when
-        Response response = management.schema().save(topic.getQualifiedName(), true, EXAMPLE_SCHEMA);
+        Response response = management.schema().save(topic.getQualifiedName(), true, SCHEMA_V1);
 
         // then
         assertThat(response).hasStatus(Response.Status.BAD_REQUEST);


### PR DESCRIPTION
References #1015 

## Changes
Hermes Management does not allow to save topic with an invalid Avro schemas:
- schema without field `__metadata`
- schema with field `__metadata` that declares types other than hermes specifies in documentation, for example `java.avro.string`