### PR TITLE
Fixed http headers now have a dedicated pane in console.

### DIFF
--- a/hermes-console/static/js/console/subscription/SubscriptionController.js
+++ b/hermes-console/static/js/console/subscription/SubscriptionController.js
@@ -36,7 +36,7 @@ subscriptions.controller('SubscriptionController', ['SubscriptionRepository', 'S
 
         $scope.retransmissionLoading = false;
 
-        $scope.showHeadersFilter = config.showHeadersFilter;
+        $scope.showFixedHeaders = config.showFixedHeaders;
 
         $scope.endpointAddressResolverMetadataConfig = config.endpointAddressResolverMetadata;
 
@@ -102,8 +102,8 @@ subscriptions.controller('SubscriptionController', ['SubscriptionRepository', 'S
                     topicContentType: function () {
                         return $scope.topicContentType;
                     },
-                    showHeadersFilter: function () {
-                        return $scope.showHeadersFilter;
+                    showFixedHeaders: function () {
+                        return $scope.showFixedHeaders;
                     }
                 }
             }).result.then(function(response){
@@ -132,8 +132,8 @@ subscriptions.controller('SubscriptionController', ['SubscriptionRepository', 'S
                     topicContentType: function () {
                         return $scope.topicContentType;
                     },
-                    showHeadersFilter: function () {
-                        return $scope.showHeadersFilter;
+                    showFixedHeaders: function () {
+                        return $scope.showFixedHeaders;
                     }
                 }
             }).result.then(function(response){
@@ -256,15 +256,15 @@ subscriptions.controller('SubscriptionController', ['SubscriptionRepository', 'S
 
 subscriptions.controller('SubscriptionEditController', ['SubscriptionRepository', '$scope', '$uibModalInstance', 'subscription',
     'topicName', 'PasswordService', 'toaster', 'operation', 'endpointAddressResolverMetadataConfig', 'topicContentType',
-    'showHeadersFilter', 'SUBSCRIPTION_CONFIG',
+    'showFixedHeaders', 'SUBSCRIPTION_CONFIG',
     function (subscriptionRepository, $scope, $modal, subscription, topicName, passwordService, toaster, operation,
-              endpointAddressResolverMetadataConfig, topicContentType, showHeadersFilter, subscriptionConfig) {
+              endpointAddressResolverMetadataConfig, topicContentType, showFixedHeaders, subscriptionConfig) {
         $scope.topicName = topicName;
         $scope.topicContentType = topicContentType;
         $scope.subscription = _.cloneDeep(subscription);
         $scope.operation = operation;
         $scope.endpointAddressResolverMetadataConfig = endpointAddressResolverMetadataConfig;
-        $scope.showHeadersFilter = showHeadersFilter;
+        $scope.showFixedHeaders = showFixedHeaders;
         $scope.config = subscriptionConfig;
 
         $scope.save = function () {

--- a/hermes-console/static/js/console/topic/TopicController.js
+++ b/hermes-console/static/js/console/topic/TopicController.js
@@ -21,7 +21,7 @@ topics.controller('TopicController', ['TOPIC_CONFIG', 'TopicRepository', 'TopicM
         $scope.offlineClientsFetching = true;
         $scope.showMessageSchema = false;
         $scope.config = topicConfig;
-        $scope.showHeadersFilter = subscriptionConfig.showHeadersFilter;
+        $scope.showFixedHeaders = subscriptionConfig.showFixedHeaders;
 
         topicRepository.get(topicName).then(function(topicWithSchema) {
             $scope.topic = topicWithSchema;
@@ -216,8 +216,8 @@ topics.controller('TopicController', ['TOPIC_CONFIG', 'TopicRepository', 'TopicM
                     topicContentType: function () {
                         return $scope.topic.contentType;
                     },
-                    showHeadersFilter: function () {
-                        return $scope.showHeadersFilter;
+                    showFixedHeaders: function () {
+                        return $scope.showFixedHeaders;
                     }
                 }
             }).result.then(function () {

--- a/hermes-console/static/partials/modal/editSubscription.html
+++ b/hermes-console/static/partials/modal/editSubscription.html
@@ -269,23 +269,23 @@
                 </div>
             </div>
 
-            <div class="form-group" ng-show="showHeadersFilter">
-                <label class="col-md-3 control-label">HTTP Header Filter</label>
+            <div class="form-group" ng-show="showFixedHeaders">
+                <label class="col-md-3 control-label">Fixed HTTP headers</label>
                 <div class="col-md-9">
                     <table class="table borderless">
                         <tr>
                             <th>Name</th>
-                            <th>Pattern</th>
+                            <th>Value</th>
                             <th></th>
                         </tr>
-                        <tr ng-repeat="filter in subscription.headers">
+                        <tr ng-repeat="header in subscription.headers">
                             <td>
-                                <input ng-model="filter.name"
-                                       class="form-control col-md-1" placeholder="{{filter.name}}"/>
+                                <input ng-model="header.name"
+                                       class="form-control col-md-1" placeholder="{{header.name}}"/>
                             </td>
                             <td>
-                                <input ng-model="filter.value"
-                                       class="form-control col-md-1" placeholder="{{filter.value}}"/>
+                                <input ng-model="header.value"
+                                       class="form-control col-md-1" placeholder="{{header.value}}"/>
                             </td>
                             <td>
                                 <button class="btn btn-danger" ng-click="delHeader($index)">Delete</button>

--- a/hermes-console/static/partials/subscription.html
+++ b/hermes-console/static/partials/subscription.html
@@ -313,19 +313,19 @@
         <div class="col-md-12">
             <div class="panel">
                 <div class="panel-heading">
-                    <h3 class="panel-title">Subscription http header filters</h3>
+                    <h3 class="panel-title">Fixed HTTP headers</h3>
                 </div>
                 <table class="table">
                     <tr>
                         <th>#</th>
                         <th>Name</th>
-                        <th>Pattern</th>
+                        <th>Value</th>
                         <th> </th>
                     </tr>
-                    <tr ng-repeat="filter in subscription.headers">
+                    <tr ng-repeat="header in subscription.headers">
                         <td>{{$index + 1}}</td>
-                        <td>{{filter.name}}</td>
-                        <td>{{filter.value}}</td>
+                        <td>{{header.name}}</td>
+                        <td>{{header.value}}</td>
                     </tr>
                 </table>
             </div>


### PR DESCRIPTION
Solves #1255 .

There was a pane in subscription view and edit panel that enabled user to check and modify the header filters for that subscription. In reality, despite what the labels said, setting those filters would instead set fixed header values for those subscriptions. 

This PR addresses the issue and instead enables user to set fixed header values explicitly.