### PR TITLE
Introduce Reactive Hermes Client

### DIFF
--- a/hermes-client/build.gradle
+++ b/hermes-client/build.gradle
@@ -9,6 +9,7 @@ dependencies {
     compileOnly group: 'org.eclipse.jetty.alpn', name: 'alpn-api', version: versions.alpn_api
 
     compile group: 'net.jodah', name: 'failsafe', version: versions.failsafe
+    compile group: 'io.projectreactor.addons', name: 'reactor-extra', version: '3.3.3.RELEASE'
 
     testCompile group: 'org.spockframework', name: 'spock-core', version: versions.spock
     testCompile group: 'com.github.tomakehurst', name: 'wiremock-standalone', version: versions.wiremock

--- a/hermes-client/build.gradle
+++ b/hermes-client/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     compileOnly group: 'org.eclipse.jetty.alpn', name: 'alpn-api', version: versions.alpn_api
 
     compile group: 'net.jodah', name: 'failsafe', version: versions.failsafe
-    compile group: 'io.projectreactor.addons', name: 'reactor-extra', version: '3.3.3.RELEASE'
+    compile group: 'io.projectreactor', name: 'reactor-core', version: '3.3.4.RELEASE'
 
     testCompile group: 'org.spockframework', name: 'spock-core', version: versions.spock
     testCompile group: 'com.github.tomakehurst', name: 'wiremock-standalone', version: versions.wiremock

--- a/hermes-client/build.gradle
+++ b/hermes-client/build.gradle
@@ -24,4 +24,6 @@ dependencies {
     testCompile group: 'com.squareup.okhttp3', name: 'okhttp', version: versions.okhttp
     testCompile group: 'org.eclipse.jetty.alpn', name: 'alpn-api', version: versions.alpn_api
     testCompile group: 'io.projectreactor.netty', name: 'reactor-netty', version: '0.8.10.RELEASE'
+    testCompile group: 'io.projectreactor', name: 'reactor-test', version: '3.3.4.RELEASE'
+
 }

--- a/hermes-client/src/main/java/pl/allegro/tech/hermes/client/ReactiveHermesClient.java
+++ b/hermes-client/src/main/java/pl/allegro/tech/hermes/client/ReactiveHermesClient.java
@@ -34,6 +34,7 @@ public class ReactiveHermesClient {
     private final Predicate<HermesResponse> retryCondition;
     private final Duration retrySleep;
     private final Duration maxRetrySleep;
+    private final Double jitterFactor;
     private final Scheduler scheduler;
     private volatile boolean shutdown = false;
     private final List<MessageDeliveryListener> messageDeliveryListeners;
@@ -45,6 +46,7 @@ public class ReactiveHermesClient {
                          Predicate<HermesResponse> retryCondition,
                          long retrySleepInMillis,
                          long maxRetrySleepInMillis,
+                         double jitterFactor,
                          Scheduler scheduler) {
         this.sender = sender;
         this.uri = createUri(uri);
@@ -53,6 +55,7 @@ public class ReactiveHermesClient {
         this.retryCondition = retryCondition;
         this.retrySleep = Duration.ofMillis(retrySleepInMillis);
         this.maxRetrySleep = Duration.ofMillis(maxRetrySleepInMillis);
+        this.jitterFactor = jitterFactor;
         this.scheduler = scheduler;
         this.messageDeliveryListeners = new ArrayList<>();
     }
@@ -179,6 +182,7 @@ public class ReactiveHermesClient {
         } else {
             return Retry.backoff(maxRetries, retrySleep)
                     .maxBackoff(maxRetrySleep)
+                    .jitter(jitterFactor)
                     .doAfterRetry(this::handleRetryAttempt);
         }
     }

--- a/hermes-client/src/main/java/pl/allegro/tech/hermes/client/ReactiveHermesClient.java
+++ b/hermes-client/src/main/java/pl/allegro/tech/hermes/client/ReactiveHermesClient.java
@@ -1,0 +1,314 @@
+package pl.allegro.tech.hermes.client;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Scheduler;
+import reactor.core.scheduler.Schedulers;
+import reactor.util.retry.Retry;
+
+import java.net.URI;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Predicate;
+
+
+import static pl.allegro.tech.hermes.client.HermesMessage.hermesMessage;
+import static reactor.core.Exceptions.*;
+
+
+public class ReactiveHermesClient {
+    private static final Logger logger = LoggerFactory.getLogger(ReactiveHermesClient.class);
+    private static final String RETRY_CONTEXT_KEY = "hermes-retry-context-key";
+
+    private final ReactiveHermesSender sender;
+    private final String uri;
+    private final Map<String, String> defaultHeaders;
+    private final AtomicInteger currentlySending = new AtomicInteger(0);
+    private final int maxRetries;
+    private final Predicate<HermesResponse> retryCondition;
+    private final Duration retrySleep;
+    private final Duration maxRetrySleep;
+    private final Scheduler scheduler;
+    private volatile boolean shutdown = false;
+    private final List<MessageDeliveryListener> messageDeliveryListeners = new ArrayList<>();
+
+    ReactiveHermesClient(ReactiveHermesSender sender,
+                         URI uri,
+                         Map<String, String> defaultHeaders,
+                         int maxRetries,
+                         Predicate<HermesResponse> retryCondition,
+                         long retrySleepInMillis,
+                         long maxRetrySleepInMillis,
+                         ScheduledExecutorService scheduler) {
+        this.sender = sender;
+        this.uri = createUri(uri);
+        this.defaultHeaders = Collections.unmodifiableMap(new HashMap<>(defaultHeaders));
+        this.maxRetries = maxRetries;
+        this.retryCondition = retryCondition;
+        this.retrySleep = Duration.ofMillis(retrySleepInMillis);
+        this.maxRetrySleep = Duration.ofMillis(maxRetrySleepInMillis);
+        this.scheduler = Schedulers.fromExecutor(scheduler);
+    }
+
+    private String createUri(URI uri) {
+        String uriString = uri.toString();
+        return uriString + (uriString.endsWith("/") ? "" : "/") + "topics/";
+    }
+
+    public Mono<HermesResponse> publishJSON(String topic, byte[] message) {
+        return publish(hermesMessage(topic, message).json().build());
+    }
+
+    public Mono<HermesResponse> publishJSON(String topic, String message) {
+        return publish(hermesMessage(topic, message).json().build());
+    }
+
+    public Mono<HermesResponse> publishAvro(String topic, int schemaVersion, byte[] message) {
+        return publish(hermesMessage(topic, message).avro(schemaVersion).build());
+    }
+
+    public Mono<HermesResponse> publish(String topic, String message) {
+        return publish(hermesMessage(topic, message).build());
+    }
+
+    public Mono<HermesResponse> publish(String topic, String contentType, byte[] message) {
+        return publish(hermesMessage(topic, message).withContentType(contentType).build());
+    }
+
+    public Mono<HermesResponse> publish(String topic, String contentType, String message) {
+        return publish(hermesMessage(topic, message).withContentType(contentType).build());
+    }
+
+    public Mono<HermesResponse> publish(String topic, String contentType, int schemaVersion, byte[] message) {
+        return publish(hermesMessage(topic, message).withContentType(contentType).withSchemaVersion(schemaVersion).build());
+    }
+
+    public Mono<HermesResponse> publish(HermesMessage message) {
+        if (shutdown) {
+            return completedWithShutdownException();
+        }
+        HermesMessage.appendDefaults(message, defaultHeaders);
+        return publishWithRetries(message);
+    }
+
+    public boolean addMessageDeliveryListener(MessageDeliveryListener listener) {
+        return messageDeliveryListeners.add(listener);
+    }
+
+    private Mono<HermesResponse> publishWithRetries(HermesMessage message) {
+        currentlySending.incrementAndGet();
+
+        Retry retry = prepareRetry(message);
+
+        return sendOnce(message)
+                .flatMap(response -> getNextAttempt()
+                        .map(attempt -> {
+                            if (retryCondition.test(response)) {
+                                return Result.failure(new ShouldRetryException(response), attempt);
+                            } else {
+                                return Result.attempt(response, attempt);
+                            }
+                        })
+                )
+                .onErrorResume(throwable -> getNextAttempt().map(attempt -> Result.failure(throwable, attempt)))
+                .subscribeOn(scheduler)
+                .flatMap(result -> {
+                    if (result instanceof Failed) {
+                        Failed failed = (Failed) result;
+                        return Mono.error(new RetryFailedException(failed.attempt, failed.cause));
+                    } else {
+                        return Mono.just((Attempt) result);
+                    }
+                })
+                .retryWhen(retry)
+                .subscriberContext(ctx -> ctx.put(RETRY_CONTEXT_KEY, HermesRetryContext.emptyRetryContext()))
+                .onErrorResume(Exception.class, exception -> {
+                    if (isRetryExhausted(exception)) {
+                        RetryFailedException rfe = (RetryFailedException) (exception.getCause());
+                        handleMaxRetriesExceeded(message, rfe.attempt);
+                        Throwable cause = rfe.getCause();
+                        if (cause instanceof ShouldRetryException) {
+                            ShouldRetryException sre = (ShouldRetryException) cause;
+                            return Mono.just((Attempt) Result.attempt(sre.hermesResponse, rfe.attempt));
+                        }
+                        handleFailure(message, rfe.getAttempt());
+                    }
+                    return Mono.error(exception);
+                })
+                .doOnSuccess(hr -> {
+                    if (hr.response.isSuccess()) {
+                        handleSuccessfulRetry(message, hr.getAttempt());
+                    } else {
+                        handleFailure(message, hr.getAttempt());
+                    }
+                })
+                .map(result -> result.response)
+                .doFinally(s -> currentlySending.decrementAndGet());
+    }
+
+    private Retry prepareRetry(HermesMessage message) {
+        Retry retry;
+        if (!retrySleep.isZero()) {
+            retry = Retry.max(maxRetries)
+                    .doAfterRetry(signal -> handleFailedAttempt(message, signal.totalRetries() + 1));
+        } else {
+            retry = Retry.backoff(maxRetries, retrySleep)
+                    .maxBackoff(maxRetrySleep)
+                    .doAfterRetry(signal -> handleFailedAttempt(message, signal.totalRetries() + 1));
+        }
+        return retry;
+    }
+
+    private Mono<Integer> getNextAttempt() {
+        return Mono.subscriberContext()
+                .map(ctx -> ctx.getOrDefault(RETRY_CONTEXT_KEY, HermesRetryContext.emptyRetryContext())
+                        .getAndIncrementAttempt()
+                );
+    }
+
+    private Mono<HermesResponse> sendOnce(HermesMessage message) {
+        return Mono.defer(() -> {
+                    long startTime = System.nanoTime();
+                    try {
+                        return sender.sendReactively(URI.create(uri + message.getTopic()), message)
+                                .onErrorResume(e -> Mono.just(HermesResponseBuilder.hermesFailureResponse(e, message)))
+                                .doOnNext(resp -> {
+                                    long latency = System.nanoTime() - startTime;
+                                    messageDeliveryListeners.forEach(l -> l.onSend(resp, latency));
+                                });
+                    } catch (Exception e) {
+                        return Mono.error(e);
+                    }
+                }
+        );
+    }
+
+    private Mono<HermesResponse> completedWithShutdownException() {
+        return Mono.error(new HermesClientShutdownException());
+    }
+
+    public Mono<Void> closeAsync(long pollInterval) {
+        shutdown = true;
+        CompletableFuture<Void> voidCompletableFuture = new HermesClientTermination(pollInterval)
+                .observe(() -> currentlySending.get() == 0)
+                .whenComplete((response, ex) -> scheduler.dispose());
+        return Mono.fromFuture(voidCompletableFuture);
+    }
+
+    public void close(long pollInterval, long timeout) {
+        closeAsync(pollInterval).block(Duration.ofMillis(timeout));
+    }
+
+    private void handleMaxRetriesExceeded(HermesMessage message, int attemptCount) {
+        messageDeliveryListeners.forEach(l -> l.onMaxRetriesExceeded(message, attemptCount));
+        logger.error("Failed to send message to topic {} after {} attempts",
+                message.getTopic(), attemptCount);
+    }
+
+    private void handleFailedAttempt(HermesMessage message, long attemptCount) {
+        messageDeliveryListeners.forEach(l -> l.onFailedRetry(message, (int) attemptCount));
+    }
+
+    private void handleFailure(HermesMessage message, long attemptCount) {
+        messageDeliveryListeners.forEach(l -> l.onFailure(message, (int) attemptCount));
+    }
+
+    private void handleSuccessfulRetry(HermesMessage message, long attemptCount) {
+        messageDeliveryListeners.forEach(l -> l.onSuccessfulRetry(message, (int) attemptCount));
+    }
+
+    private static class ShouldRetryException extends Exception {
+        private final HermesResponse hermesResponse;
+
+        public ShouldRetryException(HermesResponse hermesResponse) {
+            this.hermesResponse = hermesResponse;
+        }
+
+        public HermesResponse getHermesResponse() {
+            return hermesResponse;
+        }
+    }
+
+    private static class RetryFailedException extends Exception {
+        private final int attempt;
+
+        public RetryFailedException(int attempt, Throwable cause) {
+            super(cause);
+            this.attempt = attempt;
+        }
+
+        public long getAttempt() {
+            return attempt;
+        }
+    }
+
+    private interface Result {
+        static Result attempt(HermesResponse response, int attempt) {
+            return new Attempt(response, attempt);
+        }
+
+        static Result failure(Throwable cause, int attempt) {
+            return new Failed(attempt, cause);
+        }
+    }
+
+    private static class Attempt implements Result {
+        private final HermesResponse response;
+        private final int attempt;
+
+        private Attempt(HermesResponse response, int attempt) {
+            this.response = response;
+            this.attempt = attempt;
+        }
+
+        public long getAttempt() {
+            return attempt;
+        }
+
+        public HermesResponse getMessage() {
+            return response;
+        }
+    }
+
+    private static class Failed implements Result {
+        private final int attempt;
+        private final Throwable cause;
+
+        private Failed(int attempt, Throwable cause) {
+            this.attempt = attempt;
+            this.cause = cause;
+        }
+
+        public long getRetries() {
+            return attempt;
+        }
+
+        public Throwable getCause() {
+            return cause;
+        }
+    }
+
+    private static class HermesRetryContext {
+        private int attempt;
+
+        HermesRetryContext() {
+            attempt = 1;
+        }
+
+        static HermesRetryContext emptyRetryContext() {
+            return new HermesRetryContext();
+        }
+
+        int getAndIncrementAttempt() {
+            return attempt++;
+        }
+    }
+}

--- a/hermes-client/src/main/java/pl/allegro/tech/hermes/client/ReactiveHermesClientBuilder.java
+++ b/hermes-client/src/main/java/pl/allegro/tech/hermes/client/ReactiveHermesClientBuilder.java
@@ -2,13 +2,14 @@ package pl.allegro.tech.hermes.client;
 
 import pl.allegro.tech.hermes.client.metrics.MetricsMessageDeliveryListener;
 import pl.allegro.tech.hermes.client.metrics.MetricsProvider;
+import reactor.core.scheduler.Scheduler;
+import reactor.core.scheduler.Schedulers;
 
 import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 
@@ -21,7 +22,7 @@ public class ReactiveHermesClientBuilder {
     private Predicate<HermesResponse> retryCondition = new HermesClientBasicRetryCondition();
     private long retrySleepInMillis = 100;
     private long maxRetrySleepInMillis = 300;
-    private Supplier<ScheduledExecutorService> schedulerFactory = Executors::newSingleThreadScheduledExecutor;
+    private Supplier<Scheduler> schedulerFactory = () -> Schedulers.fromExecutor(Executors.newSingleThreadScheduledExecutor());
     private Optional<MetricsProvider> metrics = Optional.empty();
 
     public ReactiveHermesClientBuilder(ReactiveHermesSender sender) {
@@ -85,7 +86,7 @@ public class ReactiveHermesClientBuilder {
         return this;
     }
 
-    public ReactiveHermesClientBuilder withScheduler(ScheduledExecutorService scheduler) {
+    public ReactiveHermesClientBuilder withScheduler(Scheduler scheduler) {
         this.schedulerFactory = () -> scheduler;
         return this;
     }

--- a/hermes-client/src/main/java/pl/allegro/tech/hermes/client/ReactiveHermesClientBuilder.java
+++ b/hermes-client/src/main/java/pl/allegro/tech/hermes/client/ReactiveHermesClientBuilder.java
@@ -22,6 +22,7 @@ public class ReactiveHermesClientBuilder {
     private Predicate<HermesResponse> retryCondition = new HermesClientBasicRetryCondition();
     private long retrySleepInMillis = 100;
     private long maxRetrySleepInMillis = 300;
+    private double jitterFactor = 0.5d;
     private Supplier<Scheduler> schedulerFactory = () -> Schedulers.fromExecutor(Executors.newSingleThreadScheduledExecutor());
     private Optional<MetricsProvider> metrics = Optional.empty();
 
@@ -36,7 +37,7 @@ public class ReactiveHermesClientBuilder {
 
     public ReactiveHermesClient build() {
         ReactiveHermesClient hermesClient = new ReactiveHermesClient(sender, uri, defaultHeaders, retries, retryCondition,
-                retrySleepInMillis, maxRetrySleepInMillis, schedulerFactory.get());
+                retrySleepInMillis, maxRetrySleepInMillis, jitterFactor, schedulerFactory.get());
 
         metrics.ifPresent((metricsProvider) -> {
             hermesClient.addMessageDeliveryListener(new MetricsMessageDeliveryListener(metricsProvider));
@@ -88,6 +89,11 @@ public class ReactiveHermesClientBuilder {
 
     public ReactiveHermesClientBuilder withScheduler(Scheduler scheduler) {
         this.schedulerFactory = () -> scheduler;
+        return this;
+    }
+
+    public ReactiveHermesClientBuilder withJitter(Double jitterFactor) {
+        this.jitterFactor = jitterFactor;
         return this;
     }
 }

--- a/hermes-client/src/main/java/pl/allegro/tech/hermes/client/ReactiveHermesClientBuilder.java
+++ b/hermes-client/src/main/java/pl/allegro/tech/hermes/client/ReactiveHermesClientBuilder.java
@@ -1,0 +1,92 @@
+package pl.allegro.tech.hermes.client;
+
+import pl.allegro.tech.hermes.client.metrics.MetricsMessageDeliveryListener;
+import pl.allegro.tech.hermes.client.metrics.MetricsProvider;
+
+import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+
+public class ReactiveHermesClientBuilder {
+
+    private ReactiveHermesSender sender;
+    private URI uri = URI.create("http://localhost:8080");
+    private final Map<String, String> defaultHeaders = new HashMap<>();
+    private int retries = 3;
+    private Predicate<HermesResponse> retryCondition = new HermesClientBasicRetryCondition();
+    private long retrySleepInMillis = 100;
+    private long maxRetrySleepInMillis = 300;
+    private Supplier<ScheduledExecutorService> schedulerFactory = Executors::newSingleThreadScheduledExecutor;
+    private Optional<MetricsProvider> metrics = Optional.empty();
+
+    public ReactiveHermesClientBuilder(ReactiveHermesSender sender) {
+        this.sender = sender;
+        this.defaultHeaders.put(HermesMessage.CONTENT_TYPE_HEADER, HermesMessage.APPLICATION_JSON);
+    }
+
+    public static ReactiveHermesClientBuilder hermesClient(ReactiveHermesSender sender) {
+        return new ReactiveHermesClientBuilder(sender);
+    }
+
+    public ReactiveHermesClient build() {
+        ReactiveHermesClient hermesClient = new ReactiveHermesClient(sender, uri, defaultHeaders, retries, retryCondition,
+                retrySleepInMillis, maxRetrySleepInMillis, schedulerFactory.get());
+
+        metrics.ifPresent((metricsProvider) -> {
+            hermesClient.addMessageDeliveryListener(new MetricsMessageDeliveryListener(metricsProvider));
+        });
+
+        return hermesClient;
+    }
+
+    public ReactiveHermesClientBuilder withURI(URI uri) {
+        this.uri = uri;
+        return this;
+    }
+
+    public ReactiveHermesClientBuilder withMetrics(MetricsProvider metrics) {
+        this.metrics = Optional.of(metrics);
+        return this;
+    }
+
+    public ReactiveHermesClientBuilder withDefaultContentType(String defaultContentType) {
+        defaultHeaders.put(HermesMessage.CONTENT_TYPE_HEADER, defaultContentType);
+        return this;
+    }
+
+    public ReactiveHermesClientBuilder withDefaultHeaderValue(String header, String value) {
+        defaultHeaders.put(header, value);
+        return this;
+    }
+
+    public ReactiveHermesClientBuilder withRetries(int retries) {
+        this.retries = retries;
+        return this;
+    }
+
+    public ReactiveHermesClientBuilder withRetries(int retries, Predicate<HermesResponse> retryCondition) {
+        this.retryCondition = retryCondition;
+        return withRetries(retries);
+    }
+
+    public ReactiveHermesClientBuilder withRetrySleep(long retrySleepInMillis) {
+        this.retrySleepInMillis = retrySleepInMillis;
+        return this;
+    }
+
+    public ReactiveHermesClientBuilder withRetrySleep(long retrySleepInMillis, long maxRetrySleepInMillis) {
+        this.retrySleepInMillis = retrySleepInMillis;
+        this.maxRetrySleepInMillis = maxRetrySleepInMillis;
+        return this;
+    }
+
+    public ReactiveHermesClientBuilder withScheduler(ScheduledExecutorService scheduler) {
+        this.schedulerFactory = () -> scheduler;
+        return this;
+    }
+}

--- a/hermes-client/src/main/java/pl/allegro/tech/hermes/client/ReactiveHermesSender.java
+++ b/hermes-client/src/main/java/pl/allegro/tech/hermes/client/ReactiveHermesSender.java
@@ -1,0 +1,11 @@
+package pl.allegro.tech.hermes.client;
+
+import reactor.core.publisher.Mono;
+
+import java.net.URI;
+
+@FunctionalInterface
+public interface ReactiveHermesSender {
+
+    Mono<HermesResponse> sendReactively(URI uri, HermesMessage message);
+}

--- a/hermes-client/src/main/java/pl/allegro/tech/hermes/client/webclient/WebClientHermesSender.java
+++ b/hermes-client/src/main/java/pl/allegro/tech/hermes/client/webclient/WebClientHermesSender.java
@@ -28,7 +28,7 @@ public class WebClientHermesSender implements HermesSender, ReactiveHermesSender
     public Mono<HermesResponse> sendReactively(URI uri, HermesMessage message) {
         return webClient.post()
                 .uri(uri)
-                .syncBody(message.getBody()) // TODO reactively?
+                .syncBody(message.getBody())
                 .headers(httpHeaders -> httpHeaders.setAll(message.getHeaders()))
                 .exchange()
                 .flatMap(response -> response

--- a/hermes-client/src/test/groovy/pl/allegro/tech/hermes/client/ReactiveHermesClientMetricsTest.groovy
+++ b/hermes-client/src/test/groovy/pl/allegro/tech/hermes/client/ReactiveHermesClientMetricsTest.groovy
@@ -1,0 +1,205 @@
+package pl.allegro.tech.hermes.client
+
+import com.codahale.metrics.MetricRegistry
+import pl.allegro.tech.hermes.client.metrics.DropwizardMetricsProvider
+import pl.allegro.tech.hermes.client.metrics.MetricsProvider
+import reactor.core.publisher.Mono
+import spock.lang.Specification
+
+import java.time.Duration
+import java.time.temporal.ChronoUnit
+
+import static pl.allegro.tech.hermes.client.ReactiveHermesClientBuilder.hermesClient
+
+class ReactiveHermesClientMetricsTest extends Specification {
+
+    private final MetricRegistry metrics = new MetricRegistry()
+    private final MetricsProvider metricsProvider = new DropwizardMetricsProvider(metrics)
+
+    def "should measure publish latency"() {
+        given:
+        ReactiveHermesClient client = hermesClient(delayedHermesSender(Duration.ofMillis(100)))
+                .withRetrySleep(0)
+                .withMetrics(metricsProvider).build()
+
+        when:
+        client.publish("com.group.topic", "123").block()
+
+        then:
+        metrics.counter("hermes-client.com_group.topic.status.201").count == 1
+        metrics.timer("hermes-client.com_group.topic.latency").getSnapshot().getMax() >= Duration.ofMillis(100).get(ChronoUnit.NANOS)
+        metrics.timer("hermes-client.com_group.topic.latency").getSnapshot().getMax() < Duration.ofMillis(300).get(ChronoUnit.NANOS)
+    }
+
+    def "should close timer on exceptional completion and log failure metric"() {
+        given:
+        ReactiveHermesClient client = hermesClient({uri, msg ->  failingMono(new RuntimeException())})
+                .withRetrySleep(0)
+                .withRetries(3)
+                .withMetrics(metricsProvider).build()
+
+        when:
+        silence({ client.publish("com.group.topic", "123").block() })
+
+        then:
+        metrics.counter("hermes-client.com_group.topic.failure").count == 4
+        metrics.timers.containsKey("hermes-client.com_group.topic.latency")
+
+        metrics.counter("hermes-client.com_group.topic.publish.failure").count == 4
+        metrics.counter("hermes-client.com_group.topic.publish.finally.failure").count == 1
+        metrics.counter("hermes-client.com_group.topic.publish.retry.failure").count == 3
+    }
+
+    def "should update max retries exceeded metric"() {
+        given:
+        ReactiveHermesClient client = hermesClient({uri, msg ->  failingMono(new RuntimeException())})
+                .withRetrySleep(0)
+                .withRetries(3)
+                .withMetrics(metricsProvider).build()
+
+        when:
+        silence({ client.publish("com.group.topic", "123").block() })
+
+        then:
+        metrics.counter("hermes-client.com_group.topic.failure").count == 4
+        metrics.counter("hermes-client.com_group.topic.retries.count").count == 3
+        metrics.counter("hermes-client.com_group.topic.retries.exhausted").count == 1
+        metrics.counter("hermes-client.com_group.topic.retries.success").count == 0
+        metrics.histogram("hermes-client.com_group.topic.retries.attempts").getSnapshot().size() == 0
+        metrics.timers.containsKey("hermes-client.com_group.topic.latency")
+
+        metrics.counter("hermes-client.com_group.topic.publish.finally.success").count == 0
+        metrics.counter("hermes-client.com_group.topic.publish.finally.failure").count == 1
+        metrics.counter("hermes-client.com_group.topic.publish.failure").count == 4
+        metrics.counter("hermes-client.com_group.topic.publish.attempt").count == 1
+        metrics.counter("hermes-client.com_group.topic.publish.retry.success").count == 0
+        metrics.counter("hermes-client.com_group.topic.publish.retry.failure").count == 3
+        metrics.counter("hermes-client.com_group.topic.publish.retry.attempt").count == 1
+    }
+
+    def "should update retries metrics"() {
+        given:
+        ReactiveHermesClient client1 = hermesClient(failingHermesSender(2))
+                .withRetrySleep(0)
+                .withRetries(4)
+                .withMetrics(metricsProvider).build()
+
+        ReactiveHermesClient client2 = hermesClient(failingHermesSender(5))
+                .withRetrySleep(0)
+                .withRetries(6)
+                .withMetrics(metricsProvider).build()
+
+        ReactiveHermesClient client3 = hermesClient(failingHermesSender(3))
+                .withRetrySleep(0)
+                .withRetries(2)
+                .withMetrics(metricsProvider).build()
+
+        when:
+        silence({ client1.publish("com.group.topic", "123").block() })
+        silence({ client2.publish("com.group.topic", "456").block() })
+        silence({ client3.publish("com.group.topic", "789").block() })
+
+        then:
+        metrics.counter("hermes-client.com_group.topic.failure").count == 10
+        metrics.counter("hermes-client.com_group.topic.retries.exhausted").count == 1
+        metrics.counter("hermes-client.com_group.topic.retries.success").count == 2
+        metrics.counter("hermes-client.com_group.topic.retries.count").count == 9
+        metrics.histogram("hermes-client.com_group.topic.retries.attempts").getSnapshot().getMin() == 2
+        metrics.histogram("hermes-client.com_group.topic.retries.attempts").getSnapshot().getMax() == 5
+        metrics.timers.containsKey("hermes-client.com_group.topic.latency")
+
+        metrics.counter("hermes-client.com_group.topic.publish.finally.success").count == 2
+        metrics.counter("hermes-client.com_group.topic.publish.finally.failure").count == 1
+        metrics.counter("hermes-client.com_group.topic.publish.failure").count == 10
+        metrics.counter("hermes-client.com_group.topic.publish.attempt").count == 3
+        metrics.counter("hermes-client.com_group.topic.publish.retry.success").count == 2
+        metrics.counter("hermes-client.com_group.topic.publish.retry.failure").count == 9
+        metrics.counter("hermes-client.com_group.topic.publish.retry.attempt").count == 3
+    }
+
+    def "should update failure metrics when there is an application-level error"() {
+        given:
+        ReactiveHermesClient client1 = hermesClient(badRequestHermesSender())
+                .withRetrySleep(0)
+                .withRetries(4)
+                .withMetrics(metricsProvider).build()
+
+        ReactiveHermesClient client2 = hermesClient(badRequestHermesSender())
+                .withRetrySleep(0)
+                .withRetries(6)
+                .withMetrics(metricsProvider).build()
+
+        ReactiveHermesClient client3 = hermesClient(badRequestHermesSender())
+                .withRetrySleep(0)
+                .withRetries(2)
+                .withMetrics(metricsProvider).build()
+
+        when:
+        silence({ client1.publish("com.group.topic", "123").block() })
+        silence({ client2.publish("com.group.topic", "456").block() })
+        silence({ client3.publish("com.group.topic", "789").block() })
+
+        then:
+        metrics.counter("hermes-client.com_group.topic.publish.finally.success").count == 0
+        metrics.counter("hermes-client.com_group.topic.publish.finally.failure").count == 3
+        metrics.counter("hermes-client.com_group.topic.publish.failure").count == 3
+        metrics.counter("hermes-client.com_group.topic.publish.attempt").count == 3
+        metrics.counter("hermes-client.com_group.topic.publish.retry.success").count == 0
+        metrics.counter("hermes-client.com_group.topic.publish.retry.failure").count == 0
+        metrics.counter("hermes-client.com_group.topic.publish.retry.attempt").count == 0
+    }
+
+    private Mono<HermesResponse> successMono(HermesMessage message) {
+        return Mono.just(HermesResponseBuilder.hermesResponse(message).withHttpStatus(201).build())
+    }
+
+    private Mono<HermesResponse> badRequestMono(HermesMessage message) {
+        return Mono.just(HermesResponseBuilder.hermesResponse(message).withHttpStatus(400).build())
+    }
+
+    private Mono<HermesResponse> failingMono(Throwable throwable) {
+        return Mono.error(throwable)
+    }
+
+    private ReactiveHermesSender failingHermesSender(int errorNo) {
+        new ReactiveHermesSender() {
+            int i = 0
+            @Override
+            Mono<HermesResponse> sendReactively(URI uri, HermesMessage message) {
+                i++
+                if (i <= errorNo) {
+                    return failingMono(new RuntimeException())
+                }
+                return successMono(message)
+            }
+        }
+    }
+
+    private ReactiveHermesSender delayedHermesSender(Duration sendLatencyMs) {
+        new ReactiveHermesSender() {
+            @Override
+            Mono<HermesResponse> sendReactively(URI uri, HermesMessage message) {
+                Thread.sleep(sendLatencyMs.toMillis())
+                return successMono(message)
+            }
+        }
+    }
+
+    private ReactiveHermesSender badRequestHermesSender() {
+        new ReactiveHermesSender() {
+            @Override
+            Mono<HermesResponse> sendReactively(URI uri, HermesMessage message) {
+                return badRequestMono(message)
+            }
+        }
+    }
+
+    private void silence(Runnable runnable) {
+        try {
+            runnable.run()
+        } catch (Exception ex) {
+            // do nothing
+        }
+    }
+
+}

--- a/hermes-client/src/test/groovy/pl/allegro/tech/hermes/client/ReactiveHermesClientMicrometerMetricsTest.groovy
+++ b/hermes-client/src/test/groovy/pl/allegro/tech/hermes/client/ReactiveHermesClientMicrometerMetricsTest.groovy
@@ -1,0 +1,161 @@
+package pl.allegro.tech.hermes.client
+
+import io.micrometer.core.instrument.MeterRegistry
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import pl.allegro.tech.hermes.client.metrics.MetricsProvider
+import pl.allegro.tech.hermes.client.metrics.MicrometerMetricsProvider
+import reactor.core.publisher.Mono
+import spock.lang.Specification
+
+import java.time.Duration
+import java.time.temporal.ChronoUnit
+import java.util.concurrent.TimeUnit
+
+import static pl.allegro.tech.hermes.client.ReactiveHermesClientBuilder.hermesClient
+
+class ReactiveHermesClientMicrometerMetricsTest extends Specification {
+
+    private final MeterRegistry metrics = new SimpleMeterRegistry()
+    private final MetricsProvider metricsProvider = new MicrometerMetricsProvider(metrics)
+
+    def "should measure publish latency"() {
+        given:
+        ReactiveHermesClient client = hermesClient(delayedHermesSender(Duration.ofMillis(100)))
+                .withRetrySleep(0)
+                .withMetrics(metricsProvider).build()
+
+        when:
+        client.publish("com.group.topic", "123").block()
+
+        then:
+        metrics.counter("hermes-client.com_group.topic.status.{code}", "code", String.valueOf(201)).count() == 1
+        def timer = metrics.timer("hermes-client.com_group.topic.latency")
+        timer.totalTime(TimeUnit.NANOSECONDS) >= Duration.ofMillis(100).get(ChronoUnit.NANOS)
+        timer.totalTime(TimeUnit.NANOSECONDS) < Duration.ofMillis(300).get(ChronoUnit.NANOS)
+    }
+
+    def "should close timer on exceptional completion and log failure metric"() {
+        given:
+        ReactiveHermesClient client = hermesClient({uri, msg ->  failingMono(new RuntimeException())})
+                .withRetrySleep(0)
+                .withRetries(3)
+                .withMetrics(metricsProvider).build()
+
+        when:
+        silence({ client.publish("com.group.topic", "123").block() })
+
+        then:
+        metrics.counter("hermes-client.com_group.topic.failure").count()  == 4
+        metrics.timer("hermes-client.com_group.topic.latency").count() == 4
+    }
+
+    def "should update max retries exceeded metric"() {
+        given:
+        ReactiveHermesClient client = hermesClient({uri, msg ->  failingMono(new RuntimeException())})
+                .withRetrySleep(0)
+                .withRetries(3)
+                .withMetrics(metricsProvider).build()
+
+        when:
+        silence({ client.publish("com.group.topic", "123").block() })
+
+        then:
+        metrics.counter("hermes-client.com_group.topic.failure").count() == 4
+        metrics.counter("hermes-client.com_group.topic.retries.count").count() == 3
+        metrics.counter("hermes-client.com_group.topic.retries.exhausted").count() == 1
+        metrics.counter("hermes-client.com_group.topic.retries.success").count() == 0
+        metrics.summary("hermes-client.com_group.topic.retries.attempts").takeSnapshot().count() == 0
+        metrics.timer("hermes-client.com_group.topic.latency").count() == 4
+    }
+
+    def "should update retries metrics"() {
+        def retries = 3
+        ReactiveHermesClient client = hermesClient(failingHermesSender(retries - 1))
+                .withRetrySleep(0)
+                .withRetries(retries)
+                .withMetrics(metricsProvider).build()
+
+
+        client.addMessageDeliveryListener(new MessageDeliveryListener() {
+            @Override
+            void onSend(HermesResponse response, long latency) {
+                println("onSend: $latency")
+            }
+
+            @Override
+            void onFailure(HermesMessage message, int attemptCount) {
+                println("onFailure $attemptCount")
+            }
+
+            @Override
+            void onFailedRetry(HermesMessage message, int attemptCount) {
+                println("onFailedRetry $attemptCount")
+            }
+
+            @Override
+            void onSuccessfulRetry(HermesMessage message, int attemptCount) {
+                println("onSuccessfulRetry $attemptCount")
+            }
+
+            @Override
+            void onMaxRetriesExceeded(HermesMessage message, int attemptCount) {
+                println("onMaxRetriesExceeded $attemptCount")
+            }
+        })
+
+
+        when:
+        silence({ client.publish("com.group.topic", "123").block() })
+
+        then:
+        metrics.counter("hermes-client.com_group.topic.failure").count() == 2
+        metrics.counter("hermes-client.com_group.topic.retries.exhausted").count() == 0
+        metrics.counter("hermes-client.com_group.topic.retries.success").count() == 1
+        metrics.counter("hermes-client.com_group.topic.status.{code}", "code", String.valueOf(201)).count() == 1
+        metrics.counter("hermes-client.com_group.topic.retries.count").count() == 2
+        metrics.summary("hermes-client.com_group.topic.retries.attempts").takeSnapshot().percentileValues()[0].value() == 2
+        metrics.summary("hermes-client.com_group.topic.retries.attempts").takeSnapshot().max() == 2
+        metrics.timer("hermes-client.com_group.topic.latency").count() == 3
+    }
+
+    private Mono<HermesResponse> successMono(HermesMessage message) {
+        return Mono.just(HermesResponseBuilder.hermesResponse(message).withHttpStatus(201).build())
+    }
+
+    private Mono<HermesResponse> failingMono(Throwable throwable) {
+        return Mono.error(throwable)
+    }
+
+    private ReactiveHermesSender failingHermesSender(int errorNo) {
+        new ReactiveHermesSender() {
+            int i = 0
+            @Override
+            Mono<HermesResponse> sendReactively(URI uri, HermesMessage message) {
+                i++
+                if (i <= errorNo) {
+                    return failingMono(new RuntimeException())
+                }
+                return successMono(message)
+            }
+        }
+    }
+
+    private ReactiveHermesSender delayedHermesSender(Duration sendLatencyMs) {
+        new ReactiveHermesSender() {
+            @Override
+            Mono<HermesResponse> sendReactively(URI uri, HermesMessage message) {
+                Thread.sleep(sendLatencyMs.toMillis())
+                return successMono(message)
+            }
+        }
+    }
+
+    private void silence(Runnable runnable) {
+        try {
+            runnable.run()
+        } catch (Exception ex) {
+            // do nothing
+        }
+    }
+
+}

--- a/hermes-client/src/test/groovy/pl/allegro/tech/hermes/client/ReactiveHermesClientMicrometerMetricsTest.groovy
+++ b/hermes-client/src/test/groovy/pl/allegro/tech/hermes/client/ReactiveHermesClientMicrometerMetricsTest.groovy
@@ -75,35 +75,6 @@ class ReactiveHermesClientMicrometerMetricsTest extends Specification {
                 .withRetries(retries)
                 .withMetrics(metricsProvider).build()
 
-
-        client.addMessageDeliveryListener(new MessageDeliveryListener() {
-            @Override
-            void onSend(HermesResponse response, long latency) {
-                println("onSend: $latency")
-            }
-
-            @Override
-            void onFailure(HermesMessage message, int attemptCount) {
-                println("onFailure $attemptCount")
-            }
-
-            @Override
-            void onFailedRetry(HermesMessage message, int attemptCount) {
-                println("onFailedRetry $attemptCount")
-            }
-
-            @Override
-            void onSuccessfulRetry(HermesMessage message, int attemptCount) {
-                println("onSuccessfulRetry $attemptCount")
-            }
-
-            @Override
-            void onMaxRetriesExceeded(HermesMessage message, int attemptCount) {
-                println("onMaxRetriesExceeded $attemptCount")
-            }
-        })
-
-
         when:
         silence({ client.publish("com.group.topic", "123").block() })
 

--- a/hermes-client/src/test/groovy/pl/allegro/tech/hermes/client/ReactiveHermesClientTest.groovy
+++ b/hermes-client/src/test/groovy/pl/allegro/tech/hermes/client/ReactiveHermesClientTest.groovy
@@ -1,0 +1,347 @@
+package pl.allegro.tech.hermes.client
+
+import reactor.core.publisher.Mono
+import reactor.core.scheduler.Schedulers
+import spock.lang.Specification
+
+import java.time.Duration
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.function.Supplier
+
+import static java.net.URI.create
+import static pl.allegro.tech.hermes.client.ReactiveHermesClientBuilder.hermesClient
+
+class ReactiveHermesClientTest extends Specification {
+
+    private static final String HERMES_URI = "http://localhost:9999"
+
+    private static final String TOPIC = "my.group.topicName"
+
+    private static final byte[] CONTENT = "{}".bytes
+
+    private static final String CONTENT_TYPE = "application/json"
+
+    private def executor = Executors.newFixedThreadPool(2)
+
+    def "should publish message using supplied sender"() {
+        given:
+        ReactiveHermesClient client = hermesClient({ URI uri, HermesMessage message ->
+            assert uri.toString() == (String) "$HERMES_URI/topics/$TOPIC"
+            assert message.body == CONTENT
+            statusFuture(message, 201)
+        })
+                .withURI(create(HERMES_URI))
+                .build()
+
+        when:
+        HermesResponse response = client.publish(TOPIC, CONTENT_TYPE, CONTENT).block()
+
+        then:
+        response.success
+        !response.failure
+        response.httpStatus == 201
+        !response.failureCause.isPresent()
+    }
+
+    def "should interpret message as accepted when sender returns 202"() {
+        given:
+        ReactiveHermesClient client = hermesClient({ uri, msg -> statusFuture(msg, 202) })
+                .withURI(create(HERMES_URI))
+                .build()
+
+        when:
+        HermesResponse response = client.publish(TOPIC, CONTENT_TYPE, CONTENT).block()
+
+        then:
+        response.success
+        response.httpStatus == 202
+    }
+
+    def "should interpret message as failed for status different than 201 or 202"() {
+        given:
+        ReactiveHermesClient client = hermesClient({uri, msg -> statusFuture(msg, status)})
+                .withURI(create(HERMES_URI))
+                .withRetrySleep(0)
+                .build()
+
+        when:
+        HermesResponse response = client.publish(TOPIC, CONTENT_TYPE, CONTENT).block()
+
+        then:
+        !response.success
+        response.failure
+
+        where:
+        status << [203, 204, 400, 401, 404, 500]
+    }
+
+
+    def "should retry on http failure"() {
+        given:
+        CountDownLatch latch = new CountDownLatch(5)
+        ReactiveHermesClient client = hermesClient(getCountDownSender(latch, (Integer) status))
+                .withRetries(5)
+                .withRetrySleep(0)
+                .build()
+
+        when:
+        client.publish(TOPIC, CONTENT_TYPE, CONTENT).block()
+        then:
+        latch.count == 0
+
+        where:
+        status << [408, 500, 501, 502, 503, 504, 505]
+    }
+
+    def "should return failed message in case of failed sending"() {
+        given:
+        CountDownLatch latch = new CountDownLatch(5)
+        ReactiveHermesClient client = hermesClient(getExceptionallyFailingCountDownSender(latch))
+                .withRetries(5)
+                .withRetrySleep(0)
+                .build()
+
+        when:
+        def response = client.publish(TOPIC, CONTENT_TYPE, CONTENT).block()
+
+        then:
+        latch.count == 0
+        response.hermesMessage.body == CONTENT
+        response.hermesMessage.contentType == CONTENT_TYPE
+        response.hermesMessage.topic == TOPIC
+        response.failureCause.get().message == "Sending failed"
+    }
+
+    def "should retry on sender exception"() {
+        given:
+        CountDownLatch latch = new CountDownLatch(5)
+        ReactiveHermesClient client = hermesClient(getExceptionallyFailingCountDownSender(latch))
+                .withRetries(5)
+                .withRetrySleep(0)
+                .build()
+
+        when:
+        client.publish(TOPIC, CONTENT_TYPE, CONTENT).block()
+
+        then:
+        latch.count == 0
+    }
+
+    def "should not retry when supplied retry condition says it should not retry"() {
+        given:
+        CountDownLatch latch = new CountDownLatch(2)
+        ReactiveHermesClient client = hermesClient(getCountDownSender(latch, 503))
+                .withRetries(5, {false})
+                .build()
+
+        when:
+        client.publish(TOPIC, CONTENT_TYPE, CONTENT).block()
+
+        then:
+        latch.count == 1
+    }
+
+    def "should not retry when one of the attempts succeeds to send"() {
+        given:
+        CountDownLatch latch = new CountDownLatch(5)
+        ReactiveHermesClient client = hermesClient(getCountDownSender(latch, {latch.getCount() > 2 ? 408 : 201}))
+                .withRetries(5)
+                .withRetrySleep(0)
+                .build()
+
+        when:
+        client.publish(TOPIC, CONTENT_TYPE, CONTENT).block()
+
+        then:
+        latch.count == 2
+    }
+
+    def "should wait until all sent after shutdown"() {
+        given:
+        CountDownLatch latch = new CountDownLatch(5)
+        ReactiveHermesClient client = hermesClient(getCountDownDelayedSender(latch, 408, 20))
+                .withRetries(5)
+                .withRetrySleep(0)
+                .build()
+
+        when:
+        client.publish(TOPIC, CONTENT_TYPE, CONTENT)
+                .subscribeOn(Schedulers.elastic())
+                .subscribe()
+
+        and:
+        client.close(20, 1000)
+
+        then:
+        latch.await(1, TimeUnit.SECONDS)
+    }
+
+    def "should not publish after shutdown"() {
+        given:
+        ReactiveHermesClient client = hermesClient({ uri, msg -> statusFuture(msg, 201) }).build()
+
+        when:
+        client.closeAsync(10).block(Duration.ofSeconds(1))
+        client.publish(TOPIC, CONTENT_TYPE, CONTENT).block()
+
+        then:
+        thrown(HermesClientShutdownException)
+    }
+
+    def "should keep retrying on sender exception after shutdown"() {
+        given:
+        CountDownLatch latch = new CountDownLatch(5)
+        ReactiveHermesClient client = hermesClient(getExceptionallyFailingCountDownSender(latch, 20))
+                .withRetries(5)
+                .withRetrySleep(0)
+                .build()
+
+        when:
+        client.publish(TOPIC, CONTENT_TYPE, CONTENT)
+            .subscribeOn(Schedulers.elastic())
+            .subscribe()
+
+        and:
+        client.closeAsync(50).block(Duration.ofSeconds(1))
+
+        then:
+        latch.await(1, TimeUnit.SECONDS)
+    }
+
+    def "should append default headers to message"() {
+        given:
+        Map<String, String> headers = [:]
+        ReactiveHermesClient client = hermesClient(getHeaderScrapingSender(headers))
+            .withDefaultContentType('my/content')
+            .withDefaultHeaderValue('Header', 'Value')
+            .build()
+
+        when:
+        client.publish(HermesMessage.hermesMessage(TOPIC, CONTENT).build()).block()
+
+        then:
+        headers['Content-Type'] == 'my/content'
+        headers['Header'] == 'Value'
+    }
+
+    def "should overwrite default headers when specific values provided"() {
+        given:
+        Map<String, String> headers = [:]
+        ReactiveHermesClient client = hermesClient(getHeaderScrapingSender(headers))
+                .withDefaultContentType('my/content')
+                .withDefaultHeaderValue('Header', 'Value')
+                .build()
+
+        when:
+        client.publish(HermesMessage.hermesMessage(TOPIC, CONTENT)
+                .json()
+                .withHeader('Header', 'OtherValue')
+                .build()).block()
+
+        then:
+        headers['Content-Type'] == 'application/json;charset=UTF-8'
+        headers['Header'] == 'OtherValue'
+    }
+
+    def "should retry on sender exception when retry sleep is provided"() {
+        given:
+            CountDownLatch latch = new CountDownLatch(2)
+            ReactiveHermesClient client = hermesClient(getExceptionallyFailingCountDownSender(latch))
+                    .withRetries(2)
+                    .withRetrySleep(10)
+                    .build()
+
+        when:
+        client.publish(TOPIC, CONTENT_TYPE, CONTENT).block()
+
+        then:
+            latch.count == 0
+    }
+
+    def "should retry when sender throws exception"() {
+        given:
+        CountDownLatch latch = new CountDownLatch(2)
+        ReactiveHermesClient client = hermesClient(getThrowingCountDownSender(latch))
+                .withRetries(2)
+                .withRetrySleep(10)
+                .build()
+
+        when:
+        client.publish(TOPIC, CONTENT_TYPE, CONTENT).block()
+
+        then:
+        thrown(RuntimeException)
+        latch.count == 0
+    }
+
+    private ReactiveHermesSender getExceptionallyFailingCountDownSender(CountDownLatch latch, long delay) {
+        { uri, msg ->
+            def future = new CompletableFuture()
+
+            executor.submit({
+                Thread.sleep(delay)
+                latch.countDown()
+                future.completeExceptionally(new RuntimeException("Sending failed"))
+            } as Runnable)
+
+            Mono.fromFuture(future)
+        }
+    }
+
+    private ReactiveHermesSender getExceptionallyFailingCountDownSender(CountDownLatch latch) {
+        { uri, msg ->
+            Mono.fromCallable {
+                latch.countDown()
+                throw new RuntimeException("Sending failed")
+            }
+        }
+    }
+
+    private ReactiveHermesSender getThrowingCountDownSender(CountDownLatch latch) {
+        { uri, msg ->
+            latch.countDown()
+            throw new RuntimeException("Sending failed")
+        }
+    }
+
+    private Mono<HermesResponse> statusFuture(HermesMessage message, int status) {
+        Mono.just(HermesResponseBuilder.hermesResponse(message).withHttpStatus(status).build())
+    }
+
+    private ReactiveHermesSender getCountDownSender(CountDownLatch latch, int status) {
+        getCountDownSender(latch, { status } as Supplier<Integer>)
+    }
+
+    private ReactiveHermesSender getCountDownSender(CountDownLatch latch, Supplier<Integer> status) {
+        { uri, msg ->
+            Mono.fromCallable  {
+                latch.countDown()
+                return HermesResponseBuilder.hermesResponse(msg).withHttpStatus(status.get()).build()
+            }
+        }
+    }
+
+    private ReactiveHermesSender getCountDownDelayedSender(CountDownLatch latch, int status, long delay) {
+        return { uri, msg ->
+            def future = new CompletableFuture()
+
+            executor.submit({
+                Thread.sleep(delay)
+                latch.countDown()
+                future.complete(HermesResponseBuilder.hermesResponse(msg).withHttpStatus(status).build())
+            } as Runnable)
+
+            Mono.fromFuture(future)
+        }
+    }
+
+    private ReactiveHermesSender getHeaderScrapingSender(Map<String, String> headers) {
+        { uri, msg ->
+            headers.putAll(msg.headers)
+            Mono.just(HermesResponseBuilder.hermesResponse(msg).withHttpStatus(201).build())
+        }
+    }
+}

--- a/hermes-client/src/test/groovy/pl/allegro/tech/hermes/client/ReactiveHermesClientTest.groovy
+++ b/hermes-client/src/test/groovy/pl/allegro/tech/hermes/client/ReactiveHermesClientTest.groovy
@@ -292,6 +292,7 @@ class ReactiveHermesClientTest extends Specification {
         ReactiveHermesClient client = hermesClient(getThrowingCountDownSender(latch))
                 .withRetries(4)
                 .withRetrySleep(retrySleepInMillis, retrySleepInMillis * 100)
+                .withJitter(0)
                 .withScheduler(timeScheduler)
                 .build()
 

--- a/hermes-client/src/test/groovy/pl/allegro/tech/hermes/client/ReactiveHermesClientTest.groovy
+++ b/hermes-client/src/test/groovy/pl/allegro/tech/hermes/client/ReactiveHermesClientTest.groovy
@@ -3,6 +3,7 @@ package pl.allegro.tech.hermes.client
 import reactor.core.publisher.Mono
 import reactor.core.scheduler.Schedulers
 import spock.lang.Specification
+import spock.lang.Unroll
 
 import java.time.Duration
 import java.util.concurrent.CompletableFuture
@@ -60,6 +61,7 @@ class ReactiveHermesClientTest extends Specification {
         response.httpStatus == 202
     }
 
+    @Unroll
     def "should interpret message as failed for status different than 201 or 202"() {
         given:
         ReactiveHermesClient client = hermesClient({uri, msg -> statusFuture(msg, status)})
@@ -78,7 +80,7 @@ class ReactiveHermesClientTest extends Specification {
         status << [203, 204, 400, 401, 404, 500]
     }
 
-
+    @Unroll
     def "should retry on http failure"() {
         given:
         CountDownLatch latch = new CountDownLatch(5)

--- a/hermes-client/src/test/groovy/pl/allegro/tech/hermes/client/ReactiveHermesSenderTest.groovy
+++ b/hermes-client/src/test/groovy/pl/allegro/tech/hermes/client/ReactiveHermesSenderTest.groovy
@@ -1,0 +1,140 @@
+package pl.allegro.tech.hermes.client
+
+import com.github.tomakehurst.wiremock.client.WireMock
+import com.github.tomakehurst.wiremock.junit.WireMockClassRule
+import org.junit.ClassRule
+import org.springframework.web.reactive.function.client.WebClient
+import pl.allegro.tech.hermes.client.webclient.WebClientHermesSender
+import spock.lang.Shared
+import spock.lang.Specification
+import spock.lang.Unroll
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse
+import static com.github.tomakehurst.wiremock.client.WireMock.containing
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo
+import static com.github.tomakehurst.wiremock.client.WireMock.post
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
+import static pl.allegro.tech.hermes.client.HermesMessage.hermesMessage
+
+class ReactiveHermesSenderTest extends Specification {
+
+    @ClassRule
+    @Shared
+    WireMockClassRule service = new WireMockClassRule(14523)
+
+    void setup() {
+        WireMock.reset()
+    }
+
+    @Unroll
+    def "should send Content-Type header when publishing using #name sender"() {
+        given:
+        ReactiveHermesSender currentSender = sender
+        ReactiveHermesClient client = ReactiveHermesClientBuilder
+                .hermesClient(currentSender)
+                .withDefaultContentType("application/json")
+                .withURI(URI.create("http://localhost:" + service.port()))
+                .build()
+
+        service.stubFor(post(urlEqualTo('/topics/topic.test'))
+                .willReturn(aResponse().withStatus(201)))
+
+        when:
+        client.publish("topic.test", "Hello!").block()
+
+        then:
+        service.verify(postRequestedFor(urlEqualTo("/topics/topic.test"))
+                .withHeader("Content-Type", equalTo("application/json"))
+                .withRequestBody(containing("Hello!")))
+
+        where:
+        sender                                                  | name
+        new WebClientHermesSender(WebClient.create())           | 'WebClientSender'
+    }
+
+    @Unroll
+    def "should send Schema-Version header when publishing with schema using #name sender"() {
+        given:
+        ReactiveHermesSender currentSender = sender
+        ReactiveHermesClient client = ReactiveHermesClientBuilder
+                .hermesClient(currentSender)
+                .withURI(URI.create("http://localhost:" + service.port()))
+                .build()
+
+        service.stubFor(post(urlEqualTo('/topics/topic.test'))
+                .willReturn(aResponse().withStatus(201)))
+
+        when:
+        client.publish(hermesMessage('topic.test', 'Hello!').withSchemaVersion(13).build()).block()
+
+        then:
+        service.verify(postRequestedFor(urlEqualTo("/topics/topic.test"))
+                .withHeader("Schema-Version", equalTo("13"))
+                .withRequestBody(containing("Hello!")))
+
+        where:
+        sender                                                  | name
+        new WebClientHermesSender(WebClient.create())           | 'WebClientSender'
+    }
+
+    @Unroll
+    def "should send custom header when publishing using #name sender"() {
+        given:
+        ReactiveHermesSender currentSender = sender
+        ReactiveHermesClient client = ReactiveHermesClientBuilder
+                .hermesClient(currentSender)
+                .withURI(URI.create("http://localhost:" + service.port()))
+                .build()
+
+        service.stubFor(post(urlEqualTo('/topics/topic.test'))
+                .willReturn(aResponse().withStatus(201)))
+
+        when:
+        client.publish(hermesMessage('topic.test', 'Hello!').withHeader('Custom-Header', 'header value').build()).block()
+
+        then:
+        service.verify(postRequestedFor(urlEqualTo("/topics/topic.test"))
+                .withHeader("Custom-Header", equalTo("header value"))
+                .withRequestBody(containing("Hello!")))
+
+        where:
+        sender                                                  | name
+        new WebClientHermesSender(WebClient.create())           | 'WebClientSender'
+    }
+
+    @Unroll
+    def "should read header #header being case insensitive when publishing using #name sender"() {
+        given:
+        ReactiveHermesSender currentSender = sender
+        ReactiveHermesClient client = ReactiveHermesClientBuilder
+                .hermesClient(currentSender)
+                .withDefaultContentType("application/json")
+                .withURI(URI.create("http://localhost:" + service.port()))
+                .build()
+
+        service.stubFor(
+                post(urlEqualTo('/topics/topic.test'))
+                    .willReturn(aResponse()
+                        .withStatus(201)
+                        .withHeader(header, 'messageId'))
+        )
+
+        when:
+        def response = client.publish("topic.test", "Hello!").block()
+
+        then:
+        service.verify(postRequestedFor(urlEqualTo("/topics/topic.test"))
+                .withHeader("Content-Type", equalTo("application/json"))
+                .withRequestBody(containing("Hello!")))
+
+        and:
+        response.messageId == 'messageId'
+
+        where:
+        sender                                                  | name                  | header
+        new WebClientHermesSender(WebClient.create())           | 'WebClientSender'     | 'Hermes-Message-Id'
+        new WebClientHermesSender(WebClient.create())           | 'WebClientSender'     | 'hermes-message-id'
+        new WebClientHermesSender(WebClient.create())           | 'WebClientSender'     | 'HERMES-MESSAGE-ID'
+    }
+}


### PR DESCRIPTION
This PR introduces a `ReactiveHermesClient` class and a `ReactiveHermesSender` interface implemented using `WebClient`. Both `ReactiveHermesClient` and `ReactiveHermesSender` mimic their non-reactive counterparts' API and behaviour.  Also, the reactive classes' tests are almost identical to the non-reactive classes' tests.