### PR TITLE
Resolve #1164 | Removed duplicated counter for filtered messages

### DIFF
--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/common/metric/Counters.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/common/metric/Counters.java
@@ -11,7 +11,6 @@ public class Counters {
             UNPUBLISHED = "unpublished." + GROUP + "." + TOPIC,
             DELIVERED = "delivered." + GROUP + "." + TOPIC + "." + SUBSCRIPTION,
             DISCARDED = "discarded." + GROUP + "." + TOPIC + "." + SUBSCRIPTION,
-            FILTERED = "filtered." + GROUP + "." + TOPIC + "." + SUBSCRIPTION,
             INFLIGHT = "inflight." + GROUP + "." + TOPIC + "." + SUBSCRIPTION,
             EXECUTOR_RUNNING = "executors." + EXECUTOR_NAME + ".running",
             SCHEDULED_EXECUTOR_OVERRUN = "executors." + EXECUTOR_NAME + ".overrun",

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/filtering/FilteredMessageHandler.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/filtering/FilteredMessageHandler.java
@@ -3,7 +3,6 @@ package pl.allegro.tech.hermes.consumers.consumer.filtering;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import pl.allegro.tech.hermes.api.Subscription;
-import pl.allegro.tech.hermes.common.metric.Counters;
 import pl.allegro.tech.hermes.common.metric.HermesMetrics;
 import pl.allegro.tech.hermes.common.metric.Meters;
 import pl.allegro.tech.hermes.consumers.consumer.Message;
@@ -55,6 +54,5 @@ public class FilteredMessageHandler {
 
     private void updateMetrics(Subscription subscription) {
         metrics.meter(Meters.FILTERED_METER, subscription.getTopicName(), subscription.getName()).mark();
-        metrics.counter(Counters.FILTERED, subscription.getTopicName(), subscription.getName()).inc();
     }
 }


### PR DESCRIPTION
Removed duplicated counter for filtered messages. We already have `meter` for filtered messages which also contains counter, therefore we don’t need second counter for the same operation.