### PR TITLE
Prevent closing unsaved modals

### DIFF
--- a/hermes-console/static/js/console/Groups.js
+++ b/hermes-console/static/js/console/Groups.js
@@ -19,6 +19,7 @@ groups.controller('GroupsController', ['GroupRepository', '$scope', '$uibModal',
                 templateUrl: 'partials/modal/editGroup.html',
                 controller: 'GroupEditController',
                 size: 'lg',
+                backdrop: 'static',
                 resolve: {
                     group: function() {
                         return {};
@@ -41,7 +42,6 @@ groups.controller('GroupController', ['GroupRepository', 'TopicFactory', '$scope
     function (groupRepository, topicFactory, $scope, $location, $stateParams, $modal, toaster, confirmationModal, passwordService) {
         $scope.fetching = true;
         var groupName = $scope.groupName = $stateParams.groupName;
-        var topicDraft = topicFactory.create();
 
         $scope.group = groupRepository.get(groupName);
         $scope.topics = [];
@@ -61,6 +61,7 @@ groups.controller('GroupController', ['GroupRepository', 'TopicFactory', '$scope
                 templateUrl: 'partials/modal/editTopic.html',
                 controller: 'TopicEditController',
                 size: 'lg',
+                backdrop: 'static',
                 resolve: {
                     operation: function () {
                         return 'ADD';
@@ -69,7 +70,7 @@ groups.controller('GroupController', ['GroupRepository', 'TopicFactory', '$scope
                         return groupName;
                     },
                     topic: function () {
-                        return topicDraft;
+                        return topicFactory.create();
                     },
                     messageSchema: function() {
                         return null;
@@ -77,7 +78,6 @@ groups.controller('GroupController', ['GroupRepository', 'TopicFactory', '$scope
                 }
             }).result.then(function(){
                 loadTopics();
-                topicDraft = topicFactory.create();
             });
 
 
@@ -88,6 +88,7 @@ groups.controller('GroupController', ['GroupRepository', 'TopicFactory', '$scope
                 templateUrl: 'partials/modal/editGroup.html',
                 controller: 'GroupEditController',
                 size: 'lg',
+                backdrop: 'static',
                 resolve: {
                     group: function() {
                         return $scope.group;

--- a/hermes-console/static/js/console/subscription/SubscriptionController.js
+++ b/hermes-console/static/js/console/subscription/SubscriptionController.js
@@ -19,8 +19,6 @@ subscriptions.controller('SubscriptionController', ['SubscriptionRepository', 'S
         var groupName = $scope.groupName = $stateParams.groupName;
         var topicName = $scope.topicName = $stateParams.topicName;
         var subscriptionName = $scope.subscriptionName = $stateParams.subscriptionName;
-        var subscriptionDraft;
-
         $scope.config = config;
 
         subscriptionRepository.get(topicName, subscriptionName).$promise
@@ -35,7 +33,6 @@ subscriptions.controller('SubscriptionController', ['SubscriptionRepository', 'S
                         modifiedAt.setUTCSeconds(subscription.modifiedAt);
                         $scope.subscription.modifiedAt = modifiedAt;
                     }
-                    subscriptionDraft = _.cloneDeep($scope.subscription);
                 });
 
         $scope.retransmissionLoading = false;
@@ -85,14 +82,15 @@ subscriptions.controller('SubscriptionController', ['SubscriptionRepository', 'S
           return filtered;
         };
 
-        $scope.edit = function () {
+        $scope.edit = function (subscription) {
             $modal.open({
                 templateUrl: 'partials/modal/editSubscription.html',
                 controller: 'SubscriptionEditController',
                 size: 'lg',
+                backdrop: 'static',
                 resolve: {
                     subscription: function () {
-                        return subscriptionDraft;
+                        return _.cloneDeep(subscription);
                     },
                     topicName: function () {
                         return topicName;
@@ -112,7 +110,6 @@ subscriptions.controller('SubscriptionController', ['SubscriptionRepository', 'S
                 }
             }).result.then(function(response){
                 $scope.subscription = response.subscription;
-                subscriptionDraft = _.cloneDeep(response.subscription);
             });
         };
 
@@ -121,6 +118,7 @@ subscriptions.controller('SubscriptionController', ['SubscriptionRepository', 'S
                 templateUrl: 'partials/modal/editSubscription.html',
                 controller: 'SubscriptionEditController',
                 size: 'lg',
+                backdrop: 'static',
                 resolve: {
                     subscription: function () {
                         return $scope.subscription;
@@ -258,9 +256,9 @@ subscriptions.controller('SubscriptionController', ['SubscriptionRepository', 'S
         $scope.debugFilters = function () {
             filtersDebuggerModal.open(topicName, $scope.subscription.filters, $scope.topicContentType)
                 .then(function (result) {
-                    subscriptionDraft = _.cloneDeep($scope.subscription);
-                    subscriptionDraft.filters = result.messageFilters;
-                    $scope.edit();
+                    var subscription = _.cloneDeep($scope.subscription);
+                    subscription.filters = result.messageFilters;
+                    $scope.edit(subscription);
                 });
         };
 
@@ -275,7 +273,7 @@ subscriptions.controller('SubscriptionEditController', ['SubscriptionRepository'
               endpointAddressResolverMetadataConfig, topicContentType, showFixedHeaders, subscriptionConfig) {
         $scope.topicName = topicName;
         $scope.topicContentType = topicContentType;
-        $scope.subscription = subscription;
+        $scope.subscription = _.cloneDeep(subscription);
         $scope.operation = operation;
         $scope.endpointAddressResolverMetadataConfig = endpointAddressResolverMetadataConfig;
         $scope.showFixedHeaders = showFixedHeaders;

--- a/hermes-console/static/js/console/topic/TopicController.js
+++ b/hermes-console/static/js/console/topic/TopicController.js
@@ -16,8 +16,6 @@ topics.controller('TopicController', ['TOPIC_CONFIG', 'TopicRepository', 'TopicM
               subscriptionFactory, subscriptionConfig, offlineClientsRepository) {
         var groupName = $scope.groupName = $stateParams.groupName;
         var topicName = $scope.topicName = $stateParams.topicName;
-        var topicDraft;
-        var subscriptionDraft = subscriptionFactory.create(topicName);
 
         $scope.subscriptionsFetching = true;
         $scope.offlineClientsFetching = true;
@@ -44,7 +42,6 @@ topics.controller('TopicController', ['TOPIC_CONFIG', 'TopicRepository', 'TopicM
                 console.error('Could not parse topic schema: ', e);
                 $scope.messageSchema = '[schema parsing failure]';
             }
-            topicDraft = _($scope.topic).clone();
         });
 
         $scope.metricsUrls = topicMetrics.metricsUrls(groupName, topicName);
@@ -85,12 +82,13 @@ topics.controller('TopicController', ['TOPIC_CONFIG', 'TopicRepository', 'TopicM
                 templateUrl: 'partials/modal/editTopic.html',
                 controller: 'TopicEditController',
                 size: 'lg',
+                backdrop: 'static',
                 resolve: {
                     operation: function () {
                         return 'EDIT';
                     },
                     topic: function () {
-                        return topicDraft;
+                        return $scope.topic;
                     },
                     messageSchema: function() {
                         return $scope.messageSchema;
@@ -100,7 +98,6 @@ topics.controller('TopicController', ['TOPIC_CONFIG', 'TopicRepository', 'TopicM
                     }
                 }
             }).result.then(function (result) {
-                topicDraft = _(result.topic).clone();
                 $scope.topic = result.topic;
                 $scope.messageSchema = result.messageSchema;
             });
@@ -111,6 +108,7 @@ topics.controller('TopicController', ['TOPIC_CONFIG', 'TopicRepository', 'TopicM
                 templateUrl: 'partials/modal/editTopic.html',
                 controller: 'TopicEditController',
                 size: 'lg',
+                backdrop: 'static',
                 resolve: {
                     operation: function () {
                         return 'ADD';
@@ -205,6 +203,7 @@ topics.controller('TopicController', ['TOPIC_CONFIG', 'TopicRepository', 'TopicM
                 templateUrl: 'partials/modal/editSubscription.html',
                 controller: 'SubscriptionEditController',
                 size: 'lg',
+                backdrop: 'static',
                 resolve: {
                     operation: function () {
                         return 'ADD';
@@ -213,7 +212,7 @@ topics.controller('TopicController', ['TOPIC_CONFIG', 'TopicRepository', 'TopicM
                         return topicName;
                     },
                     subscription: function () {
-                        return subscriptionDraft;
+                        return subscriptionFactory.create(topicName);
                     },
                     endpointAddressResolverMetadataConfig: function() {
                         return subscriptionConfig.endpointAddressResolverMetadata;
@@ -227,7 +226,6 @@ topics.controller('TopicController', ['TOPIC_CONFIG', 'TopicRepository', 'TopicM
                 }
             }).result.then(function () {
                 loadSubscriptions();
-                subscriptionDraft = subscriptionFactory.create(topicName);
             });
         };
 
@@ -248,7 +246,7 @@ topics.controller('TopicEditController', ['TOPIC_CONFIG', 'TopicRepository', '$s
     function (topicConfig, topicRepository, $scope, $modal, passwordService, toaster, topic, messageSchema, groupName, operation) {
         $scope.config = topicConfig;
 
-        $scope.topic = topic;
+        $scope.topic = _(topic).clone();
         $scope.messageSchema = messageSchema;
         $scope.groupName = groupName;
         $scope.operation = operation;

--- a/hermes-console/static/partials/subscription.html
+++ b/hermes-console/static/partials/subscription.html
@@ -12,7 +12,7 @@
         <span ng-show="disabled" uib-popover='Sign in to edit the subscription' popover-trigger="mouseenter" class="fa helpme">&#xf128;</span>
         <button ng-show="subscription.state === 'ACTIVE'" class="btn btn-warning" ng-disabled="disabled" ng-click="suspend()">Suspend</button>
         <button ng-show="subscription.state === 'SUSPENDED'" class="btn btn-success" ng-disabled="disabled" ng-click="activate()">Activate</button>
-        <button class="btn btn-primary" ng-disabled="disabled" ng-click="edit()">Edit</button>
+        <button class="btn btn-primary" ng-disabled="disabled" ng-click="edit(subscription)">Edit</button>
         <button class="btn btn-primary" ng-disabled="disabled" ng-click="clone()">Clone</button>
         <button class="btn btn-danger" ng-disabled="disabled" ng-click="remove()">Remove</button>
     </div>


### PR DESCRIPTION
This PR reworks how we try to prevent clearing unsaved changes in Hermes-console. It should help to avoid bugs like the one we noticed recently: the state of the edited subscription wasn't propagated correctly and it was impossible to update some fields e.g. `endpoint`.