### PR TITLE
Resolve #1211 | Read only mode persistence

### DIFF
--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/api/ModeEndpoint.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/api/ModeEndpoint.java
@@ -17,8 +17,8 @@ import javax.ws.rs.core.Response;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static javax.ws.rs.core.MediaType.TEXT_PLAIN;
-import static pl.allegro.tech.hermes.management.domain.mode.ModeService.ManagementMode.READ_ONLY;
 import static pl.allegro.tech.hermes.management.domain.mode.ModeService.ManagementMode.READ_WRITE;
+import static pl.allegro.tech.hermes.management.domain.mode.ModeService.ManagementMode.READ_ONLY_ADMIN;
 
 @Component
 @Path("/mode")
@@ -51,7 +51,7 @@ public class ModeEndpoint {
                 modeService.setMode(READ_WRITE);
                 break;
             case ModeService.READ_ONLY:
-                modeService.setMode(READ_ONLY);
+                modeService.setMode(READ_ONLY_ADMIN);
                 break;
             default:
                 return Response.status(Response.Status.BAD_REQUEST).build();

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/api/ModeEndpoint.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/api/ModeEndpoint.java
@@ -48,10 +48,11 @@ public class ModeEndpoint {
         }
         switch (mode) {
             case ModeService.READ_WRITE:
-                modeService.setMode(READ_WRITE);
+                modeService.setModeByAdmin(READ_WRITE);
                 break;
             case ModeService.READ_ONLY:
-                modeService.setMode(READ_ONLY_ADMIN);
+            case ModeService.READ_ONLY_ADMIN:
+                modeService.setModeByAdmin(READ_ONLY_ADMIN);
                 break;
             default:
                 return Response.status(Response.Status.BAD_REQUEST).build();

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/domain/health/HealthCheckTask.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/domain/health/HealthCheckTask.java
@@ -57,13 +57,10 @@ class HealthCheckTask implements Runnable {
     }
 
     private void updateMode(List<HealthCheckResult> healthCheckResults) {
-        /* ReadOnly set by admin can be changed to ReadWrite only by admin */
-        if (!modeService.isReadOnlySetByAdmin()) {
-            if (healthCheckResults.contains(HealthCheckResult.UNHEALTHY)) {
-                modeService.setMode(ModeService.ManagementMode.READ_ONLY);
-            } else {
-                modeService.setMode(ModeService.ManagementMode.READ_WRITE);
-            }
+        if (healthCheckResults.contains(HealthCheckResult.UNHEALTHY)) {
+            modeService.compareAndSwapMode(ModeService.ManagementMode.READ_WRITE, ModeService.ManagementMode.READ_ONLY);
+        } else {
+            modeService.compareAndSwapMode(ModeService.ManagementMode.READ_ONLY, ModeService.ManagementMode.READ_WRITE);
         }
     }
 

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/domain/health/HealthCheckTask.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/domain/health/HealthCheckTask.java
@@ -57,10 +57,13 @@ class HealthCheckTask implements Runnable {
     }
 
     private void updateMode(List<HealthCheckResult> healthCheckResults) {
-        if (healthCheckResults.contains(HealthCheckResult.UNHEALTHY)) {
-            modeService.setMode(ModeService.ManagementMode.READ_ONLY);
-        } else {
-            modeService.setMode(ModeService.ManagementMode.READ_WRITE);
+        /* ReadOnly set by admin can be changed to ReadWrite only by admin */
+        if (!modeService.isReadOnlySetByAdmin()) {
+            if (healthCheckResults.contains(HealthCheckResult.UNHEALTHY)) {
+                modeService.setMode(ModeService.ManagementMode.READ_ONLY);
+            } else {
+                modeService.setMode(ModeService.ManagementMode.READ_WRITE);
+            }
         }
     }
 

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/domain/health/HealthCheckTask.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/domain/health/HealthCheckTask.java
@@ -58,9 +58,9 @@ class HealthCheckTask implements Runnable {
 
     private void updateMode(List<HealthCheckResult> healthCheckResults) {
         if (healthCheckResults.contains(HealthCheckResult.UNHEALTHY)) {
-            modeService.compareAndSwapMode(ModeService.ManagementMode.READ_WRITE, ModeService.ManagementMode.READ_ONLY);
+            modeService.setMode(ModeService.ManagementMode.READ_ONLY);
         } else {
-            modeService.compareAndSwapMode(ModeService.ManagementMode.READ_ONLY, ModeService.ManagementMode.READ_WRITE);
+            modeService.setMode(ModeService.ManagementMode.READ_WRITE);
         }
     }
 

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/domain/mode/ModeService.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/domain/mode/ModeService.java
@@ -7,10 +7,12 @@ public class ModeService {
 
     public static final String READ_WRITE = "readWrite";
     public static final String READ_ONLY = "readOnly";
+    public static final String READ_ONLY_ADMIN = "readOnlyAdmin";
 
     public enum ManagementMode {
         READ_WRITE(ModeService.READ_WRITE),
-        READ_ONLY(ModeService.READ_ONLY);
+        READ_ONLY(ModeService.READ_ONLY),
+        READ_ONLY_ADMIN(ModeService.READ_ONLY_ADMIN);
 
         private final String text;
 
@@ -35,6 +37,10 @@ public class ModeService {
     }
 
     public boolean isReadOnlyEnabled() {
-        return mode == ManagementMode.READ_ONLY;
+        return mode == ManagementMode.READ_ONLY || mode == ManagementMode.READ_ONLY_ADMIN;
+    }
+
+    public boolean isReadOnlySetByAdmin() {
+        return mode == ManagementMode.READ_ONLY_ADMIN;
     }
 }

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/domain/mode/ModeService.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/domain/mode/ModeService.java
@@ -32,7 +32,7 @@ public class ModeService {
         return mode;
     }
 
-    public synchronized void setMode(ManagementMode mode) {
+    public synchronized void setModeByAdmin(ManagementMode mode) {
         this.mode = mode;
     }
 
@@ -40,9 +40,10 @@ public class ModeService {
         return mode == ManagementMode.READ_ONLY || mode == ManagementMode.READ_ONLY_ADMIN;
     }
 
-    public synchronized void compareAndSwapMode(ManagementMode expectedMode, ManagementMode newMode) {
-        if (mode.equals(expectedMode)) {
-            setMode(newMode);
+    public synchronized void setMode(ManagementMode newMode) {
+        /* READ_ONLY_ADMIN is a flag that can be changed only by admin */
+        if (!mode.equals(ManagementMode.READ_ONLY_ADMIN)) {
+            this.mode = newMode;
         }
     }
 }

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/domain/mode/ModeService.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/domain/mode/ModeService.java
@@ -32,7 +32,7 @@ public class ModeService {
         return mode;
     }
 
-    public void setMode(ManagementMode mode) {
+    public synchronized void setMode(ManagementMode mode) {
         this.mode = mode;
     }
 
@@ -40,7 +40,9 @@ public class ModeService {
         return mode == ManagementMode.READ_ONLY || mode == ManagementMode.READ_ONLY_ADMIN;
     }
 
-    public boolean isReadOnlySetByAdmin() {
-        return mode == ManagementMode.READ_ONLY_ADMIN;
+    public synchronized void compareAndSwapMode(ManagementMode expectedMode, ManagementMode newMode) {
+        if (mode.equals(expectedMode)) {
+            setMode(newMode);
+        }
     }
 }

--- a/hermes-management/src/test/groovy/pl/allegro/tech/hermes/management/domain/health/HealthCheckTaskTest.groovy
+++ b/hermes-management/src/test/groovy/pl/allegro/tech/hermes/management/domain/health/HealthCheckTaskTest.groovy
@@ -90,6 +90,39 @@ class HealthCheckTaskTest extends MultiZookeeperIntegrationTest {
         successfulCounter.count() == 3
     }
 
+    def "should not change status to READ_WRITE if READ_ONLY is set by admin"() {
+        given:
+        modeService.setMode(ModeService.ManagementMode.READ_ONLY_ADMIN)
+
+        when:
+        zookeeper1.start()
+        healthCheckTask.run()
+
+        then:
+        modeService.readOnlyEnabled
+
+        and:
+        successfulCounter.count() == 2
+    }
+
+    def "should change status from READ_ONLY_ADMIN to READ_WRITE only by admin"() {
+        given:
+        modeService.setMode(ModeService.ManagementMode.READ_ONLY_ADMIN)
+
+        when:
+        zookeeper1.start()
+        healthCheckTask.run()
+
+        then:
+        modeService.readOnlyEnabled
+
+        when:
+        modeService.setMode(ModeService.ManagementMode.READ_WRITE)
+
+        then:
+        !modeService.readOnlyEnabled
+    }
+
     static setupZookeeperPath(ZookeeperClient zookeeperClient, String path) {
         def healthCheckPathExists = zookeeperClient.curatorFramework
                 .checkExists()

--- a/hermes-management/src/test/groovy/pl/allegro/tech/hermes/management/domain/health/HealthCheckTaskTest.groovy
+++ b/hermes-management/src/test/groovy/pl/allegro/tech/hermes/management/domain/health/HealthCheckTaskTest.groovy
@@ -92,10 +92,9 @@ class HealthCheckTaskTest extends MultiZookeeperIntegrationTest {
 
     def "should not change status to READ_WRITE if READ_ONLY is set by admin"() {
         given:
-        modeService.setMode(ModeService.ManagementMode.READ_ONLY_ADMIN)
+        modeService.setModeByAdmin(ModeService.ManagementMode.READ_ONLY_ADMIN)
 
         when:
-        zookeeper1.start()
         healthCheckTask.run()
 
         then:
@@ -107,17 +106,16 @@ class HealthCheckTaskTest extends MultiZookeeperIntegrationTest {
 
     def "should change status from READ_ONLY_ADMIN to READ_WRITE only by admin"() {
         given:
-        modeService.setMode(ModeService.ManagementMode.READ_ONLY_ADMIN)
+        modeService.setModeByAdmin(ModeService.ManagementMode.READ_ONLY_ADMIN)
 
         when:
-        zookeeper1.start()
         healthCheckTask.run()
 
         then:
         modeService.readOnlyEnabled
 
         when:
-        modeService.setMode(ModeService.ManagementMode.READ_WRITE)
+        modeService.setModeByAdmin(ModeService.ManagementMode.READ_WRITE)
 
         then:
         !modeService.readOnlyEnabled


### PR DESCRIPTION
Read only mode set by admin (READ_ONLY_ADMIN) in hermes management is not overwritten by healthcheck task.