### PR TITLE
fix: use jackson 2.11.4 in the whole project

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,7 +59,7 @@ allprojects {
             kafka             : '2.7.0',
             guava             : '23.0',
             jackson           : '2.11.4',
-            jersey            : '2.35',
+            jersey            : '2.26',
             jetty             : '9.4.19.v20190610',
             curator           : '2.12.0',
             dropwizard_metrics: '4.1.0',

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/api/mappers/ConstraintViolationMapper.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/api/mappers/ConstraintViolationMapper.java
@@ -4,7 +4,6 @@ import com.google.common.base.Function;
 import com.google.common.base.Joiner;
 import com.google.common.collect.Lists;
 import org.glassfish.jersey.server.validation.ValidationError;
-import org.glassfish.jersey.server.validation.ValidationErrorData;
 import org.glassfish.jersey.server.validation.internal.ValidationHelper;
 import pl.allegro.tech.hermes.api.ErrorCode;
 
@@ -34,15 +33,15 @@ public class ConstraintViolationMapper extends AbstractExceptionMapper<Constrain
     private String prepareMessage(ConstraintViolationException ex) {
         List<String> errors = Lists.transform(
                 ValidationHelper.constraintViolationToValidationErrors(ex),
-                new ValidationErrorDataConverter()
+                new ValidationErrorConverter()
         );
 
         return Joiner.on("; ").join(errors);
     }
 
-    private static final class ValidationErrorDataConverter implements Function<ValidationErrorData, String> {
+    private static final class ValidationErrorConverter implements Function<ValidationError, String> {
         @Override
-        public String apply(ValidationErrorData input) {
+        public String apply(ValidationError input) {
             return input.getPath() + " " + input.getMessage();
         }
     }


### PR DESCRIPTION
Recently upgraded jersey (from `2.26` to `2.35`) brings jackson `2.12.2` as a transitive dependency, which is not compatible with the version defined explicitly in the project: `2.11.4`. It causes a few issues when hermes itself is pulled in as an external dependency. For now I decided to downgrade jersey. In the next step we can upgrade both dependencies - jersey and jackson. 