### PR TITLE
resolve #1267 | Audit logs for unsuccessful topic and subscription operations

### DIFF
--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/domain/Auditor.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/domain/Auditor.java
@@ -1,8 +1,22 @@
 package pl.allegro.tech.hermes.management.domain;
 
 import pl.allegro.tech.hermes.api.Anonymizable;
+import pl.allegro.tech.hermes.api.PatchData;
 
 public interface Auditor {
+
+    default void beforeObjectCreation(String username, Object createdObject) {
+    }
+
+    default void beforeObjectCreation(String username, Anonymizable createdObject) {
+        beforeObjectCreation(username, (Object) createdObject.anonymize());
+    }
+
+    default void beforeObjectRemoval(String username, String removedObjectType, String removedObjectName) {
+    }
+
+    default void beforeObjectUpdate(String username, String objectClassName, Object objectName, PatchData patchData) {
+    }
 
     default void objectCreated(String username, Object createdObject) {
     }

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/domain/topic/TopicService.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/domain/topic/TopicService.java
@@ -104,6 +104,7 @@ public class TopicService {
 
     public void createTopicWithSchema(TopicWithSchema topicWithSchema, String createdBy, CreatorRights isAllowedToManage) {
         Topic topic = topicWithSchema.getTopic();
+        auditor.beforeObjectCreation(createdBy, topic);
         topicValidator.ensureCreatedTopicIsValid(topic, isAllowedToManage);
         ensureTopicDoesNotExist(topic);
 
@@ -171,6 +172,7 @@ public class TopicService {
     }
 
     public void removeTopicWithSchema(Topic topic, String removedBy) {
+        auditor.beforeObjectRemoval(removedBy, Topic.class.getSimpleName(), topic.getQualifiedName());
         removeSchema(topic);
         if (!topicProperties.isAllowRemoval()) {
             throw new TopicRemovalDisabledException(topic);
@@ -207,6 +209,7 @@ public class TopicService {
     }
 
     public void updateTopic(TopicName topicName, PatchData patch, String modifiedBy) {
+        auditor.beforeObjectUpdate(modifiedBy, Topic.class.getSimpleName(), topicName, patch);
         groupService.checkGroupExists(topicName.getGroupName());
 
         Topic retrieved = getTopicDetails(topicName);

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/infrastructure/audit/LoggingAuditor.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/infrastructure/audit/LoggingAuditor.java
@@ -5,6 +5,7 @@ import org.javers.core.Javers;
 import org.javers.core.diff.Diff;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import pl.allegro.tech.hermes.api.PatchData;
 import pl.allegro.tech.hermes.management.domain.Auditor;
 
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -19,6 +20,26 @@ public class LoggingAuditor implements Auditor {
     public LoggingAuditor(Javers javers, ObjectMapper objectMapper) {
         this.javers = checkNotNull(javers);
         this.objectMapper = checkNotNull(objectMapper);
+    }
+
+    @Override
+    public void beforeObjectCreation(String username, Object createdObject) {
+        ignoringExceptions(() ->
+                logger.info("User {} tries creating new {} {}.", username, createdObject.getClass().getSimpleName(),
+                        objectMapper.writeValueAsString(createdObject)));
+    }
+
+    @Override
+    public void beforeObjectRemoval(String username, String removedObjectType, String removedObjectName) {
+        logger.info("User {} tries removing {} {}.", username, removedObjectType, removedObjectName);
+    }
+
+    @Override
+    public void beforeObjectUpdate(String username, String objectClassName, Object objectName, PatchData patchData) {
+        ignoringExceptions(() -> {
+            logger.info("User {} tries updating {} {}. {}", username, objectClassName,
+                    objectName, patchData);
+        });
     }
 
     @Override


### PR DESCRIPTION
Hello, 

This PR references issue #1267 Audit logs for unsuccessful topic and subscription operations

As discussed in this issue:
- I added beforeObjectX methods to Auditor (default to no-op)
- I implemented those methods in LoggingAuditor following the same log format when possible
- I added calls to those methods in TopicService and SubscriptionService il all methods that already logged the success
- I rearranged a bit of code around the beforeObjectUpdate calls for it to be the earliest possible (especially updateSubscriptionState)