### PR TITLE
Fixed one test that wasn't passing from time to time

### DIFF
--- a/hermes-consumers/src/test/java/pl/allegro/tech/hermes/consumers/consumer/ConsumerMessageSenderTest.java
+++ b/hermes-consumers/src/test/java/pl/allegro/tech/hermes/consumers/consumer/ConsumerMessageSenderTest.java
@@ -397,7 +397,7 @@ public class ConsumerMessageSenderTest {
 
         // then
         long sendingTime = System.currentTimeMillis() - sendingStartTime;
-        assertThat(sendingTime).isGreaterThan(500);
+        assertThat(sendingTime).isGreaterThanOrEqualTo(500);
     }
 
     @Test
@@ -574,7 +574,7 @@ public class ConsumerMessageSenderTest {
     private Subscription subscriptionWithExponentialRetryBackoff(int messageBackoff, double backoffMultiplier) {
         return subscriptionWithExponentialRetryBackoff(messageBackoff, backoffMultiplier, 3600);
     }
-    
+
     private Subscription subscriptionWithExponentialRetryBackoff(int messageBackoff, double backoffMultiplier, int ttl) {
         return subscriptionBuilderWithTestValues()
                 .withSubscriptionPolicy(subscriptionPolicy().applyDefaults()


### PR DESCRIPTION
There is a test in Hermes tests that checks if sending delay works as intended. Unfortunately from time to time it doesn't pass, because the code is too fast:

`pl.allegro.tech.hermes.consumers.consumer.ConsumerMessageSenderTest > shouldDelaySendingMessageForHalfSecond FAILED
    java.lang.AssertionError: 
    Expecting:
     <500L>
    to be greater than:
     <500L> 
        at pl.allegro.tech.hermes.consumers.consumer.ConsumerMessageSenderTest.shouldDelaySendingMessageForHalfSecond(ConsumerMessageSenderTest.java:400)`

This PR should address this issue.