### PR TITLE
Added ability to specify the default kafka-client SSL and SASL configuration keys

### DIFF
--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/common/config/KafkaClientConfig.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/common/config/KafkaClientConfig.java
@@ -1,0 +1,54 @@
+package pl.allegro.tech.hermes.common.config;
+
+import com.netflix.config.DynamicPropertyFactory;
+import com.netflix.config.PropertyWrapper;
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.common.config.SaslConfigs;
+import org.apache.kafka.common.config.SslConfigs;
+
+import javax.annotation.Nonnull;
+
+/**
+ * @author Cyril Wattebled (cyril.wattebled@idemia.com)
+ */
+public class KafkaClientConfig {
+    public static final String KAFKA_CLIENT_PREFIX = "kafka.client.";
+
+    public interface CollectionPut {
+        Object put(String s, Object value);
+    }
+
+    public static void loadKakfaConfig(@Nonnull CollectionPut lambda) {
+        ConfigDef config = new ConfigDef();
+        SslConfigs.addClientSslSupport(config);
+        SaslConfigs.addClientSaslSupport(config);
+        DynamicPropertyFactory instance = DynamicPropertyFactory.getInstance();
+        config.configKeys().forEach((s, configKey) -> {
+            String propKey = KAFKA_CLIENT_PREFIX + s;
+            PropertyWrapper<?> value = null;
+            switch (configKey.type) {
+                case BOOLEAN:
+                    value = instance.getBooleanProperty(propKey, (Boolean) configKey.defaultValue);
+                    break;
+                case LIST:
+                case CLASS:
+                case PASSWORD:
+                case STRING:
+                    value = instance.getStringProperty(propKey, null);
+                    break;
+                case INT:
+                case SHORT:
+                    value = instance.getIntProperty(propKey, Short.toUnsignedInt((Short) configKey.defaultValue));
+                    break;
+                case LONG:
+                    value = instance.getLongProperty(propKey, (Long) configKey.defaultValue);
+                    break;
+                case DOUBLE:
+                    value = instance.getDoubleProperty(propKey, (Double) configKey.defaultValue);
+                    break;
+            }
+            if (value.getValue() != null)
+                lambda.put(s, value.getValue());
+        });
+    }
+}

--- a/hermes-common/src/test/java/pl/allegro/tech/hermes/common/config/KafkaClientConfigTest.java
+++ b/hermes-common/src/test/java/pl/allegro/tech/hermes/common/config/KafkaClientConfigTest.java
@@ -1,0 +1,31 @@
+package pl.allegro.tech.hermes.common.config;
+
+import org.apache.kafka.common.config.SaslConfigs;
+import org.apache.kafka.common.config.SslConfigs;
+import org.junit.Assert;
+import org.junit.Test;
+
+import javax.validation.constraints.AssertTrue;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+
+/**
+ * @author Cyril Wattebled (cyril.wattebled@idemia.com)
+ */
+public class KafkaClientConfigTest {
+
+    /**
+     * Read from config.properties (in test-resources) and loads the kafka client related configuration keys
+     */
+    @Test
+    public void loadKakfaConfig() {
+        Map<String, Object> map = new HashMap<>();
+        KafkaClientConfig.loadKakfaConfig(map::putIfAbsent);
+        Assert.assertEquals("file:/./truststore.jks", map.get(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG));
+        Assert.assertEquals("software.amazon.msk.auth.iam.IAMLoginModule required;", map.get(SaslConfigs.SASL_JAAS_CONFIG));
+        Assert.assertEquals("AWS_MSK_IAM", map.get(SaslConfigs.SASL_MECHANISM));
+        Assert.assertEquals("software.amazon.msk.auth.iam.IAMClientCallbackHandler", map.get(SaslConfigs.SASL_CLIENT_CALLBACK_HANDLER_CLASS));
+    }
+}

--- a/hermes-common/src/test/resources/config.properties
+++ b/hermes-common/src/test/resources/config.properties
@@ -1,0 +1,6 @@
+kafka.authorization.enabled=true
+kafka.authorization.protocol=SASL_SSL
+kafka.client.ssl.truststore.location=file:/./truststore.jks
+kafka.client.sasl.mechanism=AWS_MSK_IAM
+kafka.client.sasl.jaas.config=software.amazon.msk.auth.iam.IAMLoginModule required;
+kafka.client.sasl.client.callback.handler.class=software.amazon.msk.auth.iam.IAMClientCallbackHandler

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/receiver/kafka/KafkaMessageReceiverFactory.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/receiver/kafka/KafkaMessageReceiverFactory.java
@@ -1,10 +1,15 @@
 package pl.allegro.tech.hermes.consumers.consumer.receiver.kafka;
 
+import com.netflix.config.DynamicPropertyFactory;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.common.config.SaslConfigs;
+import org.apache.kafka.common.config.SslConfigs;
 import pl.allegro.tech.hermes.api.Subscription;
 import pl.allegro.tech.hermes.api.Topic;
 import pl.allegro.tech.hermes.common.config.ConfigFactory;
 import pl.allegro.tech.hermes.common.config.Configs;
+import pl.allegro.tech.hermes.common.config.KafkaClientConfig;
 import pl.allegro.tech.hermes.common.kafka.ConsumerGroupId;
 import pl.allegro.tech.hermes.common.kafka.KafkaNamesMapper;
 import pl.allegro.tech.hermes.common.metric.HermesMetrics;
@@ -146,6 +151,8 @@ public class KafkaMessageReceiverFactory implements ReceiverFactory {
                             + "username=\"" + configs.getStringProperty(KAFKA_AUTHORIZATION_USERNAME) + "\"\n"
                             + "password=\"" + configs.getStringProperty(KAFKA_AUTHORIZATION_PASSWORD) + "\";"
             );
+
+            KafkaClientConfig.loadKakfaConfig(props::put);
         }
         props.put(AUTO_OFFSET_RESET_CONFIG, configs.getStringProperty(Configs.KAFKA_CONSUMER_AUTO_OFFSET_RESET_CONFIG));
         props.put(SESSION_TIMEOUT_MS_CONFIG, configs.getIntProperty(Configs.KAFKA_CONSUMER_SESSION_TIMEOUT_MS_CONFIG));

--- a/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/producer/kafka/KafkaMessageProducerFactory.java
+++ b/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/producer/kafka/KafkaMessageProducerFactory.java
@@ -6,6 +6,7 @@ import org.apache.kafka.clients.producer.Producer;
 import org.glassfish.hk2.api.Factory;
 import pl.allegro.tech.hermes.common.config.ConfigFactory;
 import pl.allegro.tech.hermes.common.config.Configs;
+import pl.allegro.tech.hermes.common.config.KafkaClientConfig;
 
 import javax.inject.Inject;
 import java.util.HashMap;
@@ -90,6 +91,8 @@ public class KafkaMessageProducerFactory implements Factory<Producers> {
                             + "username=\"" + getString(KAFKA_AUTHORIZATION_USERNAME) + "\"\n"
                             + "password=\"" + getString(KAFKA_AUTHORIZATION_PASSWORD) + "\";"
             );
+
+            KafkaClientConfig.loadKakfaConfig(props::put);
         }
 
         Producer<byte[], byte[]> leaderConfirms = new KafkaProducer<>(copyWithEntryAdded(props, ACKS_CONFIG, ACK_LEADER));


### PR DESCRIPTION
if kafka.authorization.enabled is true.
This allows for freely specifying paramaters for securing connectivity between Hermes and
the underlying kafka brokers beyond SASL_PLAINTEXT and username/password

Kafka client properties will require the prefix "kafka.client." within Hermes configuration.