### PR TITLE
Fix typo in docs

### DIFF
--- a/docs/docs/user/java-client.md
+++ b/docs/docs/user/java-client.md
@@ -73,7 +73,7 @@ hermesClient.publish(
 );
 ```
 
-Publication reuslts in returning `HermesResponse` object:
+Publication results in returning `HermesResponse` object:
 
 ```java
 CompletableFuture<HermesResponse> result = client.publish("group.topic", "{}");


### PR DESCRIPTION
Hi there!
I've found and fixed some typo but cannot see a ```develop``` branch as mentioned [here](https://github.com/allegro/hermes/blob/master/CONTRIBUTING.md) so ```master``` seems to be good one for such a small change :)