### PR TITLE
Add kafka producer publishing error metrics

### DIFF
--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/common/metric/Gauges.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/common/metric/Gauges.java
@@ -9,6 +9,8 @@ public class Gauges {
     public static final String EVERYONE_CONFIRMS_BUFFER_TOTAL_BYTES = "everyone-confirms-buffer-total-bytes",
             EVERYONE_CONFIRMS_BUFFER_AVAILABLE_BYTES = "everyone-confirms-buffer-available-bytes",
             EVERYONE_CONFIRMS_COMPRESSION_RATE = "everyone-confirms-compression-rate-avg",
+            EVERYONE_CONFIRMS_FAILED_BATCHES_TOTAL = "everyone-confirms-failed-batches-total",
+            LEADER_CONFIRMS_FAILED_BATCHES_TOTAL = "leader-confirms-failed-batches-total",
             LEADER_CONFIRMS_BUFFER_TOTAL_BYTES = "leader-confirms-buffer-total-bytes",
             LEADER_CONFIRMS_BUFFER_AVAILABLE_BYTES = "leader-confirms-buffer-available-bytes",
             LEADER_CONFIRMS_COMPRESSION_RATE = "leader-confirms-compression-rate-avg",

--- a/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/producer/kafka/Producers.java
+++ b/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/producer/kafka/Producers.java
@@ -46,6 +46,8 @@ public class Producers {
         registerAvailableBytesGauge(everyoneConfirms, metrics, Gauges.EVERYONE_CONFIRMS_BUFFER_AVAILABLE_BYTES);
         registerCompressionRateGauge(leaderConfirms, metrics, Gauges.LEADER_CONFIRMS_COMPRESSION_RATE);
         registerCompressionRateGauge(everyoneConfirms, metrics, Gauges.EVERYONE_CONFIRMS_COMPRESSION_RATE);
+        registerFailedBatchesGauge(everyoneConfirms, metrics, Gauges.EVERYONE_CONFIRMS_FAILED_BATCHES_TOTAL);
+        registerFailedBatchesGauge(leaderConfirms, metrics, Gauges.LEADER_CONFIRMS_FAILED_BATCHES_TOTAL);
     }
 
     public void maybeRegisterNodeMetricsGauges(HermesMetrics metrics) {
@@ -72,6 +74,10 @@ public class Producers {
 
     private void registerAvailableBytesGauge(Producer<byte[], byte[]> producer, HermesMetrics metrics, String gauge) {
         registerProducerGauge(producer, metrics, new MetricName("buffer-available-bytes", "producer-metrics", "buffer available bytes", Collections.emptyMap()), gauge);
+    }
+
+    private void registerFailedBatchesGauge(Producer<byte[], byte[]> producer, HermesMetrics metrics, String gauge) {
+        registerProducerGauge(producer, metrics, new MetricName("record-error-total", "producer-metrics", "failed publishing batches", Collections.emptyMap()), gauge);
     }
 
     private void registerProducerGauge(final Producer<byte[], byte[]> producer,


### PR DESCRIPTION
We need a metric recorded at the moment when kafka-producer stops sending message to broker (because of its retry policy exhausted or any other case). This message will be stored in backup storage but not be retried anymore until hermes restart.