### PR TITLE
Fix: serve hermes-console by NodeJS

### DIFF
--- a/hermes-console/serve.js
+++ b/hermes-console/serve.js
@@ -33,7 +33,7 @@ function startServer(config) {
 
     var file = new static.Server('./static');
     require('http').createServer((request, response) => {
-        if(request.url == '/config') {
+        if(request.url == '/console') {
             response.setHeader('Content-Type', 'application/json');
             response.end('var config = ' + JSON.stringify(config) + ';', 'UTF-8');
         }


### PR DESCRIPTION
Hermes-console doesn't work when served by NodeJS. 


<img width="907" alt="Zrzut ekranu 2021-10-2 o 17 54 00" src="https://user-images.githubusercontent.com/1526000/135724057-cb007f56-284a-4325-aef7-cebc21edddf0.png">
You can properly serve it using hermes-management, but existing scripts (`hermes-console/serve.js`, `hermes-console/run.sh`) should be usable. 

https://github.com/allegro/hermes/blob/fa416ab9f0c6711a1f443e76e23d38fd225cd696/hermes-console/static/index.html#L30
expects configuration at `/console`, but `serve.js` expose configuration at `/config`. Hermes-management expose configuration at `/console`, so we can unify this. 