### PR TITLE
Allow header propagation just by using configuration

### DIFF
--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/common/config/Configs.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/common/config/Configs.java
@@ -156,6 +156,9 @@ public enum Configs {
     FRONTEND_AUTHENTICATION_ENABLED("frontend.authentication.enabled", false),
     FRONTEND_AUTHENTICATION_MODE("frontend.authentication.mode", "constraint_driven"),
 
+    FRONTEND_HEADER_PROPAGATION_ENABLED("frontend.header.propagation.enabled", false),
+    FRONTEND_HEADER_PROPAGATION_ALLOW_FILTER("frontend.header.propagation.allow.filter", ""),
+
     FRONTEND_MESSAGE_PREVIEW_ENABLED("frontend.message.preview.enabled", false),
     FRONTEND_MESSAGE_PREVIEW_MAX_SIZE_KB("frontend.message.preview.max.size.kb", 10),
     FRONTEND_MESSAGE_PREVIEW_SIZE("frontend.message.preview.size", 3),

--- a/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/publishing/metadata/DefaultHeadersPropagator.java
+++ b/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/publishing/metadata/DefaultHeadersPropagator.java
@@ -1,13 +1,50 @@
 package pl.allegro.tech.hermes.frontend.publishing.metadata;
 
 import com.google.common.collect.ImmutableMap;
+import pl.allegro.tech.hermes.common.config.ConfigFactory;
 
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import javax.inject.Inject;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptySet;
+import static java.util.stream.Collectors.toSet;
+import static pl.allegro.tech.hermes.common.config.Configs.FRONTEND_HEADER_PROPAGATION_ENABLED;
+import static pl.allegro.tech.hermes.common.config.Configs.FRONTEND_HEADER_PROPAGATION_ALLOW_FILTER;
 
 public class DefaultHeadersPropagator implements HeadersPropagator {
 
+    private final boolean propagate;
+    private final Set<String> supportedHeaders;
+
+    @Inject
+    public DefaultHeadersPropagator(ConfigFactory config) {
+        if (config.getBooleanProperty(FRONTEND_HEADER_PROPAGATION_ENABLED)) {
+            propagate = true;
+            supportedHeaders = asList(config.getStringProperty(FRONTEND_HEADER_PROPAGATION_ALLOW_FILTER).split(",")).stream()
+                    .map(v -> v.trim())
+                    .filter(v -> v.length() > 0)
+                    .collect(toSet());
+        } else {
+            propagate = false;
+            supportedHeaders = emptySet();
+        }
+    }
+
     @Override
     public Map<String, String> extract(Map<String, String> headers) {
-        return ImmutableMap.of();
+        if (propagate) {
+            if (supportedHeaders.isEmpty()) {
+                return ImmutableMap.copyOf(headers);
+            }
+            return headers.entrySet().stream()
+                    .filter(e -> this.supportedHeaders.contains(e.getKey()))
+                    .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+        } else {
+            return ImmutableMap.of();
+        }
     }
 }

--- a/hermes-frontend/src/test/groovy/pl/allegro/tech/hermes/frontend/publishing/metadata/DefaultHeadersPropagatorTest.groovy
+++ b/hermes-frontend/src/test/groovy/pl/allegro/tech/hermes/frontend/publishing/metadata/DefaultHeadersPropagatorTest.groovy
@@ -1,0 +1,57 @@
+package pl.allegro.tech.hermes.frontend.publishing.metadata
+
+import pl.allegro.tech.hermes.common.config.ConfigFactory
+import spock.lang.Specification
+
+import static pl.allegro.tech.hermes.common.config.Configs.FRONTEND_HEADER_PROPAGATION_ENABLED;
+import static pl.allegro.tech.hermes.common.config.Configs.FRONTEND_HEADER_PROPAGATION_ALLOW_FILTER;
+
+class DefaultHeadersPropagatorTest extends Specification {
+
+    def 'should propagate all headers when enabled and no filter'() {
+        given:
+            def configFactory = Mock(ConfigFactory) {
+                getBooleanProperty(FRONTEND_HEADER_PROPAGATION_ENABLED) >> true
+                getStringProperty(FRONTEND_HEADER_PROPAGATION_ALLOW_FILTER) >> ""
+            }
+            def propagator = new DefaultHeadersPropagator(configFactory);
+
+        when:
+            def extracted = propagator.extract(["header1": "value1", "header2": "value2"])
+
+        then:
+            extracted.size() == 2
+            extracted["header1"] == "value1"
+            extracted["header2"] == "value2"
+    }
+
+    def 'should not propagate headers when disabled'() {
+        given:
+            def configFactory = Mock(ConfigFactory) {
+                getBooleanProperty(FRONTEND_HEADER_PROPAGATION_ENABLED) >> false
+            }
+            def propagator = new DefaultHeadersPropagator(configFactory);
+
+        when:
+            def extracted = propagator.extract(["header1": "value1", "header2": "value2"])
+
+        then:
+            extracted.size() == 0
+    }
+
+    def 'should propagate only filtered headers when enabled and filter defined'() {
+        given:
+            def configFactory = Mock(ConfigFactory) {
+                getBooleanProperty(FRONTEND_HEADER_PROPAGATION_ENABLED) >> true
+                getStringProperty(FRONTEND_HEADER_PROPAGATION_ALLOW_FILTER) >> "other-header, header1"
+            }
+            def propagator = new DefaultHeadersPropagator(configFactory);
+
+        when:
+            def extracted = propagator.extract(["header1": "value1", "header2": "value2"])
+
+        then:
+            extracted.size() == 1
+            extracted["header1"] == "value1"
+    }
+}


### PR DESCRIPTION
After this change it's possible to enable header propagation and define which headers should be propagated

frontend.header.propagation.enabled=true
frontend.header.propagation.allow.filter=traceparent