### PR TITLE
resolves #1308 | Support json formatting when debugging filters in hermes-console

### DIFF
--- a/hermes-console/bower.json
+++ b/hermes-console/bower.json
@@ -20,7 +20,8 @@
     "jquery": "2.1.4",
     "smalot-bootstrap-datetimepicker": "2.3.5",
     "angular-deferred-bootstrap": "~0.1.9",
-    "utf8": "3.0.0"
+    "utf8": "3.0.0",
+    "angular-ui-ace": "0.2.3"
   },
   "resolutions": {
     "angular": "1.4.14"

--- a/hermes-console/static/css/main.css
+++ b/hermes-console/static/css/main.css
@@ -115,3 +115,5 @@ footer {
 .full-width {
     display: block;
 }
+
+.ace_editor { height: 300px; }

--- a/hermes-console/static/index.html
+++ b/hermes-console/static/index.html
@@ -73,6 +73,8 @@
         <script src="js/console/Mode.js"></script>
         <script src="js/app.js"></script>
         <script src="js/bootstrap.js"></script>
+        <script type="text/javascript" src="components/ace-builds/src-min-noconflict/ace.js"></script>
+        <script type="text/javascript" src="components/angular-ui-ace/ui-ace.js"></script>
     </head>
     <body>
         <nav class="navbar navbar-default" role="navigation">

--- a/hermes-console/static/js/app.js
+++ b/hermes-console/static/js/app.js
@@ -17,6 +17,7 @@ var hermes = angular.module('hermes', [
     'hermes.visibility',
     'hermes.mode',
     'hermes.readiness',
+    'ui.ace',
 ]);
 
 hermes.constant('DASHBOARD_CONFIG', config.dashboard);

--- a/hermes-console/static/js/console/filters/FiltersDebugger.js
+++ b/hermes-console/static/js/console/filters/FiltersDebugger.js
@@ -26,6 +26,7 @@ angular.module('hermes.filters.debugger', ['hermes.filters.repository'])
                     .finally(function () {
                         $scope.verificationInProgress = false;
                     });
+                beautifyText()
             };
 
             $scope.updateFilters = function () {
@@ -36,6 +37,12 @@ angular.module('hermes.filters.debugger', ['hermes.filters.repository'])
                 $scope.verificationStatus = '';
                 $scope.errorMessage = null;
                 $scope.verificationInProgress = false;
+            }
+            function beautifyText(){
+                const obj_message = JSON.parse($scope.message);
+                if (obj_message !== undefined) {
+                    $scope.message = JSON.stringify(obj_message, null, 4)
+                }
             }
         }])
     .factory('FiltersDebuggerModalFactory', ['$uibModal', function ($modal) {

--- a/hermes-console/static/partials/modal/debugFilters.html
+++ b/hermes-console/static/partials/modal/debugFilters.html
@@ -3,9 +3,13 @@
         <form name="debuggerForm" class="form-horizontal" role="form">
             <div class="form-group">
                 <div class="col-md-9">
-                    <textarea class="form-control" id="message"
-                              name="message" placeholder="Message (JSON)"
-                              ng-model="message" rows="20"></textarea>
+                    <div class="form-control" id="message"
+                         name="message" ng-model="message"
+                         ui-ace="{
+                              useWrapMode : true,
+                              theme:'chrome',
+                              mode: 'json'}">
+                    </div>
                 </div>
                 <div class="col-md-3">
                     <button class="btn btn-info btn-block btn-lg" ng-disabled="verificationInProgress" ng-click="verify()">Verify</button>


### PR DESCRIPTION
Added Ace editor for ease of use.
It can be customized with themes, I chose to go with `chrome` theme as it looks pretty neutral.
Upon clicking `verify` if json is valid it will be reformatted.
If it is not walid we will see a red cross on the side that can be hovered on to get an error message.
Below is a screenshoot how the editor with reformatted json looks like.( I added a invalid fragment to demonstrate error message)
![Zrzut ekranu 2021-10-15 o 13 30 19](https://user-images.githubusercontent.com/39651555/137480231-a6a5bf0d-4de6-44d0-80d3-10dc1ddb17fd.png)

closes #1308
