### PR TITLE
Downgraded kafka to 2.1.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ allprojects {
     targetCompatibility = 1.8
 
     project.ext.versions = [
-            kafka             : '2.2.2',
+            kafka             : '2.1.1',
             guava             : '23.0',
             jackson           : '2.9.10',
             jersey            : '2.23.2',

--- a/hermes-test-helper/build.gradle
+++ b/hermes-test-helper/build.gradle
@@ -6,7 +6,7 @@ dependencies {
     compile group: 'org.glassfish.jersey.core', name: 'jersey-client', version: versions.jersey
     compile group: 'org.glassfish.jersey.ext', name: 'jersey-proxy-client', version: versions.jersey
     compile group: 'commons-io', name: 'commons-io', version: '2.4'
-    compile(group: 'org.apache.kafka', name: 'kafka_2.11', version: '2.0.0') {
+    compile(group: 'org.apache.kafka', name: 'kafka_2.11', version: versions.kafka) {
         exclude group: 'javax.jms'
         exclude group: 'com.sun.jdmk'
         exclude group: 'com.sun.jmx'


### PR DESCRIPTION
Downgraded used kafka dependencies to 2.1.1 due to specific bug occurring with pre 2.4 brokers.