### PR TITLE
Add instructions for demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Hermes
 [![Documentation Status](https://readthedocs.org/projects/hermes-pubsub/badge/?version=latest)](https://readthedocs.org/projects/hermes-pubsub/?badge=latest)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/pl.allegro.tech.hermes/hermes-client/badge.svg)](https://maven-badges.herokuapp.com/maven-central/pl.allegro.tech.hermes/hermes-client)
 [![Join the chat](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/allegro/hermes?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![Blimp demo badge](https://blimpup.io/demo-badge.svg?repo=https://github.com/allegro/hermes.git)](https://blimpup.io/preview-env/?repo=https://github.com/allegro/hermes.git&port=frontend:8080&port=management:8090&composeFiles=docker/docker-compose.yml)
 
 Hermes is an asynchronous message broker built on top of [Kafka](http://kafka.apache.org/).
 We provide reliable, fault tolerant REST interface for message publishing and adaptive push
@@ -17,6 +18,17 @@ Visit our page: [hermes.allegro.tech](http://hermes.allegro.tech)
 See our full documentation: [http://hermes-pubsub.readthedocs.org/en/latest/](http://hermes-pubsub.readthedocs.org/en/latest/)
 
 Questions? We are on [gitter](https://gitter.im/allegro/hermes).
+
+## Demoing
+If you want to play around with Hermes without running it locally, you can
+[boot a personal demo copy
+](https://blimpup.io/preview-env/?repo=https://github.com/allegro/hermes.git&port=frontend:8080&port=management:8090&composeFiles=docker/docker-compose.yml)
+from your browser without downloading or setting up anything.
+
+Clicking the
+[link](https://blimpup.io/preview-env/?repo=https://github.com/allegro/hermes.git&port=frontend:8080&port=management:8090&composeFiles=docker/docker-compose.yml)
+boots this repo in the Blimp cloud, and creates a public URL for you to access
+it.
 
 ## License
 


### PR DESCRIPTION
Hi @adamdubiel  @druminski 

We've put together the first version of the demo badge so that your users can get a temporary Hermes env for poking around!

<img width="1416" alt="Screen Shot 2020-09-13 at 3 43 01 PM" src="https://user-images.githubusercontent.com/1811185/93030499-65548380-f5d8-11ea-9006-d75cfcd3b73c.png">

Everything seems to boot fine but I was getting some 404's. I'm not sure if that's because I was just using Hermes wrong, or if something isn't working.

Either way, would appreciate your feedback! Was this what you guys were imagining? What do you guys think?