### PR TITLE
Add support for publication of audit events (#1260)

### DIFF
--- a/hermes-management/build.gradle
+++ b/hermes-management/build.gradle
@@ -6,7 +6,7 @@ dependencies {
     compile project(':hermes-tracker')
     compile project(':hermes-schema')
 
-    compile group: 'org.springframework.boot', name: 'spring-boot-starter-webflux', version: versions.spring
+    compile group: 'org.springframework.boot', name: 'spring-boot-starter-web', version: versions.spring
     compile group: 'org.springframework.boot', name: 'spring-boot-starter-actuator', version: versions.spring
     compile group: 'org.springframework.boot', name: 'spring-boot-starter-jersey', version: versions.spring
     compile group: 'net.sf.jopt-simple', name: 'jopt-simple', version: '4.8'

--- a/hermes-management/build.gradle
+++ b/hermes-management/build.gradle
@@ -6,7 +6,7 @@ dependencies {
     compile project(':hermes-tracker')
     compile project(':hermes-schema')
 
-    compile group: 'org.springframework.boot', name: 'spring-boot-starter-web', version: versions.spring
+    compile group: 'org.springframework.boot', name: 'spring-boot-starter-webflux', version: versions.spring
     compile group: 'org.springframework.boot', name: 'spring-boot-starter-actuator', version: versions.spring
     compile group: 'org.springframework.boot', name: 'spring-boot-starter-jersey', version: versions.spring
     compile group: 'net.sf.jopt-simple', name: 'jopt-simple', version: '4.8'

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/config/AuditConfiguration.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/config/AuditConfiguration.java
@@ -4,27 +4,35 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.javers.core.Javers;
 import org.javers.core.JaversBuilder;
 import org.javers.core.metamodel.clazz.EntityDefinitionBuilder;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
 import pl.allegro.tech.hermes.api.Group;
 import pl.allegro.tech.hermes.api.OAuthProvider;
 import pl.allegro.tech.hermes.api.Subscription;
 import pl.allegro.tech.hermes.api.Topic;
 import pl.allegro.tech.hermes.management.domain.Auditor;
+import pl.allegro.tech.hermes.management.infrastructure.audit.CompositeAuditor;
 import pl.allegro.tech.hermes.management.infrastructure.audit.LoggingAuditor;
+
+import java.util.Collection;
 
 @Configuration
 @EnableConfigurationProperties({AuditProperties.class})
 public class AuditConfiguration {
 
     @Bean
-    public Auditor auditor(ObjectMapper objectMapper, AuditProperties auditProperties) {
-        if (auditProperties.isEnabled()) {
-            return new LoggingAuditor(javers(), objectMapper);
-        } else {
-            return Auditor.noOpAuditor();
-        }
+    @ConditionalOnProperty(prefix = "audit", value = "enabled", havingValue = "true")
+    public LoggingAuditor loggingAuditor(ObjectMapper objectMapper, AuditProperties auditProperties) {
+        return new LoggingAuditor(javers(), objectMapper);
+    }
+
+    @Bean
+    @Primary
+    public CompositeAuditor compositeAuditor(Collection<Auditor> auditors) {
+        return new CompositeAuditor(auditors);
     }
 
     private Javers javers() {

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/config/AuditConfiguration.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/config/AuditConfiguration.java
@@ -4,15 +4,13 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.javers.core.Javers;
 import org.javers.core.JaversBuilder;
 import org.javers.core.metamodel.clazz.EntityDefinitionBuilder;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.MediaType;
-import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.client.RestTemplate;
 import pl.allegro.tech.hermes.api.Group;
 import pl.allegro.tech.hermes.api.OAuthProvider;
 import pl.allegro.tech.hermes.api.Subscription;
@@ -35,13 +33,10 @@ public class AuditConfiguration {
     }
 
     @Bean
-    @ConditionalOnExpression("${audit.enabled} and ${audit.eventUrl} != null")
-    public EventAuditor eventAuditor(ObjectMapper objectMapper, AuditProperties auditProperties) {
-        WebClient webClient = WebClient.builder()
-                .baseUrl(auditProperties.getEventUrl().toString())
-                .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
-                .build();
-        return new EventAuditor(javers(), webClient, objectMapper);
+    @ConditionalOnProperty(prefix = "audit", value = "eventUrl")
+    public EventAuditor eventAuditor(AuditProperties auditProperties, RestTemplateBuilder restTemplateBuilder) {
+        RestTemplate restTemplate = restTemplateBuilder.build();
+        return new EventAuditor(javers(), restTemplate, auditProperties.getEventUrl().toString());
     }
 
     @Bean

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/config/AuditConfiguration.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/config/AuditConfiguration.java
@@ -4,17 +4,22 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.javers.core.Javers;
 import org.javers.core.JaversBuilder;
 import org.javers.core.metamodel.clazz.EntityDefinitionBuilder;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.web.reactive.function.client.WebClient;
 import pl.allegro.tech.hermes.api.Group;
 import pl.allegro.tech.hermes.api.OAuthProvider;
 import pl.allegro.tech.hermes.api.Subscription;
 import pl.allegro.tech.hermes.api.Topic;
 import pl.allegro.tech.hermes.management.domain.Auditor;
 import pl.allegro.tech.hermes.management.infrastructure.audit.CompositeAuditor;
+import pl.allegro.tech.hermes.management.infrastructure.audit.EventAuditor;
 import pl.allegro.tech.hermes.management.infrastructure.audit.LoggingAuditor;
 
 import java.util.Collection;
@@ -27,6 +32,16 @@ public class AuditConfiguration {
     @ConditionalOnProperty(prefix = "audit", value = "enabled", havingValue = "true")
     public LoggingAuditor loggingAuditor(ObjectMapper objectMapper, AuditProperties auditProperties) {
         return new LoggingAuditor(javers(), objectMapper);
+    }
+
+    @Bean
+    @ConditionalOnExpression("${audit.enabled} and ${audit.eventUrl} != null")
+    public EventAuditor eventAuditor(ObjectMapper objectMapper, AuditProperties auditProperties) {
+        WebClient webClient = WebClient.builder()
+                .baseUrl(auditProperties.getEventUrl().toString())
+                .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                .build();
+        return new EventAuditor(javers(), webClient, objectMapper);
     }
 
     @Bean

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/config/AuditProperties.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/config/AuditProperties.java
@@ -2,10 +2,14 @@ package pl.allegro.tech.hermes.management.config;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
+import java.net.URL;
+
 @ConfigurationProperties(prefix = "audit")
 class AuditProperties {
 
     private boolean enabled = false;
+
+    private URL eventUrl = null;
 
     public boolean isEnabled() {
         return enabled;
@@ -13,5 +17,13 @@ class AuditProperties {
 
     public void setEnabled(boolean enabled) {
         this.enabled = enabled;
+    }
+
+    public URL getEventUrl() {
+        return eventUrl;
+    }
+
+    public void setEventUrl(URL eventUrl) {
+        this.eventUrl = eventUrl;
     }
 }

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/domain/Auditor.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/domain/Auditor.java
@@ -35,12 +35,4 @@ public interface Auditor {
         objectUpdated(username, (Object) oldObject.anonymize(), (Object) newObject.anonymize());
     }
 
-    static Auditor noOpAuditor() {
-        return new NoOpAuditor();
-    }
-
-    class NoOpAuditor implements Auditor {
-        private NoOpAuditor() {
-        }
-    }
 }

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/infrastructure/audit/CompositeAuditor.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/infrastructure/audit/CompositeAuditor.java
@@ -1,0 +1,47 @@
+package pl.allegro.tech.hermes.management.infrastructure.audit;
+
+import pl.allegro.tech.hermes.api.PatchData;
+import pl.allegro.tech.hermes.management.domain.Auditor;
+
+import java.util.Collection;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+public class CompositeAuditor implements Auditor {
+
+    private final Collection<Auditor> auditors;
+
+    public CompositeAuditor(Collection<Auditor> auditors) {
+        this.auditors = checkNotNull(auditors);
+    }
+
+    @Override
+    public void beforeObjectCreation(String username, Object createdObject) {
+        auditors.forEach(auditor -> auditor.beforeObjectCreation(username, createdObject));
+    }
+
+    @Override
+    public void beforeObjectRemoval(String username, String removedObjectType, String removedObjectName) {
+        auditors.forEach(auditor -> auditor.beforeObjectRemoval(username, removedObjectType, removedObjectName));
+    }
+
+    @Override
+    public void beforeObjectUpdate(String username, String objectClassName, Object objectName, PatchData patchData) {
+        auditors.forEach(auditor -> auditor.beforeObjectUpdate(username, objectClassName, objectName, patchData));
+    }
+
+    @Override
+    public void objectCreated(String username, Object createdObject) {
+        auditors.forEach(auditor -> auditor.objectCreated(username, createdObject));
+    }
+
+    @Override
+    public void objectRemoved(String username, String removedObjectType, String removedObjectName) {
+        auditors.forEach(auditor -> auditor.objectRemoved(username, removedObjectType, removedObjectName));
+    }
+
+    @Override
+    public void objectUpdated(String username, Object oldObject, Object newObject) {
+        auditors.forEach(auditor -> auditor.objectUpdated(username, oldObject, newObject));
+    }
+}

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/infrastructure/audit/EventAuditor.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/infrastructure/audit/EventAuditor.java
@@ -1,0 +1,85 @@
+package pl.allegro.tech.hermes.management.infrastructure.audit;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.javers.core.Javers;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.web.reactive.function.BodyInserters;
+import org.springframework.web.reactive.function.client.WebClient;
+import pl.allegro.tech.hermes.api.PatchData;
+import pl.allegro.tech.hermes.management.domain.Auditor;
+import pl.allegro.tech.hermes.management.infrastructure.audit.pojo.AuditEvent;
+import pl.allegro.tech.hermes.management.infrastructure.audit.pojo.AuditEventType;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+public class EventAuditor implements Auditor {
+
+    private static final Logger logger = LoggerFactory.getLogger(EventAuditor.class);
+
+    private final Javers javers;
+
+    private final WebClient webClient;
+
+    private final ObjectMapper objectMapper;
+
+    public EventAuditor(Javers javers, WebClient webClient, ObjectMapper objectMapper) {
+        this.javers = checkNotNull(javers);
+        this.webClient = checkNotNull(webClient);
+        this.objectMapper = checkNotNull(objectMapper);
+    }
+
+    @Override
+    public void beforeObjectCreation(String username, Object createdObject) {
+        ignoringExceptions(() -> {
+
+        });
+    }
+
+    @Override
+    public void beforeObjectRemoval(String username, String removedObjectType, String removedObjectName) {
+        logger.info("User {} tries removing {} {}.", username, removedObjectType, removedObjectName);
+    }
+
+    @Override
+    public void beforeObjectUpdate(String username, String objectClassName, Object objectName, PatchData patchData) {
+        ignoringExceptions(() -> {
+        });
+    }
+
+    @Override
+    public void objectCreated(String username, Object createdObject) {
+        ignoringExceptions(() -> {
+            AuditEvent event = new AuditEvent(AuditEventType.CREATED, createdObject);
+            webClient.post()
+                    .body(BodyInserters.fromObject(event))
+                    .exchange()
+                    .doOnNext(clientResponse -> logger.info("Emitted creation event"));
+        });
+    }
+
+    @Override
+    public void objectRemoved(String username, String removedObjectType, String removedObjectName) {
+        logger.info("User {} has removed {} {}.", username, removedObjectType, removedObjectName);
+    }
+
+    @Override
+    public void objectUpdated(String username, Object oldObject, Object newObject) {
+        ignoringExceptions(() -> {
+        });
+    }
+
+    private void ignoringExceptions(Wrapped wrapped) {
+        try {
+            wrapped.execute();
+        } catch (Exception e) {
+            logger.info("Audit event emission failed.", e);
+        }
+    }
+
+    @FunctionalInterface
+    private interface Wrapped {
+        void execute() throws Exception;
+    }
+
+}

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/infrastructure/audit/EventAuditor.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/infrastructure/audit/EventAuditor.java
@@ -39,7 +39,7 @@ public class EventAuditor implements Auditor {
     @Override
     public void objectRemoved(String username, String removedObjectType, String removedObjectName) {
         ignoringExceptions(() -> {
-            AuditEvent event = new AuditEvent(AuditEventType.REMOVED, removedObjectName, Class.forName(removedObjectType), username);
+            AuditEvent event = new AuditEvent(AuditEventType.REMOVED, removedObjectName, removedObjectType, username);
             restTemplate.postForObject(eventDestination, event, Void.class);
         });
     }
@@ -48,7 +48,7 @@ public class EventAuditor implements Auditor {
     public void objectUpdated(String username, Object oldObject, Object newObject) {
         ignoringExceptions(() -> {
             Diff diff = javers.compare(oldObject, newObject);
-            AuditEvent event = new AuditEvent(AuditEventType.UPDATED, diff, newObject.getClass(), username);
+            AuditEvent event = new AuditEvent(AuditEventType.UPDATED, diff, newObject.getClass().getSimpleName(), username);
             restTemplate.postForObject(eventDestination, event, Void.class);
         });
     }

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/infrastructure/audit/pojo/AuditEvent.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/infrastructure/audit/pojo/AuditEvent.java
@@ -2,13 +2,21 @@ package pl.allegro.tech.hermes.management.infrastructure.audit.pojo;
 
 public class AuditEvent {
     private final AuditEventType eventType;
+    private final Class<?> resourceClass;
     private final Class<?> payloadClass;
     private final Object payload;
+    private final String username;
 
-    public AuditEvent(AuditEventType eventType, Object payload) {
+    public AuditEvent(AuditEventType eventType, Object payload, String username) {
+        this(eventType, payload, payload.getClass(), username);
+    }
+
+    public AuditEvent(AuditEventType eventType, Object payload, Class<?> resourceClass, String username){
         this.eventType = eventType;
         this.payload = payload;
         this.payloadClass = payload.getClass();
+        this.resourceClass = resourceClass;
+        this.username = username;
     }
 
     public AuditEventType getEventType() {
@@ -21,5 +29,13 @@ public class AuditEvent {
 
     public Object getPayload() {
         return payload;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public Class<?> getResourceClass() {
+        return resourceClass;
     }
 }

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/infrastructure/audit/pojo/AuditEvent.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/infrastructure/audit/pojo/AuditEvent.java
@@ -2,20 +2,20 @@ package pl.allegro.tech.hermes.management.infrastructure.audit.pojo;
 
 public class AuditEvent {
     private final AuditEventType eventType;
-    private final Class<?> resourceClass;
+    private final String resourceName;
     private final Class<?> payloadClass;
     private final Object payload;
     private final String username;
 
     public AuditEvent(AuditEventType eventType, Object payload, String username) {
-        this(eventType, payload, payload.getClass(), username);
+        this(eventType, payload, payload.getClass().getSimpleName(), username);
     }
 
-    public AuditEvent(AuditEventType eventType, Object payload, Class<?> resourceClass, String username){
+    public AuditEvent(AuditEventType eventType, Object payload, String resourceName, String username){
         this.eventType = eventType;
         this.payload = payload;
         this.payloadClass = payload.getClass();
-        this.resourceClass = resourceClass;
+        this.resourceName = resourceName;
         this.username = username;
     }
 
@@ -35,7 +35,7 @@ public class AuditEvent {
         return username;
     }
 
-    public Class<?> getResourceClass() {
-        return resourceClass;
+    public String getResourceName() {
+        return resourceName;
     }
 }

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/infrastructure/audit/pojo/AuditEvent.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/infrastructure/audit/pojo/AuditEvent.java
@@ -1,0 +1,25 @@
+package pl.allegro.tech.hermes.management.infrastructure.audit.pojo;
+
+public class AuditEvent {
+    private final AuditEventType eventType;
+    private final Class<?> payloadClass;
+    private final Object payload;
+
+    public AuditEvent(AuditEventType eventType, Object payload) {
+        this.eventType = eventType;
+        this.payload = payload;
+        this.payloadClass = payload.getClass();
+    }
+
+    public AuditEventType getEventType() {
+        return eventType;
+    }
+
+    public Class<?> getPayloadClass() {
+        return payloadClass;
+    }
+
+    public Object getPayload() {
+        return payload;
+    }
+}

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/infrastructure/audit/pojo/AuditEventType.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/infrastructure/audit/pojo/AuditEventType.java
@@ -1,0 +1,7 @@
+package pl.allegro.tech.hermes.management.infrastructure.audit.pojo;
+
+public enum AuditEventType {
+    BEFORE_CREATION, CREATED,
+    BEFORE_UPDATE, UPDATE,
+    BEFORE_REMOVAL, REMOVED
+}

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/infrastructure/audit/pojo/AuditEventType.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/infrastructure/audit/pojo/AuditEventType.java
@@ -2,6 +2,6 @@ package pl.allegro.tech.hermes.management.infrastructure.audit.pojo;
 
 public enum AuditEventType {
     BEFORE_CREATION, CREATED,
-    BEFORE_UPDATE, UPDATE,
+    BEFORE_UPDATE, UPDATED,
     BEFORE_REMOVAL, REMOVED
 }

--- a/integration/src/test/resources/application.yaml
+++ b/integration/src/test/resources/application.yaml
@@ -75,3 +75,7 @@ topicOwnerCache:
 
 subscriptionOwnerCache:
   refreshRateInSeconds: 300
+
+#audit:
+#  enabled: true
+#  eventUrl: "https://webhook.site/db3f1559-9ada-4585-85ab-2985fbf39cac"

--- a/integration/src/test/resources/application.yaml
+++ b/integration/src/test/resources/application.yaml
@@ -76,6 +76,6 @@ topicOwnerCache:
 subscriptionOwnerCache:
   refreshRateInSeconds: 300
 
-#audit:
-#  enabled: true
-#  eventUrl: "https://webhook.site/db3f1559-9ada-4585-85ab-2985fbf39cac"
+audit:
+  enabled: true
+  eventUrl: "https://webhook.site/db3f1559-9ada-4585-85ab-2985fbf39cac"


### PR DESCRIPTION
Hello, 

As said last week in https://github.com/allegro/hermes/issues/1260#issuecomment-764660395, I did some development for the support of audit events in October but I lost track of it and no longer have time to work on this.

On this branch the logging-or-no-op auditor is replaced with a composite one that calls all the other ones. There is also a new EventAuditor that uses spring rest templates to post an event pojo to a given URL. I tested it running this integration tests with the URL being webhook.site and it looked fine.

I think it still misses some tests dedicated to verifying the events are sent rather than peeking the output when all tests are executed.