### PR TITLE
[hermes-management] restore text/html content-type for web pages

### DIFF
--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/api/UiResource.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/api/UiResource.java
@@ -4,10 +4,14 @@ import org.glassfish.jersey.server.mvc.Viewable;
 
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+
+import static javax.ws.rs.core.MediaType.TEXT_HTML;
 
 @Path("/")
 public class UiResource {
     @GET
+    @Produces(TEXT_HTML)
     public Viewable getIndex() {
         return new Viewable("/index.html");
     }


### PR DESCRIPTION
This PR fixes regression introduced in https://github.com/allegro/hermes/pull/1381. Currently HTML content is returned with content type \*/\*.

Before https://github.com/allegro/hermes/pull/1381:
```sh
$ curl http://localhost:8090/ui/index.html -I -s | grep -i content-type:
Content-Type: text/html
$ curl http://localhost:8090/ui/index.html\#/groups -I -s | grep -i content-type:
Content-Type: text/html
```

Current behaviour:
```sh
$ curl http://localhost:8090/ -I -s | grep -i content-type:
Content-Type: */*;charset=UTF-8
$ curl http://localhost:8090/\#/groups -I -s | grep -i content-type:
Content-Type: */*;charset=UTF-8
```

After fix:
```sh
$ curl http://localhost:8090/ -I -s | grep -i content-type:
Content-Type: text/html;charset=UTF-8
$ curl http://localhost:8090/\#/groups -I -s | grep -i content-type:
Content-Type: text/html;charset=UTF-8
```