### PR TITLE
Readiness status available on frontend's instance endpoint.

### DIFF
--- a/hermes-api/src/main/java/pl/allegro/tech/hermes/api/Readiness.java
+++ b/hermes-api/src/main/java/pl/allegro/tech/hermes/api/Readiness.java
@@ -1,0 +1,21 @@
+package pl.allegro.tech.hermes.api;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.validation.constraints.NotNull;
+
+public class Readiness {
+    @NotNull
+    private final boolean isReady;
+
+    @JsonCreator
+    public Readiness(@JsonProperty("isReady") boolean isReady) {
+        this.isReady = isReady;
+    }
+
+    @JsonGetter("isReady")
+    public boolean isReady() {
+        return isReady;
+    }
+}

--- a/hermes-api/src/main/java/pl/allegro/tech/hermes/api/endpoints/ReadinessEndpoint.java
+++ b/hermes-api/src/main/java/pl/allegro/tech/hermes/api/endpoints/ReadinessEndpoint.java
@@ -1,0 +1,20 @@
+package pl.allegro.tech.hermes.api.endpoints;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Response;
+import pl.allegro.tech.hermes.api.Readiness;
+
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+
+@Path("readiness")
+public interface ReadinessEndpoint {
+    @POST
+    @Consumes(APPLICATION_JSON)
+    @Produces(APPLICATION_JSON)
+    @Path("/{datacenter}")
+    Response setReadiness(@PathParam("datacenter") String datacenter, Readiness readiness);
+}

--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/common/di/CommonBinder.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/common/di/CommonBinder.java
@@ -1,6 +1,7 @@
 package pl.allegro.tech.hermes.common.di;
 
 import com.yammer.metrics.core.HealthCheckRegistry;
+import java.util.List;
 import org.apache.avro.Schema;
 import org.glassfish.hk2.api.TypeLiteral;
 import pl.allegro.tech.hermes.common.clock.ClockFactory;
@@ -15,6 +16,7 @@ import pl.allegro.tech.hermes.common.di.factories.ModelAwareZookeeperNotifyingCa
 import pl.allegro.tech.hermes.common.di.factories.OAuthProviderRepositoryFactory;
 import pl.allegro.tech.hermes.common.di.factories.ObjectMapperFactory;
 import pl.allegro.tech.hermes.common.di.factories.PathsCompilerFactory;
+import pl.allegro.tech.hermes.common.di.factories.ReadinessRepositoryFactory;
 import pl.allegro.tech.hermes.common.di.factories.SharedCounterFactory;
 import pl.allegro.tech.hermes.common.di.factories.SubscriptionOffsetChangeIndicatorFactory;
 import pl.allegro.tech.hermes.common.di.factories.SubscriptionRepositoryFactory;
@@ -44,6 +46,7 @@ import pl.allegro.tech.hermes.common.schema.RawSchemaClientFactory;
 import pl.allegro.tech.hermes.common.schema.SchemaVersionsRepositoryFactory;
 import pl.allegro.tech.hermes.common.util.InstanceIdResolver;
 import pl.allegro.tech.hermes.common.util.InetAddressInstanceIdResolver;
+import pl.allegro.tech.hermes.domain.readiness.ReadinessRepository;
 import pl.allegro.tech.hermes.domain.notifications.InternalNotificationsBus;
 import pl.allegro.tech.hermes.domain.workload.constraints.WorkloadConstraintsRepository;
 import pl.allegro.tech.hermes.infrastructure.zookeeper.notifications.ZookeeperInternalNotificationBus;
@@ -95,6 +98,8 @@ public class CommonBinder extends AbstractBinder {
         bindSingletonFactory(KafkaNamesMapperFactory.class);
         bindSingletonFactory(MessagePreviewRepositoryFactory.class);
         bindFactory(WorkloadConstraintsRepositoryFactory.class).in(Singleton.class).to(WorkloadConstraintsRepository.class);
+        bindFactory(ReadinessRepositoryFactory.class).in(Singleton.class).to(new TypeLiteral<List<ReadinessRepository>>() {
+        });
 
         bind(ZookeeperInternalNotificationBus.class).to(InternalNotificationsBus.class);
         bindSingletonFactory(ModelAwareZookeeperNotifyingCacheFactory.class);

--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/common/di/factories/ReadinessRepositoryFactory.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/common/di/factories/ReadinessRepositoryFactory.java
@@ -1,0 +1,44 @@
+package pl.allegro.tech.hermes.common.di.factories;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.Lists;
+import java.util.List;
+import javax.inject.Inject;
+import javax.inject.Named;
+import org.apache.curator.framework.CuratorFramework;
+import org.glassfish.hk2.api.Factory;
+import pl.allegro.tech.hermes.common.di.CuratorType;
+import pl.allegro.tech.hermes.common.util.InstanceIdResolver;
+import pl.allegro.tech.hermes.domain.readiness.ReadinessRepository;
+import pl.allegro.tech.hermes.infrastructure.zookeeper.ZookeeperPaths;
+import pl.allegro.tech.hermes.infrastructure.zookeeper.ZookeeperDatacenterReadinessRepository;
+
+
+public class ReadinessRepositoryFactory implements Factory<List<ReadinessRepository>> {
+
+    private final String hostname;
+
+    private final CuratorFramework zookeeper;
+
+    private final ZookeeperPaths paths;
+
+    private final ObjectMapper mapper;
+
+    @Inject
+    public ReadinessRepositoryFactory(@Named(CuratorType.HERMES) CuratorFramework zookeeper, ZookeeperPaths paths,
+                                      ObjectMapper mapper, InstanceIdResolver instanceIdResolver) {
+        this.zookeeper = zookeeper;
+        this.paths = paths;
+        this.mapper = mapper;
+        this.hostname = instanceIdResolver.resolve();
+    }
+
+    @Override
+    public List<ReadinessRepository> provide() {
+        return Lists.newArrayList(new ZookeeperDatacenterReadinessRepository(zookeeper, mapper, paths, hostname));
+    }
+
+    @Override
+    public void dispose(List<ReadinessRepository> instances) {
+    }
+}

--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/domain/readiness/DatacenterReadinessRepository.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/domain/readiness/DatacenterReadinessRepository.java
@@ -1,0 +1,5 @@
+package pl.allegro.tech.hermes.domain.readiness;
+
+public interface DatacenterReadinessRepository extends ReadinessRepository {
+    boolean datacenterMatches(String datacenter);
+}

--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/domain/readiness/ReadinessRepository.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/domain/readiness/ReadinessRepository.java
@@ -1,0 +1,6 @@
+package pl.allegro.tech.hermes.domain.readiness;
+
+public interface ReadinessRepository {
+    boolean isReady();
+    void setReadiness(boolean isReady);
+}

--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/infrastructure/zookeeper/ZookeeperDatacenterReadinessRepository.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/infrastructure/zookeeper/ZookeeperDatacenterReadinessRepository.java
@@ -1,0 +1,49 @@
+package pl.allegro.tech.hermes.infrastructure.zookeeper;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.curator.framework.CuratorFramework;
+import pl.allegro.tech.hermes.api.Readiness;
+import pl.allegro.tech.hermes.common.exception.InternalProcessingException;
+import pl.allegro.tech.hermes.domain.readiness.DatacenterReadinessRepository;
+
+public class ZookeeperDatacenterReadinessRepository extends ZookeeperBasedRepository implements DatacenterReadinessRepository {
+
+    private final String datacenter;
+
+    public ZookeeperDatacenterReadinessRepository(CuratorFramework zookeeper,
+                                                  ObjectMapper mapper,
+                                                  ZookeeperPaths paths,
+                                                  String datacenter) {
+        super(zookeeper, mapper, paths);
+        this.datacenter = datacenter;
+    }
+
+    @Override
+    public boolean isReady() {
+        if (!pathExists(paths.frontendReadinessPath())) {
+            return true;
+        }
+        return readFrom(paths.frontendReadinessPath(), Readiness.class).isReady();
+    }
+
+    @Override
+    public void setReadiness(boolean isReady) {
+        try {
+            String path = paths.frontendReadinessPath();
+            if (!pathExists(path)) {
+                zookeeper.create()
+                        .creatingParentsIfNeeded()
+                        .forPath(path, mapper.writeValueAsBytes(new Readiness(isReady)));
+            } else {
+                zookeeper.setData().forPath(path, mapper.writeValueAsBytes(new Readiness(isReady)));
+            }
+        } catch (Exception ex) {
+            throw new InternalProcessingException(ex);
+        }
+    }
+
+    @Override
+    public boolean datacenterMatches(String datacenter) {
+        return this.datacenter.equals(datacenter);
+    }
+}

--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/infrastructure/zookeeper/ZookeeperPaths.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/infrastructure/zookeeper/ZookeeperPaths.java
@@ -26,6 +26,8 @@ public class ZookeeperPaths {
     public static final String MAX_RATE_PATH = "max-rate";
     public static final String MAX_RATE_HISTORY_PATH = "history";
     public static final String STORAGE_HEALTH_PATH = "storage-health";
+    public static final String FRONTEND_PATH = "frontend";
+    public static final String READINESS_PATH = "readiness";
 
     private final String basePath;
 
@@ -178,6 +180,10 @@ public class ZookeeperPaths {
 
     public String nodeHealthPathForManagementHost(String host, String port) {
         return Joiner.on(URL_SEPARATOR).join(basePath, STORAGE_HEALTH_PATH, String.format("%s_%s", host, port));
+    }
+
+    public String frontendReadinessPath() {
+        return Joiner.on(URL_SEPARATOR).join(basePath, FRONTEND_PATH, READINESS_PATH);
     }
 
     public String join(String... parts) {

--- a/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/di/FrontendBinder.java
+++ b/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/di/FrontendBinder.java
@@ -34,6 +34,7 @@ import pl.allegro.tech.hermes.frontend.server.TopicSchemaLoadingStartupHook;
 import pl.allegro.tech.hermes.frontend.server.WaitForKafkaStartupHook;
 import pl.allegro.tech.hermes.frontend.server.auth.AuthenticationConfigurationProvider;
 import pl.allegro.tech.hermes.frontend.services.HealthCheckService;
+import pl.allegro.tech.hermes.frontend.services.ReadinessCheckService;
 import pl.allegro.tech.hermes.frontend.validator.MessageValidators;
 import pl.allegro.tech.hermes.frontend.validator.TopicMessageValidator;
 import pl.allegro.tech.hermes.frontend.validator.TopicMessageValidatorListFactory;
@@ -70,6 +71,7 @@ public class FrontendBinder extends AbstractBinder {
         bind("producer").named("moduleName").to(String.class);
 
         bindSingleton(HealthCheckService.class);
+        bindSingleton(ReadinessCheckService.class);
         bind(DefaultHeadersPropagator.class).to(HeadersPropagator.class).in(Singleton.class);
 
         bindFactory(HandlersChainFactory.class).to(HttpHandler.class).in(Singleton.class);

--- a/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/server/ReadinessCheckHandler.java
+++ b/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/server/ReadinessCheckHandler.java
@@ -1,0 +1,40 @@
+package pl.allegro.tech.hermes.frontend.server;
+
+import io.undertow.server.HttpHandler;
+import io.undertow.server.HttpServerExchange;
+import pl.allegro.tech.hermes.frontend.services.ReadinessCheckService;
+
+import static io.undertow.util.StatusCodes.OK;
+import static io.undertow.util.StatusCodes.SERVICE_UNAVAILABLE;
+
+public class ReadinessCheckHandler implements HttpHandler {
+
+    private final ReadinessCheckService readinessCheckService;
+
+    public ReadinessCheckHandler(ReadinessCheckService readinessCheckService) {
+        this.readinessCheckService = readinessCheckService;
+    }
+
+    @Override
+    public void handleRequest(HttpServerExchange exchange) throws Exception {
+        if (readinessCheckService.isReady()) {
+            success(exchange);
+        } else {
+            unavailable(exchange);
+        }
+    }
+
+    private void success(HttpServerExchange exchange) {
+        response(exchange, OK, "READY");
+    }
+
+    private void unavailable(HttpServerExchange exchange) {
+        response(exchange, SERVICE_UNAVAILABLE, "NOT_READY");
+    }
+
+    private void response(HttpServerExchange exchange, int status, String data) {
+        exchange.setStatusCode(status);
+        exchange.getResponseSender().send(data);
+    }
+
+}

--- a/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/services/ReadinessCheckService.java
+++ b/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/services/ReadinessCheckService.java
@@ -1,0 +1,29 @@
+package pl.allegro.tech.hermes.frontend.services;
+
+import java.util.List;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import pl.allegro.tech.hermes.domain.readiness.ReadinessRepository;
+
+@Singleton
+public class ReadinessCheckService {
+    private static final Logger logger = LoggerFactory.getLogger(ReadinessCheckService.class);
+
+    private final List<ReadinessRepository> readinessRepositories;
+
+    @Inject
+    public ReadinessCheckService(List<ReadinessRepository> readinessRepositories) {
+        this.readinessRepositories = readinessRepositories;
+    }
+
+    public boolean isReady() {
+        try {
+            return readinessRepositories.stream().allMatch(ReadinessRepository::isReady);
+        } catch (Exception ex) {
+            logger.error("Error while reading readiness status...", ex);
+            return true;
+        }
+    }
+}

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/api/DatacenterEndpoint.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/api/DatacenterEndpoint.java
@@ -1,0 +1,32 @@
+package pl.allegro.tech.hermes.management.api;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import org.springframework.stereotype.Component;
+import pl.allegro.tech.hermes.management.config.storage.StorageClustersProperties;
+import pl.allegro.tech.hermes.management.config.storage.StorageProperties;
+
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+
+@Path("datacenters")
+@Component
+public class DatacenterEndpoint {
+
+    private final List<String> datacenters;
+
+    DatacenterEndpoint(StorageClustersProperties clustersProperties) {
+        datacenters = clustersProperties.getClusters()
+                .stream()
+                .map(StorageProperties::getDatacenter)
+                .collect(Collectors.toList());
+    }
+
+    @GET
+    @Produces(APPLICATION_JSON)
+    public List<String> getDatacenters() {
+        return datacenters;
+    }
+}

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/api/ReadinessEndpoint.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/api/ReadinessEndpoint.java
@@ -1,0 +1,36 @@
+package pl.allegro.tech.hermes.management.api;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Response;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import pl.allegro.tech.hermes.api.Readiness;
+import pl.allegro.tech.hermes.management.domain.readiness.DatacenterReadiness;
+import pl.allegro.tech.hermes.management.domain.readiness.ReadinessService;
+
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+
+@Path("readiness")
+@Component
+public class ReadinessEndpoint {
+
+    private final ReadinessService readinessService;
+
+    @Autowired
+    public ReadinessEndpoint(ReadinessService readinessService) {
+        this.readinessService = readinessService;
+    }
+
+    @POST
+    @Consumes(APPLICATION_JSON)
+    @Produces(APPLICATION_JSON)
+    @Path("/{datacenter}")
+    public Response setReadiness(@PathParam("datacenter") String datacenter, Readiness readiness) {
+        readinessService.setReady(new DatacenterReadiness(datacenter, readiness.isReady()));
+        return Response.status(Response.Status.ACCEPTED).build();
+    }
+}

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/config/ReadinessConfiguration.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/config/ReadinessConfiguration.java
@@ -1,0 +1,14 @@
+package pl.allegro.tech.hermes.management.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import pl.allegro.tech.hermes.management.domain.dc.MultiDatacenterRepositoryCommandExecutor;
+import pl.allegro.tech.hermes.management.domain.readiness.ReadinessService;
+
+@Configuration
+public class ReadinessConfiguration {
+    @Bean
+    ReadinessService readinessService(MultiDatacenterRepositoryCommandExecutor commandExecutor) {
+        return new ReadinessService(commandExecutor);
+    }
+}

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/domain/readiness/DatacenterReadiness.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/domain/readiness/DatacenterReadiness.java
@@ -1,0 +1,27 @@
+package pl.allegro.tech.hermes.management.domain.readiness;
+
+public class DatacenterReadiness {
+    private final String datacenter;
+    private final boolean ready;
+
+    public DatacenterReadiness(String datacenter, boolean ready) {
+        this.datacenter = datacenter;
+        this.ready = ready;
+    }
+
+    public String getDatacenter() {
+        return datacenter;
+    }
+
+    public boolean isReady() {
+        return ready;
+    }
+
+    @Override
+    public String toString() {
+        return "DatacenterReadiness{" +
+                "datacenter='" + datacenter + '\'' +
+                ", ready=" + ready +
+                '}';
+    }
+}

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/domain/readiness/ReadinessService.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/domain/readiness/ReadinessService.java
@@ -1,0 +1,16 @@
+package pl.allegro.tech.hermes.management.domain.readiness;
+
+import pl.allegro.tech.hermes.management.domain.dc.MultiDatacenterRepositoryCommandExecutor;
+
+
+public class ReadinessService {
+    private final MultiDatacenterRepositoryCommandExecutor commandExecutor;
+
+    public ReadinessService(MultiDatacenterRepositoryCommandExecutor commandExecutor) {
+        this.commandExecutor = commandExecutor;
+    }
+
+    public void setReady(DatacenterReadiness datacenterReadiness) {
+        commandExecutor.execute(new SetReadinessCommand(datacenterReadiness));
+    }
+}

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/domain/readiness/SetReadinessCommand.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/domain/readiness/SetReadinessCommand.java
@@ -1,0 +1,35 @@
+package pl.allegro.tech.hermes.management.domain.readiness;
+
+import pl.allegro.tech.hermes.domain.readiness.DatacenterReadinessRepository;
+import pl.allegro.tech.hermes.management.domain.dc.RepositoryCommand;
+
+public class SetReadinessCommand extends RepositoryCommand<DatacenterReadinessRepository> {
+    private final DatacenterReadiness readiness;
+
+    public SetReadinessCommand(DatacenterReadiness readiness) {
+        this.readiness = readiness;
+    }
+
+    @Override
+    public void backup(DatacenterReadinessRepository repository) { }
+
+    @Override
+    public void execute(DatacenterReadinessRepository repository) {
+        if (repository.datacenterMatches(readiness.getDatacenter())) {
+            repository.setReadiness(readiness.isReady());
+        }
+    }
+
+    @Override
+    public void rollback(DatacenterReadinessRepository repository) { }
+
+    @Override
+    public Class<DatacenterReadinessRepository> getRepositoryType() {
+        return DatacenterReadinessRepository.class;
+    }
+
+    @Override
+    public String toString() {
+        return "SetReadinessCommand(" + readiness.toString() + ")";
+    }
+}

--- a/hermes-test-helper/src/main/java/pl/allegro/tech/hermes/test/helper/client/Hermes.java
+++ b/hermes-test-helper/src/main/java/pl/allegro/tech/hermes/test/helper/client/Hermes.java
@@ -12,6 +12,7 @@ import pl.allegro.tech.hermes.api.endpoints.ModeEndpoint;
 import pl.allegro.tech.hermes.api.endpoints.OAuthProviderEndpoint;
 import pl.allegro.tech.hermes.api.endpoints.OwnerEndpoint;
 import pl.allegro.tech.hermes.api.endpoints.QueryEndpoint;
+import pl.allegro.tech.hermes.api.endpoints.ReadinessEndpoint;
 import pl.allegro.tech.hermes.api.endpoints.SchemaEndpoint;
 import pl.allegro.tech.hermes.api.endpoints.SubscriptionEndpoint;
 import pl.allegro.tech.hermes.api.endpoints.SubscriptionOwnershipEndpoint;
@@ -126,6 +127,10 @@ public class Hermes {
 
     public FilterEndpoint createFilterEndpoint() {
         return createProxy(url, FilterEndpoint.class, managementConfig);
+    }
+
+    public ReadinessEndpoint createReadinessEndpoint() {
+        return createProxy(url, ReadinessEndpoint.class, managementConfig);
     }
 
     public AsyncMessagePublisher createAsyncMessagePublisher() {

--- a/hermes-test-helper/src/main/java/pl/allegro/tech/hermes/test/helper/endpoint/HermesAPIOperations.java
+++ b/hermes-test-helper/src/main/java/pl/allegro/tech/hermes/test/helper/endpoint/HermesAPIOperations.java
@@ -1,10 +1,12 @@
 package pl.allegro.tech.hermes.test.helper.endpoint;
 
+import java.util.List;
 import pl.allegro.tech.hermes.api.BatchSubscriptionPolicy;
 import pl.allegro.tech.hermes.api.ContentType;
 import pl.allegro.tech.hermes.api.Group;
 import pl.allegro.tech.hermes.api.OAuthProvider;
 import pl.allegro.tech.hermes.api.PatchData;
+import pl.allegro.tech.hermes.api.Readiness;
 import pl.allegro.tech.hermes.api.Subscription;
 import pl.allegro.tech.hermes.api.SubscriptionMode;
 import pl.allegro.tech.hermes.api.Topic;
@@ -16,6 +18,7 @@ import javax.ws.rs.core.Response;
 
 import java.util.concurrent.TimeUnit;
 
+import static javax.ws.rs.core.Response.Status.ACCEPTED;
 import static javax.ws.rs.core.Response.Status.CREATED;
 import static javax.ws.rs.core.Response.Status.OK;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -204,4 +207,7 @@ public class HermesAPIOperations {
         wait.untilOAuthProviderCreated(oAuthProvider.getName());
     }
 
+    public void setReadiness(String dcName, boolean isReady) {
+        assertThat(endpoints.readiness().setReadiness(dcName, new Readiness(isReady)).getStatus()).isEqualTo(ACCEPTED.getStatusCode());
+    }
 }

--- a/hermes-test-helper/src/main/java/pl/allegro/tech/hermes/test/helper/endpoint/HermesEndpoints.java
+++ b/hermes-test-helper/src/main/java/pl/allegro/tech/hermes/test/helper/endpoint/HermesEndpoints.java
@@ -9,6 +9,7 @@ import pl.allegro.tech.hermes.api.endpoints.ModeEndpoint;
 import pl.allegro.tech.hermes.api.endpoints.OAuthProviderEndpoint;
 import pl.allegro.tech.hermes.api.endpoints.OwnerEndpoint;
 import pl.allegro.tech.hermes.api.endpoints.QueryEndpoint;
+import pl.allegro.tech.hermes.api.endpoints.ReadinessEndpoint;
 import pl.allegro.tech.hermes.api.endpoints.SchemaEndpoint;
 import pl.allegro.tech.hermes.api.endpoints.SubscriptionEndpoint;
 import pl.allegro.tech.hermes.api.endpoints.SubscriptionOwnershipEndpoint;
@@ -49,6 +50,8 @@ public class HermesEndpoints {
 
     private final FilterEndpoint filterEndpoint;
 
+    private final ReadinessEndpoint readinessEndpoint;
+
     public HermesEndpoints(Hermes hermes) {
         this.groupEndpoint = hermes.createGroupEndpoint();
         this.topicEndpoint = hermes.createTopicEndpoint();
@@ -64,6 +67,7 @@ public class HermesEndpoints {
         this.unhealthyEndpoint = hermes.unhealthyEndpoint();
         this.modeEndpoint = hermes.modeEndpoint();
         this.filterEndpoint = hermes.createFilterEndpoint();
+        this.readinessEndpoint = hermes.createReadinessEndpoint();
     }
 
     public HermesEndpoints(String hermesFrontendUrl, String consumerUrl) {
@@ -138,6 +142,10 @@ public class HermesEndpoints {
 
     public FilterEndpoint filter() {
         return filterEndpoint;
+    }
+
+    public ReadinessEndpoint readiness() {
+        return readinessEndpoint;
     }
 }
 

--- a/integration/src/integration/java/pl/allegro/tech/hermes/integration/DatacentersTest.java
+++ b/integration/src/integration/java/pl/allegro/tech/hermes/integration/DatacentersTest.java
@@ -1,0 +1,25 @@
+package pl.allegro.tech.hermes.integration;
+
+import com.google.common.collect.Lists;
+import java.util.List;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.GenericType;
+import org.testng.annotations.Test;
+import pl.allegro.tech.hermes.test.helper.endpoint.JerseyClientFactory;
+
+import static pl.allegro.tech.hermes.integration.test.HermesAssertions.assertThat;
+
+public class DatacentersTest extends IntegrationTest {
+    @Test
+    public void shouldReturnAvailableDatacenters() {
+        // given
+        WebTarget client = JerseyClientFactory.create().target(MANAGEMENT_ENDPOINT_URL).path("datacenters");
+
+        // when
+        List<String> datacenters = client.request().get().readEntity(new GenericType<List<String>>() {
+        });
+
+        // then
+        assertThat(datacenters).isEqualTo(Lists.newArrayList("dc"));
+    }
+}

--- a/integration/src/integration/java/pl/allegro/tech/hermes/integration/ReadinessCheckTest.java
+++ b/integration/src/integration/java/pl/allegro/tech/hermes/integration/ReadinessCheckTest.java
@@ -1,0 +1,112 @@
+package pl.allegro.tech.hermes.integration;
+
+import com.google.common.io.Files;
+import javax.ws.rs.client.WebTarget;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import pl.allegro.tech.hermes.common.config.Configs;
+import pl.allegro.tech.hermes.integration.env.FrontendStarter;
+import pl.allegro.tech.hermes.integration.env.ManagementStarter;
+import pl.allegro.tech.hermes.test.helper.endpoint.HermesAPIOperations;
+import pl.allegro.tech.hermes.test.helper.endpoint.HermesEndpoints;
+import pl.allegro.tech.hermes.test.helper.endpoint.JerseyClientFactory;
+import pl.allegro.tech.hermes.test.helper.environment.ZookeeperStarter;
+import pl.allegro.tech.hermes.test.helper.util.Ports;
+
+import static javax.ws.rs.core.Response.Status.OK;
+import static javax.ws.rs.core.Response.Status.SERVICE_UNAVAILABLE;
+import static pl.allegro.tech.hermes.integration.test.HermesAssertions.assertThat;
+
+public class ReadinessCheckTest extends IntegrationTest {
+
+    private static final int ZOOKEEPER_PORT = 14193;
+    private static final String ZOOKEEPER_URL = "localhost:" + ZOOKEEPER_PORT;
+    private static final int MANAGEMENT_PORT = 18083;
+    private static final String MANAGEMENT_URL = "http://localhost:" + MANAGEMENT_PORT + "/";
+
+    private ZookeeperStarter zookeeperStarter;
+    private ManagementStarter managementStarter;
+    private HermesAPIOperations operations;
+
+    @BeforeClass
+    public void setupEnvironment() throws Exception {
+        zookeeperStarter = setupZookeeper();
+        managementStarter = setupManagement();
+        operations = setupOperations();
+    }
+
+    @AfterClass
+    public void cleanEnvironment() throws Exception {
+        zookeeperStarter.stop();
+        managementStarter.stop();
+    }
+
+    @Test
+    public void shouldReturnCorrectHealthStatusForParticularDC() throws Exception {
+        // given
+        int frontendPort = Ports.nextAvailable();
+        String frontendUrl = "http://localhost:" + frontendPort + "/";
+
+        operations.setReadiness("dc5", false);
+        FrontendStarter frontendStarter = setupFrontend(frontendPort); // frontend needs to be started after the flag is set in zookeeper
+
+        // when
+        WebTarget clientDc5 = JerseyClientFactory.create().target(frontendUrl).path("status").path("ready");
+        WebTarget clientDefaultDc = JerseyClientFactory.create().target(FRONTEND_URL).path("status").path("ready");
+
+        // then
+        assertThat(clientDc5.request().get()).hasStatus(SERVICE_UNAVAILABLE);
+        assertThat(clientDefaultDc.request().get()).hasStatus(OK);
+
+        // cleanup
+        frontendStarter.stop();
+
+        // given
+        operations.setReadiness("dc5", true);
+        frontendStarter = setupFrontend(frontendPort);
+
+        // when
+        clientDc5 = JerseyClientFactory.create().target(frontendUrl).path("status").path("ready");
+
+        // then
+        assertThat(clientDc5.request().get()).hasStatus(OK);
+        assertThat(clientDefaultDc.request().get()).hasStatus(OK);
+
+        // cleanup
+        frontendStarter.stop();
+    }
+
+    private FrontendStarter setupFrontend(int port) throws Exception {
+        FrontendStarter frontend = new FrontendStarter(port, false);
+        frontend.overrideProperty(Configs.FRONTEND_PORT, port);
+        frontend.overrideProperty(Configs.FRONTEND_HTTP2_ENABLED, false);
+        frontend.overrideProperty(Configs.FRONTEND_SSL_ENABLED, false);
+        frontend.overrideProperty(Configs.METRICS_GRAPHITE_REPORTER, false);
+        frontend.overrideProperty(Configs.METRICS_ZOOKEEPER_REPORTER, false);
+        frontend.overrideProperty(Configs.MESSAGES_LOCAL_STORAGE_ENABLED, false);
+        frontend.overrideProperty(Configs.MESSAGES_LOCAL_STORAGE_DIRECTORY, Files.createTempDir().getAbsolutePath());
+        frontend.overrideProperty(Configs.ZOOKEEPER_CONNECT_STRING, ZOOKEEPER_URL);
+
+        frontend.start();
+
+        return frontend;
+    }
+
+    private ZookeeperStarter setupZookeeper() throws Exception {
+        ZookeeperStarter zookeeperStarter = new ZookeeperStarter(ZOOKEEPER_PORT, ZOOKEEPER_URL, CONFIG_FACTORY.getStringProperty(Configs.ZOOKEEPER_ROOT));
+        zookeeperStarter.start();
+        return zookeeperStarter;
+    }
+
+    private ManagementStarter setupManagement() throws Exception {
+        ManagementStarter managementStarter = new ManagementStarter(MANAGEMENT_PORT, "multizk");
+        managementStarter.start();
+        return managementStarter;
+    }
+
+    private HermesAPIOperations setupOperations() {
+        HermesEndpoints management = new HermesEndpoints(MANAGEMENT_URL, CONSUMER_ENDPOINT_URL);
+        return new HermesAPIOperations(management, wait);
+    }
+}

--- a/integration/src/test/resources/application-multizk.yaml
+++ b/integration/src/test/resources/application-multizk.yaml
@@ -1,0 +1,90 @@
+owner:
+  crowd:
+    enabled: true
+    path: http://localhost:18222/crowd
+    connect-timeout: 2000
+    socket-timeout: 2000
+
+application:
+  name: hermes-management
+
+zookeeper:
+  enabled: false
+
+kafka:
+  clusters:
+    -
+      datacenter: dc
+      clusterName: primary
+      connectionTimeout: 10000
+      namespace: 'itTest'
+
+topic:
+  replicationFactor: 1
+  partitions: 2
+  allowRemoval: true
+  removeSchema: true
+  defaultContentType: AVRO
+  allowedContentTypes:
+    - AVRO
+    - JSON
+  touchSchedulerEnabled: false
+  allowedTopicLabels:
+    - label-1
+    - label-2
+    - label-3
+
+storage:
+  pathPrefix: /hermes
+  clusters:
+    -
+      datacenter: dc
+      clusterName: zk1
+      connectionString: localhost:14192
+    -
+      datacenter: dc5
+      clusterName: zk2
+      connectionString: localhost:14193
+
+auth:
+  oauthServerUrl: http://localhost:19999
+
+metrics:
+  graphiteHttpUri: http://localhost:18089/
+
+graphite:
+  client:
+    cacheTtlSeconds: 1
+
+spring:
+  jersey:
+    type: servlet
+  mvc:
+    servlet:
+      path: /status
+
+management:
+  endpoints:
+    web:
+      base-path: /
+  server:
+    servlet:
+      context-path: /
+
+spring.groovy.template.check-template-location: false
+
+schema.repository:
+  type: schema_registry
+  deleteSchemaPathSuffix:
+
+topicOwnerCache:
+  refreshRateInSeconds: 300 # 5 minutes
+
+subscriptionOwnerCache:
+  refreshRateInSeconds: 300
+
+consistencyChecker:
+  threadPoolSize: 2
+
+subscription-health:
+  timeoutMillis: 200


### PR DESCRIPTION
This PR introduces a concept of readiness status. It can be used by a load balancer to determine if hermes frontends' instances are ready to take traffic. The readiness status for all instances in datacenter is managed by the hermes management endpoint. Each instance of hermes frontend reads the flag from its datacenter's zookeeper cluster.