### PR TITLE
hermes-client: allow configuring percentiles on MeterRegistry level

### DIFF
--- a/hermes-client/src/main/java/pl/allegro/tech/hermes/client/metrics/MicrometerMetricsProvider.java
+++ b/hermes-client/src/main/java/pl/allegro/tech/hermes/client/metrics/MicrometerMetricsProvider.java
@@ -1,6 +1,5 @@
 package pl.allegro.tech.hermes.client.metrics;
 
-import io.micrometer.core.instrument.DistributionSummary;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.Tags;
@@ -37,10 +36,7 @@ public class MicrometerMetricsProvider implements MetricsProvider {
 
     @Override
     public void histogramUpdate(String name, int value) {
-        DistributionSummary.builder(name)
-                .publishPercentiles(0, 0.5, 0.9, 0.95, 0.99)
-                .register(metrics)
-                .record(value);
+        metrics.summary(name).record(value);
     }
 
     private String buildCounterName(String prefix, String name, Map<String, String> tags) {

--- a/hermes-client/src/test/groovy/pl/allegro/tech/hermes/client/HermesClientMicrometerMetricsTest.groovy
+++ b/hermes-client/src/test/groovy/pl/allegro/tech/hermes/client/HermesClientMicrometerMetricsTest.groovy
@@ -85,8 +85,7 @@ class HermesClientMicrometerMetricsTest extends Specification {
         metrics.counter("hermes-client.com_group.topic.retries.success").count() == 1
         metrics.counter("hermes-client.com_group.topic.status.{code}", "code", String.valueOf(201)).count() == 1
         metrics.counter("hermes-client.com_group.topic.retries.count").count() == 2
-        metrics.summary("hermes-client.com_group.topic.retries.attempts").takeSnapshot().percentileValues()[0].value() == 2
-        metrics.summary("hermes-client.com_group.topic.retries.attempts").takeSnapshot().max() == 2
+        metrics.summary("hermes-client.com_group.topic.retries.attempts").takeSnapshot().count() == 1
         metrics.timer("hermes-client.com_group.topic.latency").count() == 3
     }
 

--- a/hermes-client/src/test/groovy/pl/allegro/tech/hermes/client/ReactiveHermesClientMicrometerMetricsTest.groovy
+++ b/hermes-client/src/test/groovy/pl/allegro/tech/hermes/client/ReactiveHermesClientMicrometerMetricsTest.groovy
@@ -84,8 +84,7 @@ class ReactiveHermesClientMicrometerMetricsTest extends Specification {
         metrics.counter("hermes-client.com_group.topic.retries.success").count() == 1
         metrics.counter("hermes-client.com_group.topic.status.{code}", "code", String.valueOf(201)).count() == 1
         metrics.counter("hermes-client.com_group.topic.retries.count").count() == 2
-        metrics.summary("hermes-client.com_group.topic.retries.attempts").takeSnapshot().percentileValues()[0].value() == 2
-        metrics.summary("hermes-client.com_group.topic.retries.attempts").takeSnapshot().max() == 2
+        metrics.summary("hermes-client.com_group.topic.retries.attempts").takeSnapshot().count() == 1
         metrics.timer("hermes-client.com_group.topic.latency").count() == 3
     }
 


### PR DESCRIPTION
We would like to make it possible to configure on `MeterRegistry` level if [client-side percentiles](https://micrometer.io/docs/concepts#_histograms_and_percentiles) are published. The main reason is that some implementations of `MeterRegistry` don't properly handle the property set by `io.micrometer.core.instrument.DistributionSummary.Builder#publishPercentiles`. Apart from that, as sending percentiles to the monitoring system generates additional time series, it is better to let the client decide which ones are useful. 