### PR TITLE
Remove demo badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@ Hermes
 [![Documentation Status](https://readthedocs.org/projects/hermes-pubsub/badge/?version=latest)](https://readthedocs.org/projects/hermes-pubsub/?badge=latest)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/pl.allegro.tech.hermes/hermes-client/badge.svg)](https://maven-badges.herokuapp.com/maven-central/pl.allegro.tech.hermes/hermes-client)
 [![Join the chat](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/allegro/hermes?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
-[![Blimp demo badge](https://blimpup.io/demo-badge.svg?repo=https://github.com/allegro/hermes.git)](https://blimpup.io/preview-env/?repo=https://github.com/allegro/hermes.git&port=frontend:8080&port=management:8090&composeFiles=docker/docker-compose.yml)
 
 Hermes is an asynchronous message broker built on top of [Kafka](http://kafka.apache.org/).
 We provide reliable, fault tolerant REST interface for message publishing and adaptive push
@@ -18,17 +17,6 @@ Visit our page: [hermes.allegro.tech](http://hermes.allegro.tech)
 See our full documentation: [http://hermes-pubsub.readthedocs.org/en/latest/](http://hermes-pubsub.readthedocs.org/en/latest/)
 
 Questions? We are on [gitter](https://gitter.im/allegro/hermes).
-
-## Demoing
-If you want to play around with Hermes without running it locally, you can
-[boot a personal demo copy
-](https://blimpup.io/preview-env/?repo=https://github.com/allegro/hermes.git&port=frontend:8080&port=management:8090&composeFiles=docker/docker-compose.yml)
-from your browser without downloading or setting up anything.
-
-Clicking the
-[link](https://blimpup.io/preview-env/?repo=https://github.com/allegro/hermes.git&port=frontend:8080&port=management:8090&composeFiles=docker/docker-compose.yml)
-boots this repo in the Blimp cloud, and creates a public URL for you to access
-it.
 
 ## License
 


### PR DESCRIPTION
Unfortunately, we're shutting down Blimp. This commit removes references
to Blimp to prevent broken links when it shuts down.

Thanks for trying out the badge while it was available! Let me know if you have any questions.