### PR TITLE
Batch subscription disabled in hermes console

### DIFF
--- a/hermes-console/config.json.example
+++ b/hermes-console/config.json.example
@@ -77,7 +77,11 @@
                     "b": "Another option"
                 }
             }
-        }
+        },
+        "deliveryTypes": [
+              {"value": "SERIAL", "label": "SERIAL"},
+              {"value": "BATCH", "label": "BATCH"}
+        ]
     },
     "owner": {
         "sources": [

--- a/hermes-console/config_default.json
+++ b/hermes-console/config_default.json
@@ -25,6 +25,10 @@
     "offlineClientsEnabled": false
   },
   "subscription": {
+    "deliveryTypes": [
+      {"value": "SERIAL", "label": "SERIAL"},
+      {"value": "BATCH", "label": "BATCH"}
+    ]
   },
   "owner": {
     "sources": [

--- a/hermes-console/static/js/console/subscription/SubscriptionController.js
+++ b/hermes-console/static/js/console/subscription/SubscriptionController.js
@@ -18,6 +18,7 @@ subscriptions.controller('SubscriptionController', ['SubscriptionRepository', 'S
         var groupName = $scope.groupName = $stateParams.groupName;
         var topicName = $scope.topicName = $stateParams.topicName;
         var subscriptionName = $scope.subscriptionName = $stateParams.subscriptionName;
+        $scope.config = config;
 
         subscriptionRepository.get(topicName, subscriptionName).$promise
                 .then(function(subscription) {
@@ -254,15 +255,17 @@ subscriptions.controller('SubscriptionController', ['SubscriptionRepository', 'S
     }]);
 
 subscriptions.controller('SubscriptionEditController', ['SubscriptionRepository', '$scope', '$uibModalInstance', 'subscription',
-    'topicName', 'PasswordService', 'toaster', 'operation', 'endpointAddressResolverMetadataConfig', 'topicContentType', 'showHeadersFilter',
+    'topicName', 'PasswordService', 'toaster', 'operation', 'endpointAddressResolverMetadataConfig', 'topicContentType',
+    'showHeadersFilter', 'SUBSCRIPTION_CONFIG',
     function (subscriptionRepository, $scope, $modal, subscription, topicName, passwordService, toaster, operation,
-              endpointAddressResolverMetadataConfig, topicContentType, showHeadersFilter) {
+              endpointAddressResolverMetadataConfig, topicContentType, showHeadersFilter, subscriptionConfig) {
         $scope.topicName = topicName;
         $scope.topicContentType = topicContentType;
         $scope.subscription = _.cloneDeep(subscription);
         $scope.operation = operation;
         $scope.endpointAddressResolverMetadataConfig = endpointAddressResolverMetadataConfig;
         $scope.showHeadersFilter = showHeadersFilter;
+        $scope.config = subscriptionConfig;
 
         $scope.save = function () {
             var promise;

--- a/hermes-console/static/partials/modal/editSubscription.html
+++ b/hermes-console/static/partials/modal/editSubscription.html
@@ -44,13 +44,12 @@
                 </div>
             </div>
 
-            <div class="form-group">
+            <div class="form-group" ng-hide="subscription.deliveryType === 'SERIAL' && operation === 'EDIT'">
                 <label for="subscriptionType" class="col-md-3 control-label">Delivery type</label>
                 <div class="col-md-9">
                     <div class="input-group">
                         <select required class="form-control" id="deliveryType" name="deliveryType" ng-model="subscription.deliveryType">
-                            <option value="SERIAL">SERIAL</option>
-                            <option value="BATCH" ng-disabled="subscription.subscriptionType === 'AVRO'">BATCH (incubating feature)</option>
+                            <option ng-repeat="deliveryType in config.deliveryTypes" value="{{deliveryType.value}}" ng-disabled="deliveryType.value == 'BATCH' && subscription.subscriptionType === 'AVRO'">{{deliveryType.label}}</option>
                         </select>
                         <span class="input-group-addon helpme-addon" uib-tooltip="Hermes can deliver messages in SERIAL (one message at a time) or in BATCH (group of messages at a time).">?</span>
                     </div>
@@ -174,7 +173,7 @@
                 <label for="subscriptionBackoffMaxIntervalInSec" class="col-md-3 control-label">Retry backoff max interval</label>
                 <div class="col-md-9">
                     <div class="input-group">
-                        <input type="number" min="1" max="600" step="1" ng-required="subscription.deliveryType === 'SERIAL'" class="form-control" id="subscriptionBackoffMaxIntervalInSec" name="subscriptionBackoffMaxIntervalInSec" placeholder="Maximum value of delay backoff" ng-model="subscription.subscriptionPolicy.backoffMaxIntervalInSec" ng-pattern="/^\d+$/"/>
+                        <input type="number" min="1" max="600" step="1" ng-required="subscription.deliveryType === 'SERIAL' && subscription.subscriptionPolicy.backoffMultiplier > 1" class="form-control" id="subscriptionBackoffMaxIntervalInSec" name="subscriptionBackoffMaxIntervalInSec" placeholder="Maximum value of delay backoff" ng-model="subscription.subscriptionPolicy.backoffMaxIntervalInSec" ng-pattern="/^\d+$/"/>
                         <span class="input-group-addon">seconds</span>
                         <span class="input-group-addon helpme-addon" uib-tooltip="Maximum value of delay backoff when using exponential calculation">?</span>
                     </div>

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/config/console/ConsoleProperties.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/config/console/ConsoleProperties.java
@@ -482,6 +482,10 @@ public class ConsoleProperties {
         private Map<String, EndpointAddressResolverMetadata> endpointAddressResolverMetadata = new HashMap<>();
         private boolean showHeadersFilter = false;
         private DefaultSubscriptionView defaults = new DefaultSubscriptionView();
+        private List<SubscriptionDeliveryType> deliveryTypes = Lists.newArrayList(
+                new SubscriptionDeliveryType("SERIAL", "SERIAL"),
+                new SubscriptionDeliveryType("BATCH", "BATCH")
+        );
 
         public Map<String, EndpointAddressResolverMetadata> getEndpointAddressResolverMetadata() {
             return endpointAddressResolverMetadata;
@@ -505,6 +509,14 @@ public class ConsoleProperties {
 
         public void setDefaults(DefaultSubscriptionView defaults) {
             this.defaults = defaults;
+        }
+
+        public List<SubscriptionDeliveryType> getDeliveryTypes() {
+            return deliveryTypes;
+        }
+
+        public void setDeliveryTypes(List<SubscriptionDeliveryType> deliveryTypes) {
+            this.deliveryTypes = deliveryTypes;
         }
     }
 
@@ -540,6 +552,7 @@ public class ConsoleProperties {
 
     public static final class DefaultSubscriptionView {
         private SubscriptionPolicy subscriptionPolicy = new SubscriptionPolicy();
+        private String deliveryType = "SERIAL";
 
         public SubscriptionPolicy getSubscriptionPolicy() {
             return subscriptionPolicy;
@@ -547,6 +560,14 @@ public class ConsoleProperties {
 
         public void setSubscriptionPolicy(SubscriptionPolicy subscriptionPolicy) {
             this.subscriptionPolicy = subscriptionPolicy;
+        }
+
+        public String getDeliveryType() {
+            return deliveryType;
+        }
+
+        public void setDeliveryType(String deliveryType) {
+            this.deliveryType = deliveryType;
         }
     }
 
@@ -559,6 +580,35 @@ public class ConsoleProperties {
 
         public void setMessageTtl(int messageTtl) {
             this.messageTtl = messageTtl;
+        }
+    }
+
+    public static final class SubscriptionDeliveryType {
+        private String value = "";
+        private String label = "";
+
+        public SubscriptionDeliveryType() {
+        }
+
+        public SubscriptionDeliveryType(String value, String label) {
+            this.value = value;
+            this.label = label;
+        }
+
+        public String getValue() {
+            return value;
+        }
+
+        public void setValue(String value) {
+            this.value = value;
+        }
+
+        public String getLabel() {
+            return label;
+        }
+
+        public void setLabel(String label) {
+            this.label = label;
         }
     }
 }

--- a/hermes-management/src/main/resources/application-local.yaml
+++ b/hermes-management/src/main/resources/application-local.yaml
@@ -23,3 +23,8 @@ console:
     offlineClientsEnabled: false
   subscription:
     showHeadersFilter: true
+    deliveryTypes:
+      - value: SERIAL
+        label: SERIAL
+      - value: BATCH
+        label: BATCH

--- a/hermes-management/src/main/resources/console/config-local.json
+++ b/hermes-management/src/main/resources/console/config-local.json
@@ -36,5 +36,11 @@
   "topic": {
     "messagePreviewEnabled": true,
     "offlineClientsEnabled": false
+  },
+  "subscription": {
+    "deliveryTypes": [
+      {"value": "SERIAL", "label": "SERIAL"},
+      {"value": "BATCH", "label": "BATCH"}
+    ]
   }
 }


### PR DESCRIPTION
- delivery types in hermes console are now read from configuration
- serial delivery cannot be changed to batch delivery
- bonus: bug fix for maxBackoffInterval field (the field is now not required for constant backoff policy)