### PR TITLE
Subscription name validation fixed

### DIFF
--- a/hermes-console/static/partials/modal/editSubscription.html
+++ b/hermes-console/static/partials/modal/editSubscription.html
@@ -14,8 +14,8 @@
 
             <div class="form-group {{subscriptionForm.subscriptionName.$valid ? '' : 'has-error'}} " ng-show="operation === 'ADD'">
                 <label for="subscriptionName" class="col-md-3 control-label">Name</label>
-                <div class="col-md-9">
-                    <input class="form-control" id="subscriptionName" name="subscriptionName" required placeholder="name of subscription" ng-model="subscription.name" ng-pattern="/^[a-zA-Z0-9._-]+$/"/>
+                <div class="col-md-9" ng-if="operation === 'ADD'">
+                    <input class="form-control" id="subscriptionName" name="subscriptionName" ng-required="operation === 'ADD'" placeholder="name of subscription" ng-model="subscription.name" ng-pattern="/^[a-zA-Z0-9.-]+$/"/>
                 </div>
             </div>
 


### PR DESCRIPTION
- subscription name cannot contain '_'
- (old) subscription with invalid name can be edited (bug fixed)