### PR TITLE
hermes-frontend change default response http status

### DIFF
--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/common/config/Configs.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/common/config/Configs.java
@@ -120,6 +120,7 @@ public enum Configs {
     FRONTEND_THROUGHPUT_DYNAMIC_DESIRED("frontend.throughput.dynamic.desired", Long.MAX_VALUE),
     FRONTEND_THROUGHPUT_DYNAMIC_IDLE("frontend.throughput.dynamic.idle", 0.5),
     FRONTEND_THROUGHPUT_DYNAMIC_CHECK_INTERVAL("frontend.throughput.dynamic.interval.seconds", 30),
+    FRONTEND_RESPONSE_ERROR_LOGGER_ENABLED("frontend.response.error.logger.enabled", false),
 
     FRONTEND_KEEP_ALIVE_HEADER_ENABLED("frontend.keep.alive.header.enabled", false),
     FRONTEND_KEEP_ALIVE_HEADER_TIMEOUT_SECONDS("frontend.keep.alive.header.timeout.seconds", 1),

--- a/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/HermesFrontend.java
+++ b/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/HermesFrontend.java
@@ -15,6 +15,7 @@ import pl.allegro.tech.hermes.common.hook.HooksHandler;
 import pl.allegro.tech.hermes.common.hook.ServiceAwareHook;
 import pl.allegro.tech.hermes.common.kafka.KafkaNamesMapper;
 import pl.allegro.tech.hermes.frontend.di.FrontendBinder;
+import pl.allegro.tech.hermes.frontend.di.LoggerConfiguration;
 import pl.allegro.tech.hermes.frontend.di.PersistentBufferExtension;
 import pl.allegro.tech.hermes.frontend.di.TrackersBinder;
 import pl.allegro.tech.hermes.frontend.listeners.BrokerAcknowledgeListener;
@@ -40,6 +41,7 @@ import java.util.UUID;
 import java.util.function.Function;
 
 import static pl.allegro.tech.hermes.common.config.Configs.FRONTEND_GRACEFUL_SHUTDOWN_ENABLED;
+import static pl.allegro.tech.hermes.common.config.Configs.FRONTEND_RESPONSE_ERROR_LOGGER_ENABLED;
 import static pl.allegro.tech.hermes.common.config.Configs.FRONTEND_STARTUP_TOPIC_METADATA_LOADING_ENABLED;
 import static pl.allegro.tech.hermes.common.config.Configs.FRONTEND_STARTUP_TOPIC_SCHEMA_LOADING_ENABLED;
 import static pl.allegro.tech.hermes.common.config.Configs.FRONTEND_STARTUP_WAIT_KAFKA_ENABLED;
@@ -87,6 +89,9 @@ public final class HermesFrontend {
         hooksHandler.addShutdownHook(defaultShutdownHook());
         if (flushLogsShutdownHookEnabled) {
             hooksHandler.addShutdownHook(new FlushLogsShutdownHook());
+        }
+        if (!config.getBooleanProperty(FRONTEND_RESPONSE_ERROR_LOGGER_ENABLED)) {
+            LoggerConfiguration.disableResponseDebugLogger();
         }
     }
 

--- a/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/HermesFrontend.java
+++ b/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/HermesFrontend.java
@@ -91,7 +91,7 @@ public final class HermesFrontend {
             hooksHandler.addShutdownHook(new FlushLogsShutdownHook());
         }
         if (!config.getBooleanProperty(FRONTEND_RESPONSE_ERROR_LOGGER_ENABLED)) {
-            LoggerConfiguration.disableResponseDebugLogger();
+            LoggerConfiguration.disableResponseErrorLogger();
         }
     }
 

--- a/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/di/LoggerConfiguration.java
+++ b/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/di/LoggerConfiguration.java
@@ -1,0 +1,14 @@
+package pl.allegro.tech.hermes.frontend.di;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import org.slf4j.LoggerFactory;
+
+public class LoggerConfiguration {
+    public static final String UNDERTOW_ERROR_RESPONSE_LOGGER = "io.undertow.request.error-response";
+
+    public static void disableResponseDebugLogger() {
+        ((Logger) LoggerFactory.getLogger(UNDERTOW_ERROR_RESPONSE_LOGGER))
+                .setLevel(Level.INFO);
+    }
+}

--- a/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/di/LoggerConfiguration.java
+++ b/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/di/LoggerConfiguration.java
@@ -7,7 +7,7 @@ import org.slf4j.LoggerFactory;
 public class LoggerConfiguration {
     public static final String UNDERTOW_ERROR_RESPONSE_LOGGER = "io.undertow.request.error-response";
 
-    public static void disableResponseDebugLogger() {
+    public static void disableResponseErrorLogger() {
         ((Logger) LoggerFactory.getLogger(UNDERTOW_ERROR_RESPONSE_LOGGER))
                 .setLevel(Level.INFO);
     }

--- a/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/publishing/handlers/TopicHandler.java
+++ b/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/publishing/handlers/TopicHandler.java
@@ -47,6 +47,7 @@ class TopicHandler implements HttpHandler {
         onRequestValid(exchange, messageId, cachedTopic -> {
             exchange.addExchangeCompleteListener(new ExchangeMetrics(cachedTopic));
             exchange.putAttachment(AttachmentContent.KEY, new AttachmentContent(cachedTopic, new MessageState(), messageId));
+            exchange.setStatusCode(500);
             try {
                 next.handleRequest(exchange);
             } catch (Exception e) {

--- a/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/publishing/handlers/TopicHandler.java
+++ b/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/publishing/handlers/TopicHandler.java
@@ -15,6 +15,7 @@ import pl.allegro.tech.hermes.frontend.server.auth.Roles;
 import java.util.Optional;
 import java.util.function.Consumer;
 
+import static io.undertow.util.StatusCodes.INTERNAL_SERVER_ERROR;
 import static pl.allegro.tech.hermes.api.ErrorCode.AUTH_ERROR;
 import static pl.allegro.tech.hermes.api.ErrorCode.TOPIC_BLACKLISTED;
 import static pl.allegro.tech.hermes.api.ErrorCode.TOPIC_NOT_EXISTS;
@@ -47,7 +48,7 @@ class TopicHandler implements HttpHandler {
         onRequestValid(exchange, messageId, cachedTopic -> {
             exchange.addExchangeCompleteListener(new ExchangeMetrics(cachedTopic));
             exchange.putAttachment(AttachmentContent.KEY, new AttachmentContent(cachedTopic, new MessageState(), messageId));
-            exchange.setStatusCode(500);
+            setDefaultResponseCode(exchange);
             try {
                 next.handleRequest(exchange);
             } catch (Exception e) {
@@ -115,5 +116,11 @@ class TopicHandler implements HttpHandler {
                 error("Topic blacklisted: " + qualifiedTopicName, TOPIC_BLACKLISTED),
                 messageId,
                 qualifiedTopicName);
+    }
+
+    // Default Undertow's response code (200) was changed in order to avoid situations in which something wrong happens and Hermes-Frontend does not publish message but return code 200
+    // Since the default code is 500, clients have information that they should retry publishing
+    private void setDefaultResponseCode(HttpServerExchange exchange) {
+        exchange.setStatusCode(INTERNAL_SERVER_ERROR);
     }
 }


### PR DESCRIPTION
This PR is related to default undertow response status [Issue](https://github.com/allegro/hermes/issues/1294)
We decided to set a 500 status code at the beginning of an exchange processing. But in consequence, Undertow logged exception for every request (related to setStatusCode method implementation). To avoid a lot of unnecessary logs we changed the logging level for an Undertow's response error logger.