### PR TITLE
Log backup storage size on shutdown

### DIFF
--- a/hermes-benchmark/src/jmh/java/pl/allegro/tech/hermes/benchmark/MessageRepositoryBenchmark.java
+++ b/hermes-benchmark/src/jmh/java/pl/allegro/tech/hermes/benchmark/MessageRepositoryBenchmark.java
@@ -1,0 +1,128 @@
+package pl.allegro.tech.hermes.benchmark;
+
+import com.google.common.io.Files;
+import net.openhft.chronicle.map.ChronicleMap;
+import net.openhft.chronicle.map.ChronicleMapBuilder;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+import pl.allegro.tech.hermes.api.Topic;
+import pl.allegro.tech.hermes.frontend.buffer.BackupMessage;
+import pl.allegro.tech.hermes.frontend.buffer.MessageRepository;
+import pl.allegro.tech.hermes.frontend.buffer.chronicle.ChronicleMapCreationException;
+import pl.allegro.tech.hermes.frontend.buffer.chronicle.ChronicleMapEntryValue;
+import pl.allegro.tech.hermes.frontend.buffer.chronicle.ChronicleMapMessageRepository;
+import pl.allegro.tech.hermes.frontend.publishing.message.JsonMessage;
+import pl.allegro.tech.hermes.frontend.publishing.message.Message;
+import pl.allegro.tech.hermes.frontend.publishing.message.MessageIdGenerator;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+import static pl.allegro.tech.hermes.test.helper.builder.TopicBuilder.topic;
+
+@Fork(1)
+@Warmup(iterations = 5)
+@Measurement(iterations = 5)
+@Threads(value = 100)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+public class MessageRepositoryBenchmark {
+
+    @State(Scope.Benchmark)
+    public static class Repositories {
+        private static final int ENTRIES = 100;
+        private static final int AVERAGE_MESSAGE_SIZE = 600;
+
+        MessageRepository hermesImplMessageRepository;
+        MessageRepository baselineMessageRepository;
+
+        Message message;
+        Topic topic;
+
+        @Setup
+        public void setup() {
+            message = generateMessage();
+            topic = topic("groupName.topic").build();
+
+            hermesImplMessageRepository = new ChronicleMapMessageRepository(prepareFile(), ENTRIES, AVERAGE_MESSAGE_SIZE);
+            baselineMessageRepository = new BaselineChronicleMapMessageRepository(prepareFile(), ENTRIES, AVERAGE_MESSAGE_SIZE);
+        }
+
+        private Message generateMessage() {
+            byte[] messageContent = UUID.randomUUID().toString().getBytes();
+            String id = MessageIdGenerator.generate();
+            return new JsonMessage(id, messageContent, System.currentTimeMillis(), "partition-key");
+        }
+
+        private File prepareFile() {
+            String baseDir = Files.createTempDir().getAbsolutePath();
+            return new File(baseDir, "messages.dat");
+        }
+    }
+
+    @Benchmark
+    public void hermesImplSave(Repositories repositories) {
+        repositories.hermesImplMessageRepository.save(repositories.message, repositories.topic);
+    }
+
+    @Benchmark
+    public void baselineSave(Repositories repositories) {
+        repositories.baselineMessageRepository.save(repositories.message, repositories.topic);
+    }
+
+    public static class BaselineChronicleMapMessageRepository implements MessageRepository {
+        private static final boolean SAME_BUILDER_CONFIG = false;
+
+        private final ChronicleMap<String, ChronicleMapEntryValue> map;
+
+        public BaselineChronicleMapMessageRepository(File file, int entries, int averageMessageSize) {
+            try {
+                map = ChronicleMapBuilder.of(String.class, ChronicleMapEntryValue.class)
+                        .constantKeySizeBySample(MessageIdGenerator.generate())
+                        .averageValueSize(averageMessageSize)
+                        .entries(entries)
+                        .createOrRecoverPersistedTo(file, SAME_BUILDER_CONFIG);
+            } catch (IOException e) {
+                throw new ChronicleMapCreationException(e);
+            }
+        }
+
+        @Override
+        public void save(Message message, Topic topic) {
+            ChronicleMapEntryValue entryValue = new ChronicleMapEntryValue(
+                    message.getData(),
+                    message.getTimestamp(),
+                    topic.getQualifiedName(),
+                    message.getPartitionKey()
+            );
+            map.put(message.getId(), entryValue);
+        }
+
+        @Override
+        public void delete(String messageId) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public List<BackupMessage> findAll() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void close() {
+            throw new UnsupportedOperationException();
+        }
+    }
+}

--- a/hermes-frontend/build.gradle
+++ b/hermes-frontend/build.gradle
@@ -6,7 +6,7 @@ dependencies {
 
     compile group: 'io.undertow', name: 'undertow-core', version: versions.undertow
     compile group: 'org.apache.commons', name: 'commons-lang3', version: '3.0'
-    compile group: 'net.openhft', name: 'chronicle-map', version: '3.16.0'
+    compile group: 'net.openhft', name: 'chronicle-map', version: '3.16.4'
     compile group: 'commons-io', name: 'commons-io', version: '2.4'
     compile group: 'net.jodah', name: 'failsafe', version: versions.failsafe
 

--- a/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/buffer/chronicle/ChronicleMapClosedException.java
+++ b/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/buffer/chronicle/ChronicleMapClosedException.java
@@ -1,0 +1,8 @@
+package pl.allegro.tech.hermes.frontend.buffer.chronicle;
+
+public class ChronicleMapClosedException extends RuntimeException {
+
+    public ChronicleMapClosedException(String message) {
+        super(message);
+    }
+}

--- a/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/buffer/chronicle/ChronicleMapMessageRepository.java
+++ b/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/buffer/chronicle/ChronicleMapMessageRepository.java
@@ -14,6 +14,9 @@ import pl.allegro.tech.hermes.frontend.publishing.message.MessageIdGenerator;
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.stream.Collectors;
 
 public class ChronicleMapMessageRepository implements MessageRepository {
@@ -22,16 +25,20 @@ public class ChronicleMapMessageRepository implements MessageRepository {
 
     private static final boolean SAME_BUILDER_CONFIG = false;
 
-    private ChronicleMap<String, ChronicleMapEntryValue> map;
+    private final ChronicleMap<String, ChronicleMapEntryValue> map;
+
+    private boolean closed = false;
+    private final ReadWriteLock closeLock = new ReentrantReadWriteLock();
 
     public ChronicleMapMessageRepository(File file, int entries, int averageMessageSize) {
         logger.info("Creating backup storage in path: {}", file.getAbsolutePath());
         try {
-            map = ChronicleMapBuilder.of(String.class, ChronicleMapEntryValue.class)
+            ChronicleMapBuilder<String, ChronicleMapEntryValue> builder = ChronicleMapBuilder.of(String.class, ChronicleMapEntryValue.class)
                     .constantKeySizeBySample(MessageIdGenerator.generate())
                     .averageValueSize(averageMessageSize)
-                    .entries(entries)
-                    .createOrRecoverPersistedTo(file, SAME_BUILDER_CONFIG);
+                    .entries(entries);
+            builder.setPreShutdownAction(new LoggingMapSizePreShutdownHook());
+            map = builder.createOrRecoverPersistedTo(file, SAME_BUILDER_CONFIG);
         } catch (IOException e) {
             logger.error("Failed to load backup storage file from path {}", file.getAbsoluteFile(), e);
             throw new ChronicleMapCreationException(e);
@@ -40,12 +47,21 @@ public class ChronicleMapMessageRepository implements MessageRepository {
 
     public ChronicleMapMessageRepository(File file, int entries, int averageMessageSize, HermesMetrics hermesMetrics) {
         this(file, entries, averageMessageSize);
-        hermesMetrics.registerMessageRepositorySizeGauge(() -> map.size());
+        hermesMetrics.registerMessageRepositorySizeGauge(map::size);
     }
 
     @Override
     public void save(Message message, Topic topic) {
-        map.put(message.getId(), new ChronicleMapEntryValue(message.getData(), message.getTimestamp(), topic.getQualifiedName(), message.getPartitionKey()));
+        Lock lock = closeLock.readLock();
+        lock.lock();
+        try {
+            if (closed) {
+                throw new ChronicleMapClosedException("Backup storage is closed. Unable to add new messages.");
+            }
+            map.put(message.getId(), new ChronicleMapEntryValue(message.getData(), message.getTimestamp(), topic.getQualifiedName(), message.getPartitionKey()));
+        } finally {
+            lock.unlock();
+        }
     }
 
     @Override
@@ -65,5 +81,22 @@ public class ChronicleMapMessageRepository implements MessageRepository {
 
     private BackupMessage toBackupMessage(String id, ChronicleMapEntryValue entryValue) {
         return new BackupMessage(id, entryValue.getData(), entryValue.getTimestamp(), entryValue.getQualifiedTopicName(), entryValue.getPartitionKey());
+    }
+
+    private class LoggingMapSizePreShutdownHook implements Runnable {
+
+        @Override
+        public void run() {
+            Lock lock = closeLock.writeLock();
+            lock.lock();
+            try {
+                closed = true;
+                if (map != null) {
+                    logger.info("Closing backup storage with {} messages.", map.size());
+                }
+            } finally {
+                lock.unlock();
+            }
+        }
     }
 }


### PR DESCRIPTION
Added additional logging as we would like to know if there are any messages in the backup storage while stopping hermes-frontend instances. 

Benchmarks show that the lock added in `ChronicleMapMessageRepository` has no significant performance impact:

```
./gradlew jmh -Pjmh.timeOnIteration=10s -Pjmh.timeOnWarmupIteration=10s -Pjmh.threads=200

...

Benchmark                                  Mode  Cnt           Score            Error  Units
MessageRepositoryBenchmark.baselineSave    avgt    4  2491959675.090 ± 6214378958.477  ns/op
MessageRepositoryBenchmark.hermesImplSave  avgt    4  2526235175.176 ± 3376593190.719  ns/op
```