### PR TITLE
Moved 'consistency checker' config to Properties class

### DIFF
--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/config/ConsistencyCheckerProperties.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/config/ConsistencyCheckerProperties.java
@@ -1,0 +1,17 @@
+package pl.allegro.tech.hermes.management.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "consistency-checker")
+public class ConsistencyCheckerProperties {
+
+    private int threadPoolSize = 2;
+
+    public int getThreadPoolSize() {
+        return threadPoolSize;
+    }
+
+    public void setThreadPoolSize(int threadPoolSize) {
+        this.threadPoolSize = threadPoolSize;
+    }
+}

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/config/ManagementConfiguration.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/config/ManagementConfiguration.java
@@ -7,24 +7,29 @@ import com.fasterxml.jackson.databind.InjectableValues;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import static javax.servlet.DispatcherType.REQUEST;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import pl.allegro.tech.hermes.api.Topic;
 import pl.allegro.tech.hermes.common.clock.ClockFactory;
 import pl.allegro.tech.hermes.management.api.ReadOnlyFilter;
 import pl.allegro.tech.hermes.management.domain.mode.ModeService;
 import pl.allegro.tech.hermes.management.domain.subscription.SubscriptionLagSource;
 import pl.allegro.tech.hermes.management.infrastructure.metrics.NoOpSubscriptionLagSource;
+
 import java.time.Clock;
-import pl.allegro.tech.hermes.api.Topic;
+
+import static javax.servlet.DispatcherType.REQUEST;
 
 @Configuration
-@EnableConfigurationProperties({TopicProperties.class, MetricsProperties.class, HttpClientProperties.class})
+@EnableConfigurationProperties({
+        TopicProperties.class,
+        MetricsProperties.class,
+        HttpClientProperties.class,
+        ConsistencyCheckerProperties.class})
 public class ManagementConfiguration {
 
     @Autowired

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/domain/consistency/ConsistencyService.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/domain/consistency/ConsistencyService.java
@@ -3,7 +3,6 @@ package pl.allegro.tech.hermes.management.domain.consistency;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import pl.allegro.tech.hermes.api.Group;
 import pl.allegro.tech.hermes.api.InconsistentGroup;
@@ -17,6 +16,7 @@ import pl.allegro.tech.hermes.domain.group.GroupNotExistsException;
 import pl.allegro.tech.hermes.domain.group.GroupRepository;
 import pl.allegro.tech.hermes.domain.subscription.SubscriptionRepository;
 import pl.allegro.tech.hermes.domain.topic.TopicRepository;
+import pl.allegro.tech.hermes.management.config.ConsistencyCheckerProperties;
 import pl.allegro.tech.hermes.management.domain.dc.DatacenterBoundRepositoryHolder;
 import pl.allegro.tech.hermes.management.domain.dc.RepositoryManager;
 
@@ -46,13 +46,13 @@ public class ConsistencyService {
 
     public ConsistencyService(RepositoryManager repositoryManager,
                               ObjectMapper objectMapper,
-                              @Value("${consistencyChecker.threadPoolSize}") int threadPoolSize) {
+                              ConsistencyCheckerProperties properties) {
         this.groupRepositories = repositoryManager.getRepositories(GroupRepository.class);
         this.topicRepositories = repositoryManager.getRepositories(TopicRepository.class);
         this.subscriptionRepositories = repositoryManager.getRepositories(SubscriptionRepository.class);
         this.objectMapper = objectMapper;
         this.executor = Executors.newFixedThreadPool(
-                threadPoolSize,
+                properties.getThreadPoolSize(),
                 new ThreadFactoryBuilder()
                         .setNameFormat("consistency-checker-%d")
                         .build()

--- a/hermes-management/src/main/resources/application.yaml
+++ b/hermes-management/src/main/resources/application.yaml
@@ -49,6 +49,3 @@ subscriptionOwnerCache:
 console:
   configurationLocation: console/config-local.json
   configurationType: classpath_resource
-
-consistencyChecker:
-  threadPoolSize: 2

--- a/hermes-management/src/test/groovy/pl/allegro/tech/hermes/management/domain/consistency/ConsistencyServiceSpec.groovy
+++ b/hermes-management/src/test/groovy/pl/allegro/tech/hermes/management/domain/consistency/ConsistencyServiceSpec.groovy
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import pl.allegro.tech.hermes.api.Group
 import pl.allegro.tech.hermes.api.Subscription
 import pl.allegro.tech.hermes.api.Topic
+import pl.allegro.tech.hermes.management.config.ConsistencyCheckerProperties
 import spock.lang.Specification
 
 import static pl.allegro.tech.hermes.test.helper.builder.GroupBuilder.group
@@ -26,7 +27,8 @@ class ConsistencyServiceSpec extends Specification {
                 .addGroup(group)
                 .addTopic(topic)
                 .addSubscription(subscription)
-        ConsistencyService consistencyService = new ConsistencyService(repositoryManager, new ObjectMapper(), 2)
+        ConsistencyService consistencyService = new ConsistencyService(repositoryManager, new ObjectMapper(),
+                new ConsistencyCheckerProperties())
 
         when:
         def inconsistentGroups = consistencyService.listInconsistentGroups([group.groupName] as Set)
@@ -43,7 +45,8 @@ class ConsistencyServiceSpec extends Specification {
         repositoryManager.datacenter("dc2")
                 .addGroup(group("testGroup").build())
                 .addGroup(group("testGroup-dc2").build())
-        ConsistencyService consistencyService = new ConsistencyService(repositoryManager, new ObjectMapper(), 2)
+        ConsistencyService consistencyService = new ConsistencyService(repositoryManager, new ObjectMapper(),
+                new ConsistencyCheckerProperties())
 
         when:
         def groups = consistencyService.listInconsistentGroups(["testGroup", "testGroup-dc1", "testGroup-dc2"] as Set)
@@ -61,7 +64,8 @@ class ConsistencyServiceSpec extends Specification {
         repositoryManager.datacenter("dc2")
                 .addGroup(group)
                 .addTopic(topic(group.groupName, "testTopic").withDescription("dc2").build())
-        ConsistencyService consistencyService = new ConsistencyService(repositoryManager, new ObjectMapper(), 2)
+        ConsistencyService consistencyService = new ConsistencyService(repositoryManager, new ObjectMapper(),
+                new ConsistencyCheckerProperties())
 
         when:
         def groups = consistencyService.listInconsistentGroups(["testGroup"] as Set)
@@ -82,7 +86,8 @@ class ConsistencyServiceSpec extends Specification {
                 .addGroup(group)
                 .addTopic(topic)
                 .addSubscription(subscription(topic, "testSubscription").withDescription("dc2").build())
-        ConsistencyService consistencyService = new ConsistencyService(repositoryManager, new ObjectMapper(), 2)
+        ConsistencyService consistencyService = new ConsistencyService(repositoryManager, new ObjectMapper(),
+                new ConsistencyCheckerProperties())
 
         when:
         def groups = consistencyService.listInconsistentGroups(["testGroup"] as Set)
@@ -99,7 +104,8 @@ class ConsistencyServiceSpec extends Specification {
         repositoryManager.datacenter("dc2")
                 .addGroup(group("testGroup").build())
                 .addGroup(group("testGroup-dc2").build())
-        ConsistencyService consistencyService = new ConsistencyService(repositoryManager, new ObjectMapper(), 2)
+        ConsistencyService consistencyService = new ConsistencyService(repositoryManager, new ObjectMapper(),
+                new ConsistencyCheckerProperties())
 
         when:
         def groups = consistencyService.listAllGroupNames()


### PR DESCRIPTION
Thanks this PR there is no need to provide additional configuration related to `consistency checker` when running custom Hermes. 