### PR TITLE
hermes-mock: adding modules find and register by default

### DIFF
--- a/hermes-mock/src/main/java/pl/allegro/tech/hermes/mock/HermesMock.java
+++ b/hermes-mock/src/main/java/pl/allegro/tech/hermes/mock/HermesMock.java
@@ -53,7 +53,7 @@ public class HermesMock {
         public Builder() {
             port = wireMockConfig().portNumber();
             awaitSeconds = 5;
-            objectMapper = new ObjectMapper();
+            objectMapper = new ObjectMapper().findAndRegisterModules();
         }
 
         public HermesMock.Builder withPort(int port) {


### PR DESCRIPTION
It is required to use annotations like @JsonCreator / @JsonProperty for classes written in kotlin. Using jackson-module-kotlin does not help, because it is not registered by default to object mapper used by HermesMockRule. 

Adding this small change fixes problem with redundant jackson annotations, and probably also a few other problems (I guess i.e. with dates conversion).   

Any idea, to test for this change?