### PR TITLE
Fixed Message preview modal

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,11 +38,3 @@ jobs:
         run: ./gradlew assemble
       - name: Run tests with Gradle
         run: ./gradlew ${{ matrix.tests }}
-      - name: Junit report
-        continue-on-error: true
-        uses: allegro-actions/junit-reporter@v1
-        if: ${{ (success() || failure()) && !contains(matrix.tests, 'jmh') && github.actor != 'dependabot[bot]' }}
-        with:
-          path: '**/build/test-results/**/TEST-*.xml'
-          show: 'all'
-          configuration-url: ''

--- a/hermes-console/static/partials/modal/messagePreview.html
+++ b/hermes-console/static/partials/modal/messagePreview.html
@@ -7,15 +7,15 @@
         <div class="panel-body">
 
             <p><strong>Topic</strong> {{topicName}}</p>
-            <p><strong>Message Id:</strong> {{previewedMessage.metadata.id}}</p>
-            <p><strong>Message timestamp:</strong> {{previewedMessage.metadata.timestamp | date:'yyyy-MM-dd HH:mm:ss'}}</p>
+            <p><strong>Message Id:</strong> {{previewedMessage.__metadata.messageId}}</p>
+            <p><strong>Message timestamp:</strong> {{previewedMessage.__metadata.timestamp | date:'yyyy-MM-dd HH:mm:ss'}}</p>
             <p><strong>Partition:</strong> {{partition}}</p>
             <p><strong>Offset:</strong> {{offset}}</p>
 
             <p>
                 <strong>Message:</strong>
                         <pre class="pre-scrollable">
-{{previewedMessage.message}}
+{{previewedMessage}}
                         </pre>
             </p>
 


### PR DESCRIPTION
Previously, Message preview modal was rendering data in incorrect way.

For `/topics/{topic}/preview/cluster/{cluster}/partition/x/offset/y` server response JSON:
```json
{
    "id": 123457,
    "__metadata": {
        "x-request-id": "685bce4e-1254-430e-8678-7caf905d2c2b",
        "messageId": "a71c5e1f-4213-4c07-93a1-92cbcffef189",
        "timestamp": "1642513311760"
    }
}
```

messagePreview modal was trying to render response by accessing:
```
metadata.id
metadata.timestamp
message
```

which was invalid and was resulting in empty fields rendered for final user.

<img width="1262" alt="Screenshot 2022-01-19 at 08 33 56" src="https://user-images.githubusercontent.com/16356036/150084811-6a63bfaa-6366-4afc-88fe-bbc150b56222.png">