### PR TITLE
Add ace editor to schemaMessage field

### DIFF
--- a/hermes-console/static/css/main.css
+++ b/hermes-console/static/css/main.css
@@ -116,4 +116,5 @@ footer {
     display: block;
 }
 
-.ace_editor { height: 300px; }
+.ace_editor_debug { height: 300px; }
+.ace_editor_schema { height: 500px; }

--- a/hermes-console/static/index.html
+++ b/hermes-console/static/index.html
@@ -75,6 +75,8 @@
         <script src="js/bootstrap.js"></script>
         <script type="text/javascript" src="components/ace-builds/src-min-noconflict/ace.js"></script>
         <script type="text/javascript" src="components/angular-ui-ace/ui-ace.js"></script>
+        <script type="text/javascript" src="components/ace-builds/src-min-noconflict/ext-language_tools.js"></script>
+
     </head>
     <body>
         <nav class="navbar navbar-default" role="navigation">

--- a/hermes-console/static/js/console/topic/TopicController.js
+++ b/hermes-console/static/js/console/topic/TopicController.js
@@ -286,5 +286,11 @@ topics.controller('TopicEditController', ['TOPIC_CONFIG', 'TopicRepository', '$s
                         passwordService.reset();
                     });
         };
+         $scope.beautifyText = function (){
+            const obj_message = JSON.parse($scope.messageSchema);
+            if (obj_message !== undefined) {
+                $scope.messageSchema = JSON.stringify(obj_message, null, 4);
+            }
+        };
 
     }]);

--- a/hermes-console/static/partials/modal/debugFilters.html
+++ b/hermes-console/static/partials/modal/debugFilters.html
@@ -3,7 +3,7 @@
         <form name="debuggerForm" class="form-horizontal" role="form">
             <div class="form-group">
                 <div class="col-md-9">
-                    <div class="form-control" id="message"
+                    <div class="form-control ace_editor_debug" id="message"
                          name="message" ng-model="message"
                          ui-ace="{
                               useWrapMode : true,

--- a/hermes-console/static/partials/modal/editTopic.html
+++ b/hermes-console/static/partials/modal/editTopic.html
@@ -180,9 +180,19 @@
 }
                         </pre>
                     </div>
-                    <textarea class="form-control" id="messageSchema" ng-required="topic.contentType === 'AVRO'"
-                              name="messageSchema" placeholder="Message schema"
-                              ng-model="messageSchema" rows="20"></textarea>
+                    <div class="form-control ace_editor_schema" id="messageSchema" ng-required="topic.contentType === 'AVRO'"
+                         name="message" ng-model="messageSchema"
+                         ui-ace="{
+                            require: ['ace/ext/language_tools'],
+                            advanced: {
+                                enableBasicAutocompletion: true,
+                                enableLiveAutocompletion: true
+                            },
+                            useWrapMode : true,
+                            theme:'chrome',
+                            mode: 'json'}">
+                    </div>
+                    <button class="btn btn-info pull-right margin-top-10" ng-click="beautifyText()">Beautify</button>
                 </div>
             </div>
         </form>


### PR DESCRIPTION
Hey
In this PR I have added `Ace` editor to message schema edit field.
While I was at it I decided that some basic autocompletion can come in handy here, so I added it.
I would be grateful for any css advices as I'm pretty terrible at it :P

Below is the screenshot of editor with some autocompletion 
![Zrzut ekranu 2021-10-20 o 19 22 18](https://user-images.githubusercontent.com/39651555/138142181-2e58d057-027a-43b1-9d73-41d51dac6c45.png)
:)