### PR TITLE
configurable namespace separator

### DIFF
--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/common/config/Configs.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/common/config/Configs.java
@@ -35,6 +35,7 @@ public enum Configs {
     KAFKA_CLUSTER_NAME("kafka.cluster.name", "primary-dc"),
     KAFKA_BROKER_LIST("kafka.broker.list", "localhost:9092"),
     KAFKA_NAMESPACE("kafka.namespace", ""),
+    KAFKA_NAMESPACE_SEPARATOR("kafka.namespace.separator", "_"),
 
     KAFKA_HEADER_NAME_MESSAGE_ID("kafka.header.name.message.id", "id"),
     KAFKA_HEADER_NAME_TIMESTAMP("kafka.header.name.timestamp", "ts"),

--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/common/kafka/JsonToAvroMigrationKafkaNamesMapper.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/common/kafka/JsonToAvroMigrationKafkaNamesMapper.java
@@ -11,6 +11,10 @@ public class JsonToAvroMigrationKafkaNamesMapper extends NamespaceKafkaNamesMapp
         super(namespace);
     }
 
+    public JsonToAvroMigrationKafkaNamesMapper(String namespace, String namespaceSeparator) {
+        super(namespace, namespaceSeparator);
+    }
+
     public KafkaTopics toKafkaTopics(Topic topic) {
         KafkaTopic primary = mapToKafkaTopic.andThen(appendNamespace).andThen(appendContentTypeSuffix).apply(topic);
 

--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/common/kafka/KafkaNamesMapperFactory.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/common/kafka/KafkaNamesMapperFactory.java
@@ -9,15 +9,17 @@ import javax.inject.Inject;
 public class KafkaNamesMapperFactory implements Factory<KafkaNamesMapper> {
 
     private final String namespace;
+    private final String namespaceSeparator;
 
     @Inject
     public KafkaNamesMapperFactory(ConfigFactory configFactory) {
         this.namespace = configFactory.getStringProperty(Configs.KAFKA_NAMESPACE);
+        this.namespaceSeparator = configFactory.getStringProperty(Configs.KAFKA_NAMESPACE_SEPARATOR);
     }
 
     @Override
     public KafkaNamesMapper provide() {
-        return new NamespaceKafkaNamesMapper(namespace);
+        return new NamespaceKafkaNamesMapper(namespace, namespaceSeparator);
     }
 
     @Override

--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/common/kafka/NamespaceKafkaNamesMapper.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/common/kafka/NamespaceKafkaNamesMapper.java
@@ -3,6 +3,7 @@ package pl.allegro.tech.hermes.common.kafka;
 import com.google.common.base.Joiner;
 import pl.allegro.tech.hermes.api.SubscriptionName;
 import pl.allegro.tech.hermes.api.Topic;
+import pl.allegro.tech.hermes.common.config.Configs;
 
 import java.util.function.Function;
 
@@ -10,12 +11,16 @@ import static pl.allegro.tech.hermes.api.helpers.Replacer.replaceInAll;
 
 public class NamespaceKafkaNamesMapper implements KafkaNamesMapper {
 
-    private static final String SEPARATOR = "_";
-
     private final String namespace;
+    private final String namespaceSeparator;
 
     public NamespaceKafkaNamesMapper(String namespace) {
+        this(namespace, Configs.KAFKA_NAMESPACE_SEPARATOR.getDefaultValue());
+    }
+
+    public NamespaceKafkaNamesMapper(String namespace, String namespaceSeparator) {
         this.namespace = namespace;
+        this.namespaceSeparator = namespaceSeparator;
     }
 
     @Override
@@ -47,6 +52,6 @@ public class NamespaceKafkaNamesMapper implements KafkaNamesMapper {
     }
 
     private String appendNamespace(String name) {
-        return namespace.isEmpty() ? name : namespace + SEPARATOR + name;
+        return namespace.isEmpty() ? name : namespace + namespaceSeparator + name;
     }
 }

--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/common/schema/RawSchemaClientFactory.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/common/schema/RawSchemaClientFactory.java
@@ -35,7 +35,9 @@ public class RawSchemaClientFactory implements Factory<RawSchemaClient> {
                 .withValueSuffixIf(configFactory.getBooleanProperty(Configs.SCHEMA_REPOSITORY_SUBJECT_SUFFIX_ENABLED))
                 .withNamespacePrefixIf(
                         configFactory.getBooleanProperty(Configs.SCHEMA_REPOSITORY_SUBJECT_NAMESPACE_ENABLED),
-                        configFactory.getStringProperty(Configs.KAFKA_NAMESPACE));
+                        new SubjectNamingStrategy.Namespace(
+                                configFactory.getStringProperty(Configs.KAFKA_NAMESPACE),
+                                configFactory.getStringProperty(Configs.KAFKA_NAMESPACE_SEPARATOR)));
         String schemaRepositoryType = configFactory.getStringProperty(Configs.SCHEMA_REPOSITORY_TYPE).toUpperCase();
         SchemaRepositoryType repoType = SchemaRepositoryType.valueOf(schemaRepositoryType);
         switch (repoType) {

--- a/hermes-frontend/src/test/java/pl/allegro/tech/hermes/frontend/producer/kafka/KafkaBrokerMessageProducerTest.java
+++ b/hermes-frontend/src/test/java/pl/allegro/tech/hermes/frontend/producer/kafka/KafkaBrokerMessageProducerTest.java
@@ -44,7 +44,7 @@ public class KafkaBrokerMessageProducerTest {
     private Producers producers = new Producers(leaderConfirmsProducer, everyoneConfirmProducer, configFactory);
 
     private KafkaBrokerMessageProducer producer;
-    private KafkaNamesMapper kafkaNamesMapper = new NamespaceKafkaNamesMapper("ns");
+    private KafkaNamesMapper kafkaNamesMapper = new NamespaceKafkaNamesMapper("ns", "_");
     private KafkaHeaderFactory kafkaHeaderFactory = new KafkaHeaderFactory(configFactory);
 
     @Mock

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/config/SchemaRepositoryConfiguration.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/config/SchemaRepositoryConfiguration.java
@@ -58,7 +58,9 @@ public class SchemaRepositoryConfiguration {
     @Bean
     public SubjectNamingStrategy subjectNamingStrategy(KafkaClustersProperties kafkaClustersProperties) {
         return qualifiedName
-                .withNamespacePrefixIf(schemaRepositoryProperties.isSubjectNamespaceEnabled(), kafkaClustersProperties.getDefaultNamespace())
+                .withNamespacePrefixIf(
+                        schemaRepositoryProperties.isSubjectNamespaceEnabled(),
+                        new SubjectNamingStrategy.Namespace(kafkaClustersProperties.getDefaultNamespace(), kafkaClustersProperties.getNamespaceSeparator()))
                 .withValueSuffixIf(schemaRepositoryProperties.isSubjectSuffixEnabled());
     }
 

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/config/kafka/KafkaClustersProperties.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/config/kafka/KafkaClustersProperties.java
@@ -10,6 +10,7 @@ import java.util.List;
 public class KafkaClustersProperties {
     private List<KafkaProperties> clusters = new ArrayList<>();
     private String defaultNamespace = "";
+    private String namespaceSeparator = "_";
 
     public List<KafkaProperties> getClusters() {
         return clusters;
@@ -25,5 +26,13 @@ public class KafkaClustersProperties {
 
     public void setDefaultNamespace(String defaultNamespace) {
         this.defaultNamespace = defaultNamespace;
+    }
+
+    public String getNamespaceSeparator() {
+        return namespaceSeparator;
+    }
+
+    public void setNamespaceSeparator(String namespaceSeparator) {
+        this.namespaceSeparator = namespaceSeparator;
     }
 }

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/config/kafka/MultipleDcKafkaNamesMappersFactory.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/config/kafka/MultipleDcKafkaNamesMappersFactory.java
@@ -11,7 +11,7 @@ import static java.util.stream.Collectors.toMap;
 public interface MultipleDcKafkaNamesMappersFactory {
 
     default KafkaNamesMappers createDefaultKafkaNamesMapper(KafkaClustersProperties clustersProperties) {
-        return createKafkaNamesMapper(clustersProperties, namespace -> new NamespaceKafkaNamesMapper(namespace));
+        return createKafkaNamesMapper(clustersProperties, namespace -> new NamespaceKafkaNamesMapper(namespace, clustersProperties.getNamespaceSeparator()));
     }
 
     default KafkaNamesMappers createKafkaNamesMapper(KafkaClustersProperties clustersProperties, Function<String, KafkaNamesMapper> factoryFunction) {

--- a/hermes-schema/src/main/java/pl/allegro/tech/hermes/schema/SubjectNamingStrategy.java
+++ b/hermes-schema/src/main/java/pl/allegro/tech/hermes/schema/SubjectNamingStrategy.java
@@ -4,12 +4,30 @@ import pl.allegro.tech.hermes.api.TopicName;
 
 public interface SubjectNamingStrategy {
 
+    class Namespace {
+        private final String value;
+        private final String separator;
+
+        public Namespace(String value, String separator) {
+            this.value = value;
+            this.separator = separator;
+        }
+
+        public String getValue() {
+            return value;
+        }
+
+        public String apply(String name) {
+            return value.isEmpty() ? name : value + separator + name;
+        }
+    }
+
     String apply(TopicName topic);
 
     SubjectNamingStrategy qualifiedName = TopicName::qualifiedName;
 
-    default SubjectNamingStrategy withNamespacePrefixIf(boolean enabled, String namespace) {
-        return enabled ? topicName -> namespace + "." + this.apply(topicName) : this;
+    default SubjectNamingStrategy withNamespacePrefixIf(boolean enabled, Namespace namespace) {
+        return enabled ? topicName -> namespace.apply(this.apply(topicName)) : this;
     }
 
     default SubjectNamingStrategy withValueSuffixIf(boolean valueSuffixEnabled) {

--- a/hermes-schema/src/test/groovy/pl/allegro/tech/hermes/schema/SubjectNamingStrategyTest.groovy
+++ b/hermes-schema/src/test/groovy/pl/allegro/tech/hermes/schema/SubjectNamingStrategyTest.groovy
@@ -10,6 +10,8 @@ import static pl.allegro.tech.hermes.schema.SubjectNamingStrategy.qualifiedName
 @Subject(SubjectNamingStrategy)
 class SubjectNamingStrategyTest extends Specification {
 
+    static def namespace = new SubjectNamingStrategy.Namespace("ns", "_")
+
     def "should create proper subject names"() {
         given:
         def topicName = new TopicName("group", "name")
@@ -21,20 +23,20 @@ class SubjectNamingStrategyTest extends Specification {
         subjectNamingStrategy << [
                 qualifiedName,
                 qualifiedName.withValueSuffixIf(true),
-                qualifiedName.withNamespacePrefixIf(true, "ns"),
+                qualifiedName.withNamespacePrefixIf(true, namespace),
                 qualifiedName
                         .withValueSuffixIf(true)
-                        .withNamespacePrefixIf(true, "ns"),
+                        .withNamespacePrefixIf(true, namespace),
                 qualifiedName
-                        .withNamespacePrefixIf(true, "ns")
+                        .withNamespacePrefixIf(true, namespace)
                         .withValueSuffixIf(true)
         ]
         subject << [
                 "group.name",
                 "group.name-value",
-                "ns.group.name",
-                "ns.group.name-value",
-                "ns.group.name-value"
+                "ns_group.name",
+                "ns_group.name-value",
+                "ns_group.name-value"
         ]
     }
 }

--- a/hermes-schema/src/test/groovy/pl/allegro/tech/hermes/schema/confluent/SchemaRegistryRawSchemaClientTest.groovy
+++ b/hermes-schema/src/test/groovy/pl/allegro/tech/hermes/schema/confluent/SchemaRegistryRawSchemaClientTest.groovy
@@ -54,11 +54,12 @@ class SchemaRegistryRawSchemaClientTest extends Specification {
         wireMock = new WireMockServer(port)
         wireMock.start()
         resolver = new DefaultSchemaRepositoryInstanceResolver(ClientBuilder.newClient(), URI.create("http://localhost:$port"))
+        def namespace = new SubjectNamingStrategy.Namespace("test", "_")
         subjectNamingStrategies = [
                 qualifiedName,
                 qualifiedName.withValueSuffixIf(true),
-                qualifiedName.withNamespacePrefixIf(true, "test"),
-                qualifiedName.withValueSuffixIf(true).withNamespacePrefixIf(true, "test")
+                qualifiedName.withNamespacePrefixIf(true, namespace),
+                qualifiedName.withValueSuffixIf(true).withNamespacePrefixIf(true, namespace)
         ]
         clients = subjectNamingStrategies.collect { new SchemaRegistryRawSchemaClient(resolver, new ObjectMapper(), it) }
     }

--- a/hermes-schema/src/test/groovy/pl/allegro/tech/hermes/schema/schemarepo/SchemaRepoRawSchemaClientTest.groovy
+++ b/hermes-schema/src/test/groovy/pl/allegro/tech/hermes/schema/schemarepo/SchemaRepoRawSchemaClientTest.groovy
@@ -49,11 +49,12 @@ class SchemaRepoRawSchemaClientTest extends Specification {
         wireMock = new WireMockServer(new WireMockConfiguration().port(port).usingFilesUnderClasspath("schema-repo-stub"))
         wireMock.start()
         resolver = new DefaultSchemaRepositoryInstanceResolver(ClientBuilder.newClient(), URI.create("http://localhost:$port/schema-repo"))
+        def namespace = new SubjectNamingStrategy.Namespace("test", "_")
         subjectNamingStrategies = [
                 qualifiedName,
                 qualifiedName.withValueSuffixIf(true),
-                qualifiedName.withNamespacePrefixIf(true, "test"),
-                qualifiedName.withValueSuffixIf(true).withNamespacePrefixIf(true, "test")
+                qualifiedName.withNamespacePrefixIf(true, namespace),
+                qualifiedName.withValueSuffixIf(true).withNamespacePrefixIf(true, namespace)
         ]
         clients = subjectNamingStrategies.collect { new SchemaRepoRawSchemaClient(resolver, it) }
     }

--- a/hermes-test-helper/src/main/java/pl/allegro/tech/hermes/test/helper/endpoint/BrokerOperations.java
+++ b/hermes-test-helper/src/main/java/pl/allegro/tech/hermes/test/helper/endpoint/BrokerOperations.java
@@ -38,11 +38,12 @@ public class BrokerOperations {
         this(kafkaZkConnection, configFactory.getIntProperty(Configs.ZOOKEEPER_SESSION_TIMEOUT),
                 configFactory.getIntProperty(Configs.ZOOKEEPER_CONNECTION_TIMEOUT),
                 configFactory.getIntProperty(Configs.ZOOKEEPER_MAX_INFLIGHT_REQUESTS),
-                configFactory.getStringProperty(Configs.KAFKA_NAMESPACE));
+                configFactory.getStringProperty(Configs.KAFKA_NAMESPACE),
+                configFactory.getStringProperty(Configs.KAFKA_NAMESPACE_SEPARATOR));
     }
 
     private BrokerOperations(Map<String, String> kafkaZkConnection, int sessionTimeout, int connectionTimeout,
-                             int maxInflightRequests, String namespace) {
+                             int maxInflightRequests, String namespace, String namespaceSeparator) {
         zkClients = kafkaZkConnection.entrySet().stream()
                 .collect(toMap(Map.Entry::getKey,
                                e -> {
@@ -52,7 +53,7 @@ public class BrokerOperations {
 
                                    return new KafkaZkClient(zooKeeperClient, false, Time.SYSTEM);
                                }));
-        kafkaNamesMapper = new JsonToAvroMigrationKafkaNamesMapper(namespace);
+        kafkaNamesMapper = new JsonToAvroMigrationKafkaNamesMapper(namespace, namespaceSeparator);
     }
 
     public void createTopic(String topicName) {

--- a/integration/src/integration/java/pl/allegro/tech/hermes/integration/env/IntegrationTestKafkaNamesMapperFactory.java
+++ b/integration/src/integration/java/pl/allegro/tech/hermes/integration/env/IntegrationTestKafkaNamesMapperFactory.java
@@ -12,6 +12,6 @@ public class IntegrationTestKafkaNamesMapperFactory {
     }
 
     public KafkaNamesMapper create() {
-        return new JsonToAvroMigrationKafkaNamesMapper(namespace);
+        return new JsonToAvroMigrationKafkaNamesMapper(namespace, "_");
     }
 }

--- a/integration/src/integration/java/pl/allegro/tech/hermes/integration/helper/Waiter.java
+++ b/integration/src/integration/java/pl/allegro/tech/hermes/integration/helper/Waiter.java
@@ -54,7 +54,7 @@ public class Waiter extends pl.allegro.tech.hermes.test.helper.endpoint.Waiter {
         this.zookeeper = zookeeper;
         this.brokerOperations = brokerOperations;
         this.clusterName = clusterName;
-        this.kafkaNamesMapper = new JsonToAvroMigrationKafkaNamesMapper(kafkaNamespace);
+        this.kafkaNamesMapper = new JsonToAvroMigrationKafkaNamesMapper(kafkaNamespace, "_");
     }
 
     public void untilHermesZookeeperNodeCreation(final String path) {


### PR DESCRIPTION
In #1209 I have made a mistake.
I used `.` as a namespace separator, because it is the way we define namespaces in our project, but I did not notice that the separator for namespaces on Kafka is `_`. It works, as for Hermes alone, but it is inconsistent a causes us some problems.
In this PR I have made the separator configurable.