### PR TITLE
Benchmarks refactor

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         java: [ '8','11' ]
-        tests: [ 'check', 'integrationTest' ]
+        tests: [ 'check', 'integrationTest', 'jmh -Pjmh.iterations=1 -Pjmh.timeOnIteration=5s -Pjmh.warmupIterations=0' ]
     name: Java ${{ matrix.java }} ${{ matrix.tests }}
     steps:
       - uses: actions/checkout@v2

--- a/hermes-benchmark/build.gradle
+++ b/hermes-benchmark/build.gradle
@@ -11,7 +11,7 @@ jmh {
     humanOutputFile = null
     jmhVersion = '1.12'
     zip64 = true
-    verbosity = 'SILENT'
+    verbosity = 'NORMAL'
     iterations = intProperty('jmh.iterations', 4)
     timeOnIteration = stringProperty('jmh.timeOnIteration', '80s')
     fork = intProperty('jmh.fork', 1)

--- a/hermes-benchmark/src/jmh/java/pl/allegro/tech/hermes/benchmark/environment/BenchmarkZookeeperStarter.java
+++ b/hermes-benchmark/src/jmh/java/pl/allegro/tech/hermes/benchmark/environment/BenchmarkZookeeperStarter.java
@@ -1,0 +1,58 @@
+package pl.allegro.tech.hermes.benchmark.environment;
+
+
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.retry.ExponentialBackoffRetry;
+import org.apache.curator.test.TestingServer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import pl.allegro.tech.hermes.test.helper.environment.Starter;
+
+public class BenchmarkZookeeperStarter implements Starter<TestingServer> {
+
+    private static final Logger logger = LoggerFactory.getLogger(pl.allegro.tech.hermes.test.helper.environment.ZookeeperStarter.class);
+
+    private TestingServer zookeeperServer;
+
+    public BenchmarkZookeeperStarter() {
+
+    }
+
+    public String getConnectString() {
+        return String.format("localhost:%s", zookeeperServer.getPort());
+    }
+
+    @Override
+    public void start() throws Exception {
+        zookeeperServer = new TestingServer(true);
+        int port = zookeeperServer.getPort();
+        logger.info("Running in-memory Zookeeper at port {}", port);
+
+        try(CuratorFramework curator = startZookeeperClient(getConnectString())) {
+            curator.createContainers("hermes/groups");
+        }
+    }
+
+    @Override
+    public void stop() throws Exception {
+        logger.info("Stopping in-memory Zookeeper");
+        zookeeperServer.close();
+    }
+
+    @Override
+    public TestingServer instance() {
+        return zookeeperServer;
+    }
+
+
+    private CuratorFramework startZookeeperClient(String connectString) throws InterruptedException {
+        CuratorFramework zookeeperClient = CuratorFrameworkFactory.builder()
+                .connectString(connectString)
+                .retryPolicy(new ExponentialBackoffRetry(1000, 3))
+                .build();
+        zookeeperClient.start();
+        zookeeperClient.blockUntilConnected();
+        return zookeeperClient;
+    }
+}

--- a/hermes-benchmark/src/jmh/java/pl/allegro/tech/hermes/benchmark/environment/InMemorySchemaClient.java
+++ b/hermes-benchmark/src/jmh/java/pl/allegro/tech/hermes/benchmark/environment/InMemorySchemaClient.java
@@ -24,7 +24,7 @@ public class InMemorySchemaClient implements RawSchemaClient {
 
     @Override
     public Optional<RawSchemaWithMetadata> getRawSchemaWithMetadata(TopicName topic, SchemaVersion version) {
-        return schemaTopicName.equals(topic) && Objects.equals(rawSchemaWithMetadata.getVersion(), version) ?
+        return schemaTopicName.equals(topic) && Objects.equals(rawSchemaWithMetadata.getVersion(), version.value()) ?
             Optional.of(rawSchemaWithMetadata) : Optional.empty();
     }
 
@@ -35,7 +35,7 @@ public class InMemorySchemaClient implements RawSchemaClient {
 
     @Override
     public Optional<RawSchemaWithMetadata> getRawSchemaWithMetadata(TopicName topic, SchemaId schemaId) {
-        return schemaTopicName.equals(topic) && Objects.equals(rawSchemaWithMetadata.getId(), schemaId) ?
+        return schemaTopicName.equals(topic) && Objects.equals(rawSchemaWithMetadata.getId(), schemaId.value()) ?
             Optional.of(rawSchemaWithMetadata) : Optional.empty();
     }
 


### PR DESCRIPTION
migration to GitHub Actions allowed to detect the problems such as:
- fixed ports
- outdated `InMemorySchemaClient` class
- problems with not created Zookeeper Nodes