### PR TITLE
fixes #1303 | hermes-console: support unicode in filter debug

### DIFF
--- a/hermes-console/bower.json
+++ b/hermes-console/bower.json
@@ -19,7 +19,8 @@
     "hello": "~1.3.7",
     "jquery": "2.1.4",
     "smalot-bootstrap-datetimepicker": "2.3.5",
-    "angular-deferred-bootstrap": "~0.1.9"
+    "angular-deferred-bootstrap": "~0.1.9",
+    "utf8": "3.0.0"
   },
   "resolutions": {
     "angular": "1.4.14"

--- a/hermes-console/static/index.html
+++ b/hermes-console/static/index.html
@@ -26,6 +26,7 @@
         <script src="components/json-formatter/dist/json-formatter.min.js.js"></script>
         <script src="components/hello/dist/hello.min.js"></script>
         <script src="components/smalot-bootstrap-datetimepicker/js/bootstrap-datetimepicker.min.js"></script>
+        <script src="components/utf8/utf8.js"></script>
 
         <script src="/console"></script>
 

--- a/hermes-console/static/js/console/filters/FiltersRepository.js
+++ b/hermes-console/static/js/console/filters/FiltersRepository.js
@@ -5,7 +5,7 @@ angular.module('hermes.filters.repository', [])
 
             return {
                 verify: function (topicName, filters, message) {
-                    return filtersResource.verify({topicName: topicName}, {filters: filters, message: btoa(message)});
+                    return filtersResource.verify({topicName: topicName}, {filters: filters, message: btoa(utf8.encode(message || ""))});
                 }
             };
         }]);


### PR DESCRIPTION
This PR fixes https://github.com/allegro/hermes/issues/1303. Filter debug does not support unicode strings. When you use unicode strings in filter debug no result is returned and an error is displayed in a console. 
Example content
```json
{"a": "★"}
```
causes
```
Error: String contains an invalid character
verify@http://localhost:8090/ui/js/console/filters/FiltersRepository.js:8:103
```
<img width="1056" alt="Zrzut ekranu 2021-10-2 o 17 19 44" src="https://user-images.githubusercontent.com/1526000/135722723-bdf0e495-92ea-4916-a94c-5b1a6430f970.png">

The error is thrown from
https://github.com/allegro/hermes/blob/fa416ab9f0c6711a1f443e76e23d38fd225cd696/hermes-console/static/js/console/filters/FiltersRepository.js#L8

`btoa` does not support unicode (try to run `btoa("★")` in JS console). 

Possible solutions:
- use base64 encoder which handles unicode (suggested in https://developer.mozilla.org/en-US/docs/Glossary/Base64#the_unicode_problem)
- encode a string with utf8 (suggested in https://github.com/mathiasbynens/base64#base64encodeinput)

I used the second option to fix the problem.  