### PR TITLE
Fixed unstable KafkaRetransmissionServiceTest and updated dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -74,7 +74,7 @@ allprojects {
             undertow          : '2.0.29.Final',
             spring_web        : '5.1.5.RELEASE',
             failsafe          : '2.3.1',
-            junit_jupiter     : '5.4.2',
+            junit_jupiter     : '5.8.2',
             testcontainers    : '1.15.3'
     ]
 

--- a/build.gradle
+++ b/build.gradle
@@ -59,7 +59,7 @@ allprojects {
             kafka             : '2.1.1',
             guava             : '23.0',
             jackson           : '2.11.4',
-            jersey            : '2.26',
+            jersey            : '2.35',
             jetty             : '9.4.19.v20190610',
             curator           : '2.12.0',
             dropwizard_metrics: '4.1.0',

--- a/hermes-api/src/main/java/pl/allegro/tech/hermes/api/OfflineRetransmissionRequest.java
+++ b/hermes-api/src/main/java/pl/allegro/tech/hermes/api/OfflineRetransmissionRequest.java
@@ -4,7 +4,10 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.time.Instant;
 import javax.validation.constraints.NotNull;
+
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import org.hibernate.validator.constraints.NotEmpty;
+import pl.allegro.tech.hermes.api.jackson.InstantIsoSerializer;
 
 public class OfflineRetransmissionRequest {
     @NotEmpty
@@ -36,10 +39,12 @@ public class OfflineRetransmissionRequest {
         return targetTopic;
     }
 
+    @JsonSerialize(using = InstantIsoSerializer.class)
     public Instant getStartTimestamp() {
         return startTimestamp;
     }
 
+    @JsonSerialize(using = InstantIsoSerializer.class)
     public Instant getEndTimestamp() {
         return endTimestamp;
     }

--- a/hermes-api/src/main/java/pl/allegro/tech/hermes/api/OffsetRetransmissionDate.java
+++ b/hermes-api/src/main/java/pl/allegro/tech/hermes/api/OffsetRetransmissionDate.java
@@ -1,6 +1,8 @@
 package pl.allegro.tech.hermes.api;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import pl.allegro.tech.hermes.api.jackson.OffsetDateTimeSerializer;
 
 import javax.validation.constraints.NotNull;
 import java.time.OffsetDateTime;
@@ -14,6 +16,7 @@ public class OffsetRetransmissionDate {
         this.retransmissionDate = retransmissionDate;
     }
 
+    @JsonSerialize(using = OffsetDateTimeSerializer.class)
     public OffsetDateTime getRetransmissionDate() {
         return retransmissionDate;
     }

--- a/hermes-api/src/main/java/pl/allegro/tech/hermes/api/jackson/OffsetDateTimeSerializer.java
+++ b/hermes-api/src/main/java/pl/allegro/tech/hermes/api/jackson/OffsetDateTimeSerializer.java
@@ -1,0 +1,18 @@
+package pl.allegro.tech.hermes.api.jackson;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+
+import java.io.IOException;
+import java.time.OffsetDateTime;
+
+import static java.time.format.DateTimeFormatter.ISO_OFFSET_DATE_TIME;
+
+public class OffsetDateTimeSerializer extends JsonSerializer<OffsetDateTime> {
+
+    @Override
+    public void serialize(OffsetDateTime value, JsonGenerator jgen, SerializerProvider provider) throws IOException {
+       jgen.writeString(ISO_OFFSET_DATE_TIME.format(value));
+    }
+}

--- a/hermes-management/build.gradle
+++ b/hermes-management/build.gradle
@@ -12,7 +12,7 @@ dependencies {
     compile group: 'net.sf.jopt-simple', name: 'jopt-simple', version: '4.8'
     compile group: 'org.glassfish.jersey.ext', name: 'jersey-mvc-freemarker', version: versions.jersey
 
-    compile group: 'com.wordnik', name: 'swagger-jersey2-jaxrs_2.10', version: '1.3.4'
+    compile 'io.swagger:swagger-jersey2-jaxrs:1.6.3'
 
     compile group: 'org.apache.kafka', name: 'kafka-clients', version: versions.kafka
 

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/api/BlacklistEndpoint.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/api/BlacklistEndpoint.java
@@ -1,7 +1,7 @@
 package pl.allegro.tech.hermes.management.api;
 
-import com.wordnik.swagger.annotations.Api;
-import com.wordnik.swagger.annotations.ApiOperation;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import pl.allegro.tech.hermes.api.BlacklistStatus;

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/api/ConsoleEndpoint.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/api/ConsoleEndpoint.java
@@ -1,7 +1,7 @@
 package pl.allegro.tech.hermes.management.api;
 
-import com.wordnik.swagger.annotations.Api;
-import com.wordnik.swagger.annotations.ApiOperation;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
 import org.springframework.stereotype.Component;
 import pl.allegro.tech.hermes.management.domain.console.ConsoleService;
 

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/api/GroupsEndpoint.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/api/GroupsEndpoint.java
@@ -1,7 +1,7 @@
 package pl.allegro.tech.hermes.management.api;
 
-import com.wordnik.swagger.annotations.Api;
-import com.wordnik.swagger.annotations.ApiOperation;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import pl.allegro.tech.hermes.api.Group;

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/api/MigrationsEndpoint.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/api/MigrationsEndpoint.java
@@ -1,8 +1,8 @@
 package pl.allegro.tech.hermes.management.api;
 
 import com.google.common.collect.ImmutableList;
-import com.wordnik.swagger.annotations.Api;
-import com.wordnik.swagger.annotations.ApiOperation;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/api/ModeEndpoint.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/api/ModeEndpoint.java
@@ -1,7 +1,7 @@
 package pl.allegro.tech.hermes.management.api;
 
-import com.wordnik.swagger.annotations.Api;
-import com.wordnik.swagger.annotations.ApiOperation;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
 import org.springframework.stereotype.Component;
 import pl.allegro.tech.hermes.management.api.auth.Roles;
 import pl.allegro.tech.hermes.management.domain.mode.ModeService;

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/api/OAuthProvidersEndpoint.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/api/OAuthProvidersEndpoint.java
@@ -1,7 +1,7 @@
 package pl.allegro.tech.hermes.management.api;
 
-import com.wordnik.swagger.annotations.Api;
-import com.wordnik.swagger.annotations.ApiOperation;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import pl.allegro.tech.hermes.api.OAuthProvider;

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/api/OfflineRetransmissionEndpoint.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/api/OfflineRetransmissionEndpoint.java
@@ -1,6 +1,6 @@
 package pl.allegro.tech.hermes.management.api;
 
-import com.wordnik.swagger.annotations.Api;
+import io.swagger.annotations.Api;
 import java.util.List;
 import javax.validation.Valid;
 import javax.ws.rs.Consumes;

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/api/OwnersEndpoint.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/api/OwnersEndpoint.java
@@ -1,8 +1,8 @@
 package pl.allegro.tech.hermes.management.api;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.wordnik.swagger.annotations.Api;
-import com.wordnik.swagger.annotations.ApiOperation;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import pl.allegro.tech.hermes.api.Owner;

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/api/RolesEndpoint.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/api/RolesEndpoint.java
@@ -1,7 +1,7 @@
 package pl.allegro.tech.hermes.management.api;
 
-import com.wordnik.swagger.annotations.Api;
-import com.wordnik.swagger.annotations.ApiOperation;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
 import org.springframework.stereotype.Component;
 import pl.allegro.tech.hermes.management.api.auth.Roles;
 

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/api/SchemaEndpoint.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/api/SchemaEndpoint.java
@@ -1,6 +1,6 @@
 package pl.allegro.tech.hermes.management.api;
 
-import com.wordnik.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiOperation;
 import org.springframework.beans.factory.annotation.Autowired;
 import pl.allegro.tech.hermes.api.RawSchema;
 import pl.allegro.tech.hermes.api.Topic;

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/api/SubscriptionsEndpoint.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/api/SubscriptionsEndpoint.java
@@ -1,6 +1,6 @@
 package pl.allegro.tech.hermes.management.api;
 
-import com.wordnik.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiOperation;
 import org.springframework.beans.factory.annotation.Autowired;
 import pl.allegro.tech.hermes.api.ConsumerGroup;
 import pl.allegro.tech.hermes.api.MessageTrace;
@@ -211,6 +211,7 @@ public class SubscriptionsEndpoint {
     }
 
     @PUT
+    @Logged
     @Consumes(APPLICATION_JSON)
     @Produces(APPLICATION_JSON)
     @Path("/{subscriptionName}/retransmission")

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/api/SubscriptionsEndpoint.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/api/SubscriptionsEndpoint.java
@@ -211,7 +211,6 @@ public class SubscriptionsEndpoint {
     }
 
     @PUT
-    @Logged
     @Consumes(APPLICATION_JSON)
     @Produces(APPLICATION_JSON)
     @Path("/{subscriptionName}/retransmission")

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/api/TopicsEndpoint.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/api/TopicsEndpoint.java
@@ -1,7 +1,7 @@
 package pl.allegro.tech.hermes.management.api;
 
-import com.wordnik.swagger.annotations.Api;
-import com.wordnik.swagger.annotations.ApiOperation;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import pl.allegro.tech.hermes.api.MessageTextPreview;

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/api/WorkloadConstraintsEndpoint.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/api/WorkloadConstraintsEndpoint.java
@@ -1,7 +1,7 @@
 package pl.allegro.tech.hermes.management.api;
 
-import com.wordnik.swagger.annotations.Api;
-import com.wordnik.swagger.annotations.ApiOperation;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
 import org.springframework.stereotype.Component;
 import pl.allegro.tech.hermes.api.SubscriptionConstraints;
 import pl.allegro.tech.hermes.api.SubscriptionName;

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/api/mappers/ConstraintViolationMapper.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/api/mappers/ConstraintViolationMapper.java
@@ -4,6 +4,7 @@ import com.google.common.base.Function;
 import com.google.common.base.Joiner;
 import com.google.common.collect.Lists;
 import org.glassfish.jersey.server.validation.ValidationError;
+import org.glassfish.jersey.server.validation.ValidationErrorData;
 import org.glassfish.jersey.server.validation.internal.ValidationHelper;
 import pl.allegro.tech.hermes.api.ErrorCode;
 
@@ -33,15 +34,15 @@ public class ConstraintViolationMapper extends AbstractExceptionMapper<Constrain
     private String prepareMessage(ConstraintViolationException ex) {
         List<String> errors = Lists.transform(
                 ValidationHelper.constraintViolationToValidationErrors(ex),
-                new ValidationErrorConverter()
+                new ValidationErrorDataConverter()
         );
 
         return Joiner.on("; ").join(errors);
     }
 
-    private static final class ValidationErrorConverter implements Function<ValidationError, String> {
+    private static final class ValidationErrorDataConverter implements Function<ValidationErrorData, String> {
         @Override
-        public String apply(ValidationError input) {
+        public String apply(ValidationErrorData input) {
             return input.getPath() + " " + input.getMessage();
         }
     }

--- a/hermes-test-helper/build.gradle
+++ b/hermes-test-helper/build.gradle
@@ -36,6 +36,7 @@ dependencies {
     compile group: 'org.testng', name: 'testng', version: '6.8.8'
     compile group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.13'
     compile group: 'com.jayway.jsonpath', name: 'json-path', version: '2.5.0'
+    compile group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: versions.jackson
 
     compile group: 'org.apache.oltu.oauth2', name: 'org.apache.oltu.oauth2.authzserver', version: '1.0.2'
     compile group: 'org.apache.oltu.oauth2', name: 'org.apache.oltu.oauth2.resourceserver', version: '1.0.2'

--- a/hermes-test-helper/src/main/java/pl/allegro/tech/hermes/test/helper/client/Hermes.java
+++ b/hermes-test-helper/src/main/java/pl/allegro/tech/hermes/test/helper/client/Hermes.java
@@ -1,5 +1,8 @@
 package pl.allegro.tech.hermes.test.helper.client;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.fasterxml.jackson.jaxrs.json.JacksonJaxbJsonProvider;
 import com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider;
 import org.glassfish.jersey.client.ClientConfig;
 import org.glassfish.jersey.client.ClientProperties;
@@ -19,6 +22,7 @@ import pl.allegro.tech.hermes.api.endpoints.SubscriptionEndpoint;
 import pl.allegro.tech.hermes.api.endpoints.SubscriptionOwnershipEndpoint;
 import pl.allegro.tech.hermes.api.endpoints.TopicEndpoint;
 import pl.allegro.tech.hermes.api.endpoints.UnhealthyEndpoint;
+import pl.allegro.tech.hermes.common.di.factories.ObjectMapperFactory;
 import pl.allegro.tech.hermes.consumers.ConsumerEndpoint;
 
 import javax.ws.rs.Path;
@@ -174,6 +178,11 @@ public class Hermes {
     }
 
     private static ClientBuilder getClientBuilder(ClientConfig clientConfig) {
-        return ClientBuilder.newBuilder().withConfig(clientConfig).register(JacksonJsonProvider.class);
+        return ClientBuilder.newBuilder().withConfig(clientConfig).register(
+                new JacksonJaxbJsonProvider(
+                        new ObjectMapper().registerModule(new JavaTimeModule()),
+                        JacksonJaxbJsonProvider.DEFAULT_ANNOTATIONS
+                )
+        );
     }
 }

--- a/integration/src/integration/java/pl/allegro/tech/hermes/integration/PublishingTest.java
+++ b/integration/src/integration/java/pl/allegro/tech/hermes/integration/PublishingTest.java
@@ -418,7 +418,7 @@ public class PublishingTest extends IntegrationTest {
         assertThat(response).hasStatus(CREATED);
         remoteService.waitUntilReceived();
         long receivedTime = System.currentTimeMillis();
-        assertThat(receivedTime - publishedTime).isGreaterThan(delay);
+        assertThat(receivedTime - publishedTime).isGreaterThanOrEqualTo(delay);
     }
 
     @Test


### PR DESCRIPTION
`KafkaRetransmissionServiceTest` was unstable due to stochastic way of serialising `OffsetDateTime` to JSON format. Sometimes Jersey client in integration tests was serialising `OffsetDateTime` with _ObjectMapper_ having _JavaTimeModule_ registered, sometimes _ObjectMapper_ had no module registered at all. 

When tests were failing, `BeanSerializerFactory` instance was exactly the same one as the one created by `ConfluentSchemaRegistryStarter ` during environment preparation. 

When tests were passing, `BeanSerializerFactory` instance differed from the one created during environment preparation.