### PR TITLE
Add new meaningful metrics to MetricsMessageDeliveryListener

### DIFF
--- a/hermes-client/src/main/java/pl/allegro/tech/hermes/client/HermesClient.java
+++ b/hermes-client/src/main/java/pl/allegro/tech/hermes/client/HermesClient.java
@@ -164,17 +164,14 @@ public class HermesClient {
     }
 
     private void handleFailedAttempt(ExecutionAttemptedEvent<HermesResponse> event) {
-        HermesMessage message = event.getLastResult().getHermesMessage();
         messageDeliveryListeners.forEach(l -> l.onFailedRetry(event.getLastResult(), event.getAttemptCount()));
     }
 
     private void handleFailure(ExecutionCompletedEvent<HermesResponse> event) {
-        HermesMessage message = event.getResult().getHermesMessage();
         messageDeliveryListeners.forEach(l -> l.onFailure(event.getResult(), event.getAttemptCount()));
     }
 
     private void handleSuccessfulRetry(ExecutionCompletedEvent<HermesResponse> event) {
-        HermesMessage message = event.getResult().getHermesMessage();
         messageDeliveryListeners.forEach(l -> l.onSuccessfulRetry(event.getResult(), event.getAttemptCount()));
     }
 }

--- a/hermes-client/src/main/java/pl/allegro/tech/hermes/client/HermesClient.java
+++ b/hermes-client/src/main/java/pl/allegro/tech/hermes/client/HermesClient.java
@@ -158,23 +158,23 @@ public class HermesClient {
         }
 
         HermesMessage message = event.getResult().getHermesMessage();
-        messageDeliveryListeners.forEach(l -> l.onMaxRetriesExceeded(message, event.getAttemptCount()));
+        messageDeliveryListeners.forEach(l -> l.onMaxRetriesExceeded(event.getResult(), event.getAttemptCount()));
         logger.error("Failed to send message to topic {} after {} attempts",
                 message.getTopic(), event.getAttemptCount());
     }
 
     private void handleFailedAttempt(ExecutionAttemptedEvent<HermesResponse> event) {
         HermesMessage message = event.getLastResult().getHermesMessage();
-        messageDeliveryListeners.forEach(l -> l.onFailedRetry(message, event.getAttemptCount()));
+        messageDeliveryListeners.forEach(l -> l.onFailedRetry(event.getLastResult(), event.getAttemptCount()));
     }
 
     private void handleFailure(ExecutionCompletedEvent<HermesResponse> event) {
         HermesMessage message = event.getResult().getHermesMessage();
-        messageDeliveryListeners.forEach(l -> l.onFailure(message, event.getAttemptCount()));
+        messageDeliveryListeners.forEach(l -> l.onFailure(event.getResult(), event.getAttemptCount()));
     }
 
     private void handleSuccessfulRetry(ExecutionCompletedEvent<HermesResponse> event) {
         HermesMessage message = event.getResult().getHermesMessage();
-        messageDeliveryListeners.forEach(l -> l.onSuccessfulRetry(message, event.getAttemptCount()));
+        messageDeliveryListeners.forEach(l -> l.onSuccessfulRetry(event.getResult(), event.getAttemptCount()));
     }
 }

--- a/hermes-client/src/main/java/pl/allegro/tech/hermes/client/MessageDeliveryListener.java
+++ b/hermes-client/src/main/java/pl/allegro/tech/hermes/client/MessageDeliveryListener.java
@@ -4,11 +4,11 @@ public interface MessageDeliveryListener {
 
     void onSend(HermesResponse response, long latency);
 
-    void onFailure(HermesMessage message, int attemptCount);
+    void onFailure(HermesResponse message, int attemptCount);
 
-    void onFailedRetry(HermesMessage message, int attemptCount);
+    void onFailedRetry(HermesResponse message, int attemptCount);
 
-    void onSuccessfulRetry(HermesMessage message, int attemptCount);
+    void onSuccessfulRetry(HermesResponse message, int attemptCount);
 
-    void onMaxRetriesExceeded(HermesMessage message, int attemptCount);
+    void onMaxRetriesExceeded(HermesResponse message, int attemptCount);
 }

--- a/hermes-client/src/main/java/pl/allegro/tech/hermes/client/metrics/MetricsMessageDeliveryListener.java
+++ b/hermes-client/src/main/java/pl/allegro/tech/hermes/client/metrics/MetricsMessageDeliveryListener.java
@@ -25,31 +25,53 @@ public class MetricsMessageDeliveryListener implements MessageDeliveryListener {
         Map<String, String> tags = new HashMap<>();
         tags.put("code", String.valueOf(response.getHttpStatus()));
         metrics.counterIncrement(prefix, "status", tags);
+
+        counterIncrementIf(prefix + ".publish.failure", response.isFailure());
     }
 
     @Override
-    public void onFailure(HermesMessage message, int attemptCount) {
-        String prefix = MetricsUtils.getMetricsPrefix(message.getTopic());
+    public void onFailure(HermesResponse response, int attemptCount) {
+        String prefix = MetricsUtils.getMetricsPrefix(response.getHermesMessage().getTopic());
         metrics.counterIncrement(prefix + ".failure");
     }
 
     @Override
-    public void onFailedRetry(HermesMessage message, int attemptCount) {
-        String prefix = MetricsUtils.getMetricsPrefix(message.getTopic());
+    public void onFailedRetry(HermesResponse response, int attemptCount) {
+        String prefix = MetricsUtils.getMetricsPrefix(response.getHermesMessage().getTopic());
         metrics.counterIncrement(prefix + ".retries.count");
         metrics.counterIncrement(prefix + ".failure");
+
+        metrics.counterIncrement(prefix + ".publish.retry.failure");
     }
 
     @Override
-    public void onSuccessfulRetry(HermesMessage message, int attemptCount) {
-        String prefix = MetricsUtils.getMetricsPrefix(message.getTopic());
+    public void onSuccessfulRetry(HermesResponse response, int attemptCount) {
+        String prefix = MetricsUtils.getMetricsPrefix(response.getHermesMessage().getTopic());
         metrics.counterIncrement(prefix + ".retries.success");
         metrics.histogramUpdate(prefix + ".retries.attempts", attemptCount - 1);
+
+        boolean wasRetried = attemptCount > 1;
+
+        metrics.counterIncrement(prefix + ".publish.attempt");
+        counterIncrementIf(prefix + ".publish.retry.success", response.isSuccess() && wasRetried);
+        counterIncrementIf(prefix + ".publish.finally.success", response.isSuccess());
+        counterIncrementIf(prefix + ".publish.retry.failure", response.isFailure() && wasRetried);
+        counterIncrementIf(prefix + ".publish.finally.failure", response.isFailure());
+        counterIncrementIf(prefix + ".publish.retry.attempt", wasRetried);
     }
 
     @Override
-    public void onMaxRetriesExceeded(HermesMessage message, int attemptCount) {
-        String prefix = MetricsUtils.getMetricsPrefix(message.getTopic());
+    public void onMaxRetriesExceeded(HermesResponse response, int attemptCount) {
+        String prefix = MetricsUtils.getMetricsPrefix(response.getHermesMessage().getTopic());
         metrics.counterIncrement(prefix + ".retries.exhausted");
+        metrics.counterIncrement(prefix + ".publish.finally.failure");
+        metrics.counterIncrement(prefix + ".publish.attempt");
+        metrics.counterIncrement(prefix + ".publish.retry.attempt");
+    }
+
+    private void counterIncrementIf(String name, boolean condition) {
+        if (condition) {
+            metrics.counterIncrement(name);
+        }
     }
 }


### PR DESCRIPTION
Currently metrics provided by MetricsMessageDeliveryListener might be
confusing due to poor naming and the fact that only transport layer
errors are considered a "failure".
New metrics take into account also application level errors which
are represented by http status codes. Following metrics have been
added:

- topic.publish.finally.success:
Message has been accepted by Hermes

- topic.publish.finally.failure
Message has been rejected by Hermes or there was transport level issue. Whole publish
operation is considered atomic so intermittent failures handled by retries will not
be counted by this metric.

- topic.publish.failure:
Counts number of failures including retries.

- topic.publish.attempts:
Counts number of publish attempt. Does not include retries.

- topic.publish.retry.success:
Counts number of successful publications after one or more retry.

- topic.publish.retry.failure:
Counts number of failures after retries have been exhausted.

- topic.publish.retry.attempt:
Counts number of publications where retry was involved.


I'm not sure if topic.publish.failure fits nicely this set of metrics. It's the only metric that counts all underlying requests and not only logical ones.