### PR TITLE
Feature: default schema id serialization

### DIFF
--- a/hermes-api/src/main/java/pl/allegro/tech/hermes/api/Topic.java
+++ b/hermes-api/src/main/java/pl/allegro/tech/hermes/api/Topic.java
@@ -1,9 +1,6 @@
 package pl.allegro.tech.hermes.api;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 
 import javax.validation.Valid;
 import javax.validation.constraints.Max;
@@ -54,7 +51,7 @@ public class Topic {
 
     private boolean migratedFromJsonType = false;
 
-    private boolean schemaIdAwareSerializationEnabled = false;
+    private final boolean schemaIdAwareSerializationEnabled;
 
     private boolean subscribingRestricted = false;
 
@@ -67,8 +64,8 @@ public class Topic {
     private Instant modifiedAt;
 
     public Topic(TopicName name, String description, OwnerId owner, RetentionTime retentionTime,
-                 boolean migratedFromJsonType, Ack ack, boolean trackingEnabled, ContentType contentType,
-                 boolean jsonToAvroDryRunEnabled, boolean schemaIdAwareSerializationEnabled,
+                 boolean migratedFromJsonType, Ack ack, boolean trackingEnabled, ContentType contentType, boolean jsonToAvroDryRunEnabled,
+                 @JacksonInject(value = "defaultSchemaIdAwareSerializationEnabled", useInput = OptBoolean.TRUE) Boolean schemaIdAwareSerializationEnabled,
                  int maxMessageSize, PublishingAuth publishingAuth, boolean subscribingRestricted,
                  TopicDataOfflineStorage offlineStorage, Instant createdAt, Instant modifiedAt) {
         this.name = name;
@@ -99,7 +96,7 @@ public class Topic {
             @JsonProperty("ack") Ack ack,
             @JsonProperty("trackingEnabled") boolean trackingEnabled,
             @JsonProperty("migratedFromJsonType") boolean migratedFromJsonType,
-            @JsonProperty("schemaIdAwareSerializationEnabled") boolean schemaIdAwareSerializationEnabled,
+            @JsonProperty("schemaIdAwareSerializationEnabled") @JacksonInject(value = "defaultSchemaIdAwareSerializationEnabled", useInput = OptBoolean.TRUE) Boolean schemaIdAwareSerializationEnabled,
             @JsonProperty("contentType") ContentType contentType,
             @JsonProperty("maxMessageSize") Integer maxMessageSize,
             @JsonProperty("auth") PublishingAuth publishingAuth,

--- a/hermes-api/src/main/java/pl/allegro/tech/hermes/api/Topic.java
+++ b/hermes-api/src/main/java/pl/allegro/tech/hermes/api/Topic.java
@@ -1,6 +1,11 @@
 package pl.allegro.tech.hermes.api;
 
-import com.fasterxml.jackson.annotation.*;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.OptBoolean;
+import com.fasterxml.jackson.annotation.JacksonInject;
 
 import javax.validation.Valid;
 import javax.validation.constraints.Max;
@@ -38,6 +43,7 @@ public class Topic {
     public static final int MIN_MESSAGE_SIZE = 1024;
     public static final int MAX_MESSAGE_SIZE = 2 * 1024 * 1024;
     private static final int DEFAULT_MAX_MESSAGE_SIZE = 50 * 1024;
+    public static final String DEFAULT_SCHEMA_ID_SERIALIZATION_ENABLED_KEY = "defaultSchemaIdAwareSerializationEnabled";
 
     public enum Ack {
         NONE, LEADER, ALL
@@ -65,7 +71,7 @@ public class Topic {
 
     public Topic(TopicName name, String description, OwnerId owner, RetentionTime retentionTime,
                  boolean migratedFromJsonType, Ack ack, boolean trackingEnabled, ContentType contentType, boolean jsonToAvroDryRunEnabled,
-                 @JacksonInject(value = "defaultSchemaIdAwareSerializationEnabled", useInput = OptBoolean.TRUE) Boolean schemaIdAwareSerializationEnabled,
+                 @JacksonInject(value = DEFAULT_SCHEMA_ID_SERIALIZATION_ENABLED_KEY, useInput = OptBoolean.TRUE) Boolean schemaIdAwareSerializationEnabled,
                  int maxMessageSize, PublishingAuth publishingAuth, boolean subscribingRestricted,
                  TopicDataOfflineStorage offlineStorage, Instant createdAt, Instant modifiedAt) {
         this.name = name;
@@ -96,7 +102,7 @@ public class Topic {
             @JsonProperty("ack") Ack ack,
             @JsonProperty("trackingEnabled") boolean trackingEnabled,
             @JsonProperty("migratedFromJsonType") boolean migratedFromJsonType,
-            @JsonProperty("schemaIdAwareSerializationEnabled") @JacksonInject(value = "defaultSchemaIdAwareSerializationEnabled", useInput = OptBoolean.TRUE) Boolean schemaIdAwareSerializationEnabled,
+            @JsonProperty("schemaIdAwareSerializationEnabled") @JacksonInject(value = DEFAULT_SCHEMA_ID_SERIALIZATION_ENABLED_KEY, useInput = OptBoolean.TRUE) Boolean schemaIdAwareSerializationEnabled,
             @JsonProperty("contentType") ContentType contentType,
             @JsonProperty("maxMessageSize") Integer maxMessageSize,
             @JsonProperty("auth") PublishingAuth publishingAuth,

--- a/hermes-api/src/main/java/pl/allegro/tech/hermes/api/TopicWithSchema.java
+++ b/hermes-api/src/main/java/pl/allegro/tech/hermes/api/TopicWithSchema.java
@@ -1,8 +1,6 @@
 package pl.allegro.tech.hermes.api;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 
 import java.time.Instant;
 import java.util.Objects;
@@ -31,7 +29,7 @@ public class TopicWithSchema extends Topic {
                            @JsonProperty("ack") Ack ack,
                            @JsonProperty("trackingEnabled") boolean trackingEnabled,
                            @JsonProperty("migratedFromJsonType") boolean migratedFromJsonType,
-                           @JsonProperty("schemaIdAwareSerializationEnabled") boolean schemaIdAwareSerializationEnabled,
+                           @JsonProperty("schemaIdAwareSerializationEnabled") @JacksonInject(value = "defaultSchemaIdAwareSerializationEnabled", useInput = OptBoolean.TRUE) Boolean schemaIdAwareSerializationEnabled,
                            @JsonProperty("contentType") ContentType contentType,
                            @JsonProperty("maxMessageSize") Integer maxMessageSize,
                            @JsonProperty("auth") PublishingAuth publishingAuth,

--- a/hermes-api/src/main/java/pl/allegro/tech/hermes/api/TopicWithSchema.java
+++ b/hermes-api/src/main/java/pl/allegro/tech/hermes/api/TopicWithSchema.java
@@ -1,9 +1,14 @@
 package pl.allegro.tech.hermes.api;
 
-import com.fasterxml.jackson.annotation.*;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JacksonInject;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.OptBoolean;
 
 import java.time.Instant;
 import java.util.Objects;
+import pl.allegro.tech.hermes.api.Topic.Ack;
 
 public class TopicWithSchema extends Topic {
 
@@ -29,7 +34,7 @@ public class TopicWithSchema extends Topic {
                            @JsonProperty("ack") Ack ack,
                            @JsonProperty("trackingEnabled") boolean trackingEnabled,
                            @JsonProperty("migratedFromJsonType") boolean migratedFromJsonType,
-                           @JsonProperty("schemaIdAwareSerializationEnabled") @JacksonInject(value = "defaultSchemaIdAwareSerializationEnabled", useInput = OptBoolean.TRUE) Boolean schemaIdAwareSerializationEnabled,
+                           @JsonProperty("schemaIdAwareSerializationEnabled") @JacksonInject(value = Topic.DEFAULT_SCHEMA_ID_SERIALIZATION_ENABLED_KEY, useInput = OptBoolean.TRUE) Boolean schemaIdAwareSerializationEnabled,
                            @JsonProperty("contentType") ContentType contentType,
                            @JsonProperty("maxMessageSize") Integer maxMessageSize,
                            @JsonProperty("auth") PublishingAuth publishingAuth,

--- a/hermes-api/src/test/java/pl/allegro/tech/hermes/api/TopicTest.java
+++ b/hermes-api/src/test/java/pl/allegro/tech/hermes/api/TopicTest.java
@@ -1,6 +1,7 @@
 package pl.allegro.tech.hermes.api;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.InjectableValues;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Test;
 
@@ -11,7 +12,7 @@ public class TopicTest {
     private final ObjectMapper objectMapper = createObjectMapper();
 
     @Test
-    public void shouldDeserializeTopic() throws Exception {
+    public void shouldDeserializeTopicWithDefaults() throws Exception {
         // given
         String json = "{\"name\":\"foo.bar\", \"description\": \"description\"}";
 
@@ -22,6 +23,22 @@ public class TopicTest {
         assertThat(topic.getName().getName()).isEqualTo("bar");
         assertThat(topic.getName().getGroupName()).isEqualTo("foo");
         assertThat(topic.getDescription()).isEqualTo("description");
+        assertThat(topic.isSchemaIdAwareSerializationEnabled()).isEqualTo(true);
+    }
+
+    @Test
+    public void shouldDeserializeTopic() throws Exception {
+        // given
+        String json = "{\"name\":\"foo.bar\", \"description\": \"description\", \"schemaIdAwareSerializationEnabled\": \"false\"}";
+
+        // when
+        Topic topic = objectMapper.readValue(json, Topic.class);
+
+        // then
+        assertThat(topic.getName().getName()).isEqualTo("bar");
+        assertThat(topic.getName().getGroupName()).isEqualTo("foo");
+        assertThat(topic.getDescription()).isEqualTo("description");
+        assertThat(topic.isSchemaIdAwareSerializationEnabled()).isEqualTo(false);
     }
 
     @Test
@@ -49,8 +66,13 @@ public class TopicTest {
     }
 
     private ObjectMapper createObjectMapper() {
-        ObjectMapper objectMapper = new ObjectMapper();
-        objectMapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
-        return objectMapper;
+        ObjectMapper mapper = new ObjectMapper();
+
+        final InjectableValues defaultSchemaIdAwareSerializationEnabled = new InjectableValues
+            .Std().addValue("defaultSchemaIdAwareSerializationEnabled", true);
+
+        mapper.setInjectableValues(defaultSchemaIdAwareSerializationEnabled);
+        mapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+        return mapper;
     }
 }

--- a/hermes-api/src/test/java/pl/allegro/tech/hermes/api/TopicTest.java
+++ b/hermes-api/src/test/java/pl/allegro/tech/hermes/api/TopicTest.java
@@ -69,7 +69,7 @@ public class TopicTest {
         ObjectMapper mapper = new ObjectMapper();
 
         final InjectableValues defaultSchemaIdAwareSerializationEnabled = new InjectableValues
-            .Std().addValue("defaultSchemaIdAwareSerializationEnabled", true);
+            .Std().addValue(Topic.DEFAULT_SCHEMA_ID_SERIALIZATION_ENABLED_KEY, true);
 
         mapper.setInjectableValues(defaultSchemaIdAwareSerializationEnabled);
         mapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);

--- a/hermes-console/static/partials/topic.html
+++ b/hermes-console/static/partials/topic.html
@@ -73,6 +73,7 @@
                     </p>
                     <p><strong>Tracking enabled:</strong> {{topic.trackingEnabled}}</p>
                     <p><strong>Max message size:</strong> {{topic.maxMessageSize | readableSize}}</p>
+                    <p><strong>SchemaId Serialization Enabled:</strong> {{topic.schemaIdAwareSerializationEnabled}}</p>
 
                     <div class="ng-hide" ng-show="config.authEnabled">
                         <hr />

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/config/ManagementConfiguration.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/config/ManagementConfiguration.java
@@ -3,11 +3,13 @@ package pl.allegro.tech.hermes.management.config;
 import com.codahale.metrics.MetricRegistry;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.InjectableValues;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import static javax.servlet.DispatcherType.REQUEST;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
@@ -24,6 +26,9 @@ import java.time.Clock;
 @EnableConfigurationProperties({TopicProperties.class, MetricsProperties.class, HttpClientProperties.class})
 public class ManagementConfiguration {
 
+    @Autowired
+    TopicProperties topicProperties;
+
     @Bean
     public ObjectMapper objectMapper() {
         ObjectMapper mapper = new ObjectMapper();
@@ -31,6 +36,12 @@ public class ManagementConfiguration {
         mapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
         mapper.disable(SerializationFeature.WRITE_NULL_MAP_VALUES);
         mapper.registerModule(new JavaTimeModule());
+
+        final InjectableValues defaultSchemaIdAwareSerializationEnabled = new InjectableValues
+            .Std().addValue("defaultSchemaIdAwareSerializationEnabled", topicProperties.isDefaultSchemaIdAwareSerializationEnabled());
+
+        mapper.setInjectableValues(defaultSchemaIdAwareSerializationEnabled);
+
         return mapper;
     }
 

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/config/ManagementConfiguration.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/config/ManagementConfiguration.java
@@ -21,10 +21,13 @@ import pl.allegro.tech.hermes.management.domain.mode.ModeService;
 import pl.allegro.tech.hermes.management.domain.subscription.SubscriptionLagSource;
 import pl.allegro.tech.hermes.management.infrastructure.metrics.NoOpSubscriptionLagSource;
 import java.time.Clock;
+import pl.allegro.tech.hermes.api.Topic;
 
 @Configuration
 @EnableConfigurationProperties({TopicProperties.class, MetricsProperties.class, HttpClientProperties.class})
 public class ManagementConfiguration {
+
+    public static String MAPPER_DEFAULT_SCHEMA_ID_ENABLED_NAMESPACE = "";
 
     @Autowired
     TopicProperties topicProperties;
@@ -38,7 +41,7 @@ public class ManagementConfiguration {
         mapper.registerModule(new JavaTimeModule());
 
         final InjectableValues defaultSchemaIdAwareSerializationEnabled = new InjectableValues
-            .Std().addValue("defaultSchemaIdAwareSerializationEnabled", topicProperties.isDefaultSchemaIdAwareSerializationEnabled());
+            .Std().addValue(MAPPER_DEFAULT_SCHEMA_ID_ENABLED_NAMESPACE, topicProperties.isDefaultSchemaIdAwareSerializationEnabled());
 
         mapper.setInjectableValues(defaultSchemaIdAwareSerializationEnabled);
 

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/config/ManagementConfiguration.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/config/ManagementConfiguration.java
@@ -27,8 +27,6 @@ import pl.allegro.tech.hermes.api.Topic;
 @EnableConfigurationProperties({TopicProperties.class, MetricsProperties.class, HttpClientProperties.class})
 public class ManagementConfiguration {
 
-    public static String MAPPER_DEFAULT_SCHEMA_ID_ENABLED_NAMESPACE = "";
-
     @Autowired
     TopicProperties topicProperties;
 
@@ -41,7 +39,7 @@ public class ManagementConfiguration {
         mapper.registerModule(new JavaTimeModule());
 
         final InjectableValues defaultSchemaIdAwareSerializationEnabled = new InjectableValues
-            .Std().addValue(MAPPER_DEFAULT_SCHEMA_ID_ENABLED_NAMESPACE, topicProperties.isDefaultSchemaIdAwareSerializationEnabled());
+            .Std().addValue(Topic.DEFAULT_SCHEMA_ID_SERIALIZATION_ENABLED_KEY, topicProperties.isDefaultSchemaIdAwareSerializationEnabled());
 
         mapper.setInjectableValues(defaultSchemaIdAwareSerializationEnabled);
 

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/config/TopicProperties.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/config/TopicProperties.java
@@ -27,6 +27,8 @@ public class TopicProperties {
 
     private int subscriptionsAssignmentsCompletedTimeoutSeconds = 30;
 
+    private boolean defaultSchemaIdAwareSerializationEnabled = false;
+
     /**
      * Introduced in Kafka 0.11.0.0 mechanism of splitting oversized batches does not respect configuration of maximum
      * message size which broker can accept. It can cause an infinite loop of resending the same records in one batch.
@@ -118,5 +120,13 @@ public class TopicProperties {
 
     public void setMaxMessageSize(int maxMessageSize) {
         this.maxMessageSize = maxMessageSize;
+    }
+
+    public void setDefaultSchemaIdAwareSerializationEnabled(boolean defaultSchemaIdAwareSerializationEnabled) {
+        this.defaultSchemaIdAwareSerializationEnabled = defaultSchemaIdAwareSerializationEnabled;
+    }
+
+    public boolean isDefaultSchemaIdAwareSerializationEnabled() {
+        return defaultSchemaIdAwareSerializationEnabled;
     }
 }

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/config/console/ConsoleProperties.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/config/console/ConsoleProperties.java
@@ -303,6 +303,7 @@ public class ConsoleProperties {
         private DefaultTopicView defaults = new DefaultTopicView();
         private String buttonsExtension = "";
         private boolean removeSchema = false;
+        private boolean schemaIdAwareSerializationEnabled = false;
         private List<TopicContentType> contentTypes = Lists.newArrayList(
                 new TopicContentType("AVRO", "AVRO"),
                 new TopicContentType("JSON", "JSON")
@@ -362,6 +363,12 @@ public class ConsoleProperties {
 
         public void setRemoveSchema(boolean removeSchema) {
             this.removeSchema = removeSchema;
+        }
+
+        public boolean isSchemaIdAwareSerializationEnabled() { return schemaIdAwareSerializationEnabled; }
+
+        public void setSchemaIdAwareSerializationEnabled(boolean schemaIdAwareSerializationEnabled) {
+            this.schemaIdAwareSerializationEnabled = schemaIdAwareSerializationEnabled;
         }
     }
 

--- a/hermes-management/src/test/resources/application.yaml
+++ b/hermes-management/src/test/resources/application.yaml
@@ -17,3 +17,6 @@ spring:
   mvc:
     servlet:
       path: /status
+
+topic:
+  defaultSchemaIdAwareSerializationEnabled: true


### PR DESCRIPTION
- Add management flag `defaultSchemaIdAwareSerializationEnabled` at TopicProperties for default behavior topic in case when we don't send `schemaIdAwareSerializationEnabled`. 
- Add displaying information about `schemaIdAwareSerializationEnabled` at FE Console.