### PR TITLE
resolve #1279 | copy message schema to clipboard

### DIFF
--- a/hermes-console/static/js/console/topic/TopicController.js
+++ b/hermes-console/static/js/console/topic/TopicController.js
@@ -224,6 +224,17 @@ topics.controller('TopicController', ['TOPIC_CONFIG', 'TopicRepository', 'TopicM
                 loadSubscriptions();
             });
         };
+
+        $scope.copyToClipboard = function () {
+            var tempElement = document.createElement('textarea');
+            tempElement.value = $scope.messageSchema;
+            document.body.appendChild(tempElement);
+            tempElement.select();
+            document.execCommand('copy');
+            document.body.removeChild(tempElement);
+
+            toaster.pop('info', 'Info', 'Message schema has been copied to clipboard');
+        };
     }]);
 
 topics.controller('TopicEditController', ['TOPIC_CONFIG', 'TopicRepository', '$scope', '$uibModalInstance', 'PasswordService',

--- a/hermes-console/static/partials/topic.html
+++ b/hermes-console/static/partials/topic.html
@@ -120,10 +120,9 @@
 
     <div class="row" ng-show="topic.contentType == 'AVRO'">
         <div class="col-md-12">
-            <div class="panel panel-default">
-                <div style="position: relative">
-                    <span class="btn pull-right glyphicon {{showMessageSchema ? 'glyphicon-chevron-up' : 'glyphicon-chevron-down' }}" ng-click="showMessageSchema = !showMessageSchema"></span>
-                </div>
+            <div class="panel panel-default" style="position: relative">
+                <span class="btn pull-right glyphicon {{showMessageSchema ? 'glyphicon-chevron-up' : 'glyphicon-chevron-down' }}" ng-click="showMessageSchema = !showMessageSchema"></span>
+                <button class="btn btn-default pull-right" style="padding: 4px; margin-top: 4px" ng-click="copyToClipboard()">Copy to clipboard</button>
                 <div class="panel-heading" ng-click="showMessageSchema = !showMessageSchema">
                     <h3 class="panel-title">Message schema</h3>
                 </div>
@@ -136,10 +135,8 @@
 
     <div class="row" ng-show="config.messagePreviewEnabled">
         <div class="col-md-12">
-            <div class="panel panel-default">
-                <div style="position: relative">
-                    <span class="btn pull-right glyphicon {{showMessageSchema ? 'glyphicon-chevron-up' : 'glyphicon-chevron-down' }}" ng-click="showPreview = !showPreview"></span>
-                </div>
+            <div class="panel panel-default" style="position: relative">
+                <span class="btn pull-right glyphicon {{showPreview ? 'glyphicon-chevron-up' : 'glyphicon-chevron-down' }}" ng-click="showPreview = !showPreview"></span>
                 <div class="panel-heading" ng-click="showPreview = !showPreview">
                     <h3 class="panel-title">Topic messages preview</h3>
                 </div>


### PR DESCRIPTION
Adds "Copy to clipboard" button on `Message schema` bar in topic view.

![image](https://user-images.githubusercontent.com/17440354/96133989-64768080-0efb-11eb-9675-c8553de8025c.png)
