### PR TITLE
Added UI panel for http header filters

### DIFF
--- a/hermes-console/static/index.html
+++ b/hermes-console/static/index.html
@@ -48,6 +48,7 @@
         <script src="js/console/subscription/SubscriptionFactory.js"></script>
         <script src="js/console/subscription/SubscriptionController.js"></script>
         <script src="js/console/filters/FiltersEditor.js"></script>
+        <script src="js/console/filters/HttpHeaderFiltersEditor.js"></script>
         <script src="js/console/filters/FiltersRepository.js"></script>
         <script src="js/console/filters/FiltersDebugger.js"></script>
         <script src="js/console/constraints/ConstraintsRepository.js"></script>

--- a/hermes-console/static/js/console/filters/FiltersDebugger.js
+++ b/hermes-console/static/js/console/filters/FiltersDebugger.js
@@ -11,7 +11,10 @@ angular.module('hermes.filters.debugger', ['hermes.filters.repository'])
 
             $scope.verify = function () {
                 resetVerificationState();
-                filtersRepository.verify($scope.topicName, $scope.messageFilters, $scope.message).$promise
+                var filtersWithoutHeaderFilterType = _.reject($scope.messageFilters, function (f) {
+                    return f.header;
+                });
+                filtersRepository.verify($scope.topicName, filtersWithoutHeaderFilterType, $scope.message).$promise
                     .then(function (response) {
                         $scope.verificationStatus = response.status;
                         $scope.errorMessage = response.errorMessage;

--- a/hermes-console/static/js/console/filters/FiltersEditor.js
+++ b/hermes-console/static/js/console/filters/FiltersEditor.js
@@ -17,8 +17,10 @@ angular.module('hermes.filters')
                 $scope.filter = {};
             };
 
-            $scope.delFilter = function (index) {
-                $scope.filters.splice(index, 1);
+            $scope.delFilter = function (filter) {
+                $scope.filters = _.reject($scope.filters, function (f) {
+                    return f === filter;
+                });
             };
 
             $scope.debugFilters = function () {
@@ -32,7 +34,7 @@ angular.module('hermes.filters')
         return {
             controller: 'FiltersEditorController',
             restrict: 'E',
-            templateUrl: 'partials/filtersEditor.html',
+            templateUrl: 'partials/filter/filtersEditor.html',
             scope: {
                 form: '=',
                 topicContentType: '=topicContentType',

--- a/hermes-console/static/js/console/filters/HttpHeaderFiltersEditor.js
+++ b/hermes-console/static/js/console/filters/HttpHeaderFiltersEditor.js
@@ -1,0 +1,36 @@
+angular.module('hermes.filters')
+    .controller('HttpHeaderFiltersEditorController', ['$scope',
+        function ($scope) {
+
+            $scope.addFilter = function () {
+                if (!$scope.filter.header || !$scope.filter.matcher) {
+                    return;
+                }
+
+                $scope.filters.push({
+                    type: 'header',
+                    header: $scope.filter.header,
+                    matcher: $scope.filter.matcher,
+                    matchingStrategy: $scope.filter.matchingStrategy
+                });
+                $scope.filter = {};
+            };
+
+            $scope.delFilter = function (filter) {
+                $scope.filters = _.reject($scope.filters, function (f) {
+                    return f === filter;
+                });
+            };
+
+        }])
+    .directive('httpHeaderFiltersEditor', function () {
+        return {
+            controller: 'HttpHeaderFiltersEditorController',
+            restrict: 'E',
+            templateUrl: 'partials/filter/httpHeaderFiltersEditor.html',
+            scope: {
+                form: '=',
+                filters: '=filters'
+            }
+        };
+    });

--- a/hermes-console/static/js/console/subscription/SubscriptionController.js
+++ b/hermes-console/static/js/console/subscription/SubscriptionController.js
@@ -37,6 +37,7 @@ subscriptions.controller('SubscriptionController', ['SubscriptionRepository', 'S
 
         $scope.retransmissionLoading = false;
 
+        $scope.showHeadersFilter = config.showHeadersFilter;
         $scope.showFixedHeaders = config.showFixedHeaders;
 
         $scope.endpointAddressResolverMetadataConfig = config.endpointAddressResolverMetadata;
@@ -106,6 +107,9 @@ subscriptions.controller('SubscriptionController', ['SubscriptionRepository', 'S
                     },
                     showFixedHeaders: function () {
                         return $scope.showFixedHeaders;
+                    },
+                    showHeadersFilter: function () {
+                      return $scope.showHeadersFilter;
                     }
                 }
             }).result.then(function(response){
@@ -137,6 +141,9 @@ subscriptions.controller('SubscriptionController', ['SubscriptionRepository', 'S
                     },
                     showFixedHeaders: function () {
                         return $scope.showFixedHeaders;
+                    },
+                    showHeadersFilter: function () {
+                        return $scope.showHeadersFilter;
                     }
                 }
             }).result.then(function(response){
@@ -268,15 +275,16 @@ subscriptions.controller('SubscriptionController', ['SubscriptionRepository', 'S
 
 subscriptions.controller('SubscriptionEditController', ['SubscriptionRepository', '$scope', '$uibModalInstance', 'subscription',
     'topicName', 'PasswordService', 'toaster', 'operation', 'endpointAddressResolverMetadataConfig', 'topicContentType',
-    'showFixedHeaders', 'SUBSCRIPTION_CONFIG',
+    'showFixedHeaders', 'showHeadersFilter', 'SUBSCRIPTION_CONFIG',
     function (subscriptionRepository, $scope, $modal, subscription, topicName, passwordService, toaster, operation,
-              endpointAddressResolverMetadataConfig, topicContentType, showFixedHeaders, subscriptionConfig) {
+              endpointAddressResolverMetadataConfig, topicContentType, showFixedHeaders, showHeadersFilter, subscriptionConfig) {
         $scope.topicName = topicName;
         $scope.topicContentType = topicContentType;
         $scope.subscription = _.cloneDeep(subscription);
         $scope.operation = operation;
         $scope.endpointAddressResolverMetadataConfig = endpointAddressResolverMetadataConfig;
         $scope.showFixedHeaders = showFixedHeaders;
+        $scope.showHeadersFilter = showHeadersFilter;
         $scope.config = subscriptionConfig;
 
         $scope.save = function () {
@@ -318,6 +326,7 @@ subscriptions.controller('SubscriptionEditController', ['SubscriptionRepository'
         $scope.delHeader = function (index) {
             $scope.subscription.headers.splice(index, 1);
         };
+
     }]);
 
 function initRetransmissionCalendar(daysBack) {

--- a/hermes-console/static/partials/filter/filtersEditor.html
+++ b/hermes-console/static/partials/filter/filtersEditor.html
@@ -10,49 +10,43 @@
                 </button>
             </th>
         </tr>
-        <tr ng-repeat="filter in filters">
+        <tr ng-repeat="filter in filters" ng-if="filter.type !== 'header'">
             <td>
                 <input ng-model="filter.path"
                        class="form-control col-md-1 {{filter.path.$valid ? '' : 'has-error'}}"
-                       id="subscriptionFilterPathEdit"
                        name="subscriptionFilterPathInput" placeholder="{{filter.path}}"/>
             </td>
             <td>
                 <input ng-model="filter.matcher"
                        class="form-control col-md-1 {{filter.matcher.$valid ? '' : 'has-error'}}"
-                       id="subscriptionFilterMatcherEdit"
                        name="subscriptionFilterMatcherInput" placeholder="{{filter.matcher}}"/>
             </td>
             <td>
                 <select ng-model="filter.matchingStrategy"
                         class="form-control col-md-1"
-                        id="subscriptionFilterMatchingStrategyEdit"
                         name="subscriptionFilterMatchingStrategySelect">
                     <option value="all">all (default)</option>
                     <option value="any">any</option>
                 </select>
             </td>
             <td>
-                <button class="btn btn-danger btn-block" ng-click="delFilter($index)">Delete</button>
+                <button class="btn btn-danger btn-block" ng-click="delFilter(filter)">Delete</button>
             </td>
         </tr>
         <tr>
             <td>
                 <input ng-model="filter.path"
                        class="form-control col-md-1 {{filter.path.$valid ? '' : 'has-error'}}"
-                       id="subscriptionFilterPath"
                        name="subscriptionFilterPathInput" placeholder="Path for filter"/>
             </td>
             <td>
                 <input ng-model="filter.matcher"
                        class="form-control col-md-1 {{filter.matcher.$valid ? '' : 'has-error'}}"
-                       id="subscriptionFilterMatcher"
                        name="subscriptionFilterMatcherInput" placeholder="Matcher for filter"/>
             </td>
             <td>
                 <select ng-model="filter.matchingStrategy" ng-init="filter.matchingStrategy='all'"
                         class="form-control col-md-1"
-                        id="subscriptionFilterMatchingStrategy"
                         name="subscriptionFilterMatchingStrategySelect">
                     <option value="all">all (default)</option>
                     <option value="any">any</option>

--- a/hermes-console/static/partials/filter/httpHeaderFiltersEditor.html
+++ b/hermes-console/static/partials/filter/httpHeaderFiltersEditor.html
@@ -1,0 +1,41 @@
+<div>
+    <table class="table borderless">
+        <tr>
+            <th>Header name</th>
+            <th>Matcher</th>
+            <th></th>
+        </tr>
+        <tr ng-repeat="filter in filters" ng-if="filter.type === 'header'">
+            <td>
+                <input ng-model="filter.header"
+                       class="form-control col-md-1 {{filter.header.$valid ? '' : 'has-error'}}"
+                       name="subscriptionHttpHeaderFilterInput" placeholder="{{filter.header}}"/>
+            </td>
+            <td>
+                <input ng-model="filter.matcher"
+                       class="form-control col-md-1 {{filter.matcher.$valid ? '' : 'has-error'}}"
+                       name="subscriptionHttpFilterMatcherEdit" placeholder="{{filter.matcher}}"/>
+            </td>
+            <td>
+                <button class="btn btn-danger" ng-click="delFilter(filter)">Delete</button>
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <input ng-model="filter.header"
+                       class="form-control col-md-1 {{filter.header.$valid ? '' : 'has-error'}}"
+                       name="subscriptionHttpHeaderFilterInput" placeholder="Header name"/>
+            </td>
+            <td>
+                <input ng-model="filter.matcher"
+                       class="form-control col-md-1 {{filter.matcher.$valid ? '' : 'has-error'}}"
+                       name="subscriptionHttpFilterMatcherInput" placeholder="Matcher for filter"/>
+            </td>
+            <td>
+                <div class="col-md-1">
+                    <button class="btn btn-success" ng-click="addFilter()">Add</button>
+                </div>
+            </td>
+        </tr>
+    </table>
+</div>

--- a/hermes-console/static/partials/modal/editSubscription.html
+++ b/hermes-console/static/partials/modal/editSubscription.html
@@ -206,6 +206,15 @@
                 </div>
             </div>
 
+            <div class="form-group" ng-show="showHeadersFilter">
+                <label class="col-md-3 control-label">HTTP header filter</label>
+                <div class="col-md-9">
+                    <http-header-filters-editor
+                        form="subscriptionForm"
+                        filters="subscription.filters"></http-header-filters-editor>
+                </div>
+            </div>
+
             <div class="form-group" ng-show="showFixedHeaders">
                 <label class="col-md-3 control-label">Fixed HTTP headers</label>
                 <div class="col-md-9">

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/config/FilteringConfiguration.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/config/FilteringConfiguration.java
@@ -6,6 +6,7 @@ import pl.allegro.tech.hermes.domain.filtering.MessageFilters;
 import pl.allegro.tech.hermes.domain.filtering.SubscriptionMessageFilterCompiler;
 import pl.allegro.tech.hermes.domain.filtering.avro.AvroPathSubscriptionMessageFilterCompiler;
 import pl.allegro.tech.hermes.domain.filtering.chain.FilterChainFactory;
+import pl.allegro.tech.hermes.domain.filtering.header.HeaderSubscriptionMessageFilterCompiler;
 import pl.allegro.tech.hermes.domain.filtering.json.JsonPathSubscriptionMessageFilterCompiler;
 
 import java.util.Arrays;
@@ -20,7 +21,8 @@ public class FilteringConfiguration {
     FilterChainFactory filterChainFactory() {
         List<SubscriptionMessageFilterCompiler> subscriptionFilterCompilers = Arrays.asList(
                 new AvroPathSubscriptionMessageFilterCompiler(),
-                new JsonPathSubscriptionMessageFilterCompiler()
+                new JsonPathSubscriptionMessageFilterCompiler(),
+                new HeaderSubscriptionMessageFilterCompiler()
         );
         MessageFilters messageFilters = new MessageFilters(emptyList(), subscriptionFilterCompilers);
         return new FilterChainFactory(messageFilters);

--- a/hermes-management/src/main/resources/application-local.yaml
+++ b/hermes-management/src/main/resources/application-local.yaml
@@ -29,6 +29,7 @@ console:
         label: DAYS
   subscription:
     showHeadersFilter: true
+    showFixedHeaders: false
     deliveryTypes:
       - value: SERIAL
         label: SERIAL


### PR DESCRIPTION
Added `Http header filter` panel in subscription view. The panel is displayed below `Filter` panel as in the attached image. By default `Http header panel` is disabled. It can be enabled by `showHeadersFilter` flag in Hermes console config. At the moment the panel dosen't support `Debug` mode and `matching strategy`, but they can be added in the future.
 
![Zrzut ekranu 2021-06-2 o 15 53 18](https://user-images.githubusercontent.com/4473056/120493217-0da2b600-c3bb-11eb-8866-f8898c2402c1.png)
