### PR TITLE
Renamed HostnameResolver to InstanceIdResolver

### DIFF
--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/common/config/Configs.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/common/config/Configs.java
@@ -2,7 +2,7 @@ package pl.allegro.tech.hermes.common.config;
 
 import com.google.common.io.Files;
 import pl.allegro.tech.hermes.api.Topic;
-import pl.allegro.tech.hermes.common.util.InetAddressHostnameResolver;
+import pl.allegro.tech.hermes.common.util.InetAddressInstanceIdResolver;
 
 import static java.lang.Math.abs;
 import static java.util.UUID.randomUUID;
@@ -252,7 +252,7 @@ public enum Configs {
     CONSUMER_WORKLOAD_MAX_SUBSCRIPTIONS_PER_CONSUMER("consumer.workload.max.subscriptions.per.consumer", 200),
     CONSUMER_WORKLOAD_ASSIGNMENT_PROCESSING_THREAD_POOL_SIZE("consumer.workload.assignment.processing.thread.pool.size", 5),
     CONSUMER_WORKLOAD_NODE_ID("consumer.workload.node.id",
-            new InetAddressHostnameResolver().resolve().replaceAll("\\.", "_") + "$" + abs(randomUUID().getMostSignificantBits())),
+            new InetAddressInstanceIdResolver().resolve().replaceAll("\\.", "_") + "$" + abs(randomUUID().getMostSignificantBits())),
     CONSUMER_WORKLOAD_MONITOR_SCAN_INTERVAL("consumer.workload.monitor.scan.interval.seconds", 120),
     CONSUMER_WORKLOAD_AUTO_REBALANCE("consumer.workload.rebalance.auto", true),
     CONSUMER_WORKLOAD_DEAD_AFTER_SECONDS("consumer.workload.dead.after.seconds", 120),
@@ -271,7 +271,7 @@ public enum Configs {
 
     CONSUMER_USE_TOPIC_MESSAGE_SIZE("consumer.use.topic.message.size", false),
 
-    CONSUMER_CLIENT_ID("consumer.clientId", new InetAddressHostnameResolver().resolve()),
+    CONSUMER_CLIENT_ID("consumer.clientId", new InetAddressInstanceIdResolver().resolve()),
 
     OAUTH_MISSING_SUBSCRIPTION_HANDLERS_CREATION_DELAY("oauth.missing.subscription.handlers.creation.delay", 10_000L),
     OAUTH_SUBSCRIPTION_TOKENS_CACHE_MAX_SIZE("oauth.subscription.tokens.cache.max.size", 1000L),

--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/common/config/Configs.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/common/config/Configs.java
@@ -28,7 +28,7 @@ public enum Configs {
     ZOOKEEPER_TASK_PROCESSING_THREAD_POOL_SIZE("zookeeper.cache.processing.thread.pool.size", 5),
 
     ENVIRONMENT_NAME("environment.name", "dev"),
-    HOSTNAME("hostname", new InetAddressHostnameResolver().resolve()),
+    HOSTNAME("hostname", new InetAddressInstanceIdResolver().resolve()),
 
     KAFKA_CLUSTER_NAME("kafka.cluster.name", "primary-dc"),
     KAFKA_BROKER_LIST("kafka.broker.list", "localhost:9092"),

--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/common/di/CommonBinder.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/common/di/CommonBinder.java
@@ -42,8 +42,8 @@ import pl.allegro.tech.hermes.common.schema.SchemaRepositoryInstanceResolverFact
 import pl.allegro.tech.hermes.common.schema.SchemaRepositoryFactory;
 import pl.allegro.tech.hermes.common.schema.RawSchemaClientFactory;
 import pl.allegro.tech.hermes.common.schema.SchemaVersionsRepositoryFactory;
-import pl.allegro.tech.hermes.common.util.HostnameResolver;
-import pl.allegro.tech.hermes.common.util.InetAddressHostnameResolver;
+import pl.allegro.tech.hermes.common.util.InstanceIdResolver;
+import pl.allegro.tech.hermes.common.util.InetAddressInstanceIdResolver;
 import pl.allegro.tech.hermes.domain.notifications.InternalNotificationsBus;
 import pl.allegro.tech.hermes.domain.workload.constraints.WorkloadConstraintsRepository;
 import pl.allegro.tech.hermes.infrastructure.zookeeper.notifications.ZookeeperInternalNotificationBus;
@@ -58,7 +58,7 @@ public class CommonBinder extends AbstractBinder {
     protected void configure() {
         bind(ZookeeperCounterStorage.class).to(CounterStorage.class).in(Singleton.class);
         bindFactory(ClockFactory.class).in(Singleton.class).to(Clock.class);
-        bind(InetAddressHostnameResolver.class).in(Singleton.class).to(HostnameResolver.class);
+        bind(InetAddressInstanceIdResolver.class).in(Singleton.class).to(InstanceIdResolver.class);
         bindSingletonFactory(SchemaRepositoryClientFactory.class);
         bindSingletonFactory(SchemaRepositoryInstanceResolverFactory.class);
         bindSingletonFactory(RawSchemaClientFactory.class);

--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/common/di/factories/MetricRegistryFactory.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/common/di/factories/MetricRegistryFactory.java
@@ -21,7 +21,7 @@ import pl.allegro.tech.hermes.common.metric.MetricRegistryWithHdrHistogramReserv
 import pl.allegro.tech.hermes.common.metric.MetricsReservoirType;
 import pl.allegro.tech.hermes.common.metric.counter.CounterStorage;
 import pl.allegro.tech.hermes.common.metric.counter.zookeeper.ZookeeperCounterReporter;
-import pl.allegro.tech.hermes.common.util.HostnameResolver;
+import pl.allegro.tech.hermes.common.util.InstanceIdResolver;
 
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -34,17 +34,17 @@ public class MetricRegistryFactory implements Factory<MetricRegistry> {
 
     private final ConfigFactory configFactory;
     private final CounterStorage counterStorage;
-    private final HostnameResolver hostnameResolver;
+    private final InstanceIdResolver instanceIdResolver;
     private final String moduleName;
 
     @Inject
     public MetricRegistryFactory(ConfigFactory configFactory,
                                  CounterStorage counterStorage,
-                                 HostnameResolver hostnameResolver,
+                                 InstanceIdResolver instanceIdResolver,
                                  @Named("moduleName") String moduleName) {
         this.configFactory = configFactory;
         this.counterStorage = counterStorage;
-        this.hostnameResolver = hostnameResolver;
+        this.instanceIdResolver = instanceIdResolver;
         this.moduleName = moduleName;
 
     }
@@ -67,7 +67,7 @@ public class MetricRegistryFactory implements Factory<MetricRegistry> {
             String prefix = Joiner.on(".").join(
                     configFactory.getStringProperty(Configs.GRAPHITE_PREFIX),
                     moduleName,
-                    hostnameResolver.resolve().replaceAll("\\.", HermesMetrics.REPLACEMENT_CHAR));
+                    instanceIdResolver.resolve().replaceAll("\\.", HermesMetrics.REPLACEMENT_CHAR));
 
             GraphiteReporter
                     .forRegistry(registry)

--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/common/di/factories/PathsCompilerFactory.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/common/di/factories/PathsCompilerFactory.java
@@ -2,22 +2,22 @@ package pl.allegro.tech.hermes.common.di.factories;
 
 import org.glassfish.hk2.api.Factory;
 import pl.allegro.tech.hermes.metrics.PathsCompiler;
-import pl.allegro.tech.hermes.common.util.HostnameResolver;
+import pl.allegro.tech.hermes.common.util.InstanceIdResolver;
 
 import javax.inject.Inject;
 
 public class PathsCompilerFactory implements Factory<PathsCompiler> {
 
-    private final HostnameResolver hostnameResolver;
+    private final InstanceIdResolver instanceIdResolver;
 
     @Inject
-    public PathsCompilerFactory(HostnameResolver hostnameResolver) {
-        this.hostnameResolver = hostnameResolver;
+    public PathsCompilerFactory(InstanceIdResolver instanceIdResolver) {
+        this.instanceIdResolver = instanceIdResolver;
     }
 
     @Override
     public PathsCompiler provide() {
-        return new PathsCompiler(hostnameResolver.resolve());
+        return new PathsCompiler(instanceIdResolver.resolve());
     }
 
     @Override

--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/common/util/InetAddressInstanceIdResolver.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/common/util/InetAddressInstanceIdResolver.java
@@ -6,11 +6,11 @@ import org.slf4j.LoggerFactory;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 
-public final class InetAddressHostnameResolver implements HostnameResolver {
+public final class InetAddressInstanceIdResolver implements InstanceIdResolver {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(InetAddressHostnameResolver.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(InetAddressInstanceIdResolver.class);
 
-    public InetAddressHostnameResolver() { }
+    public InetAddressInstanceIdResolver() { }
 
     public String resolve() {
         String hostname = "hostname-could-not-be-detected";

--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/common/util/InstanceIdResolver.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/common/util/InstanceIdResolver.java
@@ -1,5 +1,5 @@
 package pl.allegro.tech.hermes.common.util;
 
-public interface HostnameResolver {
+public interface InstanceIdResolver {
     String resolve();
 }

--- a/hermes-common/src/test/java/pl/allegro/tech/hermes/common/metric/counter/zookeeper/ZookeeperCounterReporterTest.java
+++ b/hermes-common/src/test/java/pl/allegro/tech/hermes/common/metric/counter/zookeeper/ZookeeperCounterReporterTest.java
@@ -15,7 +15,7 @@ import pl.allegro.tech.hermes.api.TopicName;
 import pl.allegro.tech.hermes.common.config.ConfigFactory;
 import pl.allegro.tech.hermes.common.config.Configs;
 import pl.allegro.tech.hermes.common.metric.counter.CounterStorage;
-import pl.allegro.tech.hermes.common.util.HostnameResolver;
+import pl.allegro.tech.hermes.common.util.InstanceIdResolver;
 import pl.allegro.tech.hermes.metrics.PathsCompiler;
 
 import java.util.SortedMap;
@@ -80,14 +80,14 @@ public class ZookeeperCounterReporterTest {
     private ConfigFactory configFactory;
 
     @Mock
-    private HostnameResolver hostnameResolver;
+    private InstanceIdResolver instanceIdResolver;
 
     private ZookeeperCounterReporter zookeeperCounterReporter;
 
     @Before
     public void before() {
         when(configFactory.getStringProperty(Configs.GRAPHITE_PREFIX)).thenReturn(GRAPHITE_PREFIX);
-        when(hostnameResolver.resolve()).thenReturn("localhost.domain");
+        when(instanceIdResolver.resolve()).thenReturn("localhost.domain");
         zookeeperCounterReporter = new ZookeeperCounterReporter(metricRegistry, counterStorage, configFactory);
     }
 


### PR DESCRIPTION
In this PR I renamed interface `pl.allegro.tech.hermes.common.util.HostnameResolver` to `pl.allegro.tech.hermes.common.util.InstanceIdResolver`. This adds more flexibility to the provided implementation which does not currently need to be hostname based.