### PR TITLE
Fixed issue with inconsistent KafkaRawMessageReader reads resulting in both 200s and 404s.

### DIFF
--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/infrastructure/kafka/service/KafkaRawMessageReader.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/infrastructure/kafka/service/KafkaRawMessageReader.java
@@ -33,6 +33,7 @@ public class KafkaRawMessageReader {
 
         try {
             kafkaConsumer.assign(Collections.singleton(topicPartition));
+            kafkaConsumer.poll(0);
             kafkaConsumer.seek(topicPartition, offset);
             ConsumerRecords<byte[], byte[]> records = kafkaConsumer.poll(Duration.ofMillis(pollTimeoutMillis));
             for (ConsumerRecord<byte[], byte[]> record : records.records(topicPartition)) {


### PR DESCRIPTION
# Fix non-deterministing fetching message preview from Kafka

**Description of the problem:**

When fetching message preview from Kafka by using `@Path("/{topicName}/preview/cluster/{brokersClusterName}/partition/{partition}/offset/{offset}")` endpoint, result was *"sometimes"* 200, and *"sometimes"* 404 (for valid partition and offset params). After investigation I've found that way to reproduce this bug is:
1. Start hermes-management,
2. Call `/partition/{partition}/offset/{offset}` endpoint with valid params will result in 200 response,
3. Wait more than 60 seconds,
4. Call `/partition/{partition}/offset/{offset}` again, and it will response with 404,
5. Then, immediately after 404 perform another `/partition/{partition}/offset/{offset}` call - this time, it will result wit 200 response.

It occurred that waiting more than 60 seconds between calls causes 404 error. These 60 seconds are `KafkaConsumerPoolConfig.cacheExpirationSeconds` param, which value is defined in `KafkaProperties.KafkaConsumer.cacheExpirationSeconds = 60;`.

`/partition/{partition}/offset/{offset}` endpoint underneath reads message from Kafka by using KafkaConsumer from KafkaConsumerPool. This pool has expiration policy `expireAfterAccess` set for 60 seconds, so new KafkaConsumer is created and used to read message from Kafka, when previous one is expired.

Reading for the first time:
```
11:13:22.144 o.a.k.clients.consumer.KafkaConsumer     : [Consumer clientId=consumer-offsetChecker_RETRANSMISSION_GROUP-1, groupId=offsetChecker_RETRANSMISSION_GROUP] Subscribed to partition(s): com.example.events.clicks2-4
11:13:22.147 o.a.k.clients.consumer.KafkaConsumer     : [Consumer clientId=consumer-offsetChecker_RETRANSMISSION_GROUP-1, groupId=offsetChecker_RETRANSMISSION_GROUP] Seeking to offset 3 for partition com.example.events.clicks2-4
11:13:22.160 org.apache.kafka.clients.Metadata        : [Consumer clientId=consumer-offsetChecker_RETRANSMISSION_GROUP-1, groupId=offsetChecker_RETRANSMISSION_GROUP] Cluster ID: WTRzZ6cFRfa2NkooxGWIuA
```
consumer `consumer-offsetChecker_RETRANSMISSION_GROUP-1` is created and subscribed to test partition.

When I've fetched `/partition/{partition}/offset/{offset}` endpoint after +60 seconds:
```
Removing consumer...

11:14:26.561 org.apache.kafka.common.metrics.Metrics  : Metrics scheduler closed
11:14:26.561 org.apache.kafka.common.metrics.Metrics  : Closing reporter org.apache.kafka.common.metrics.JmxReporter
11:14:26.561 org.apache.kafka.common.metrics.Metrics  : Metrics reporters closed
11:14:26.566 o.a.kafka.common.utils.AppInfoParser     : App info kafka.consumer for consumer-offsetChecker_RETRANSMISSION_GROUP-1 unregistered

Removed consumer.

11:14:26.573 o.a.k.clients.consumer.KafkaConsumer     : [Consumer clientId=consumer-offsetChecker_RETRANSMISSION_GROUP-2, groupId=offsetChecker_RETRANSMISSION_GROUP] Subscribed to partition(s): com.example.events.clicks2-4
11:14:26.573 o.a.k.clients.consumer.KafkaConsumer     : [Consumer clientId=consumer-offsetChecker_RETRANSMISSION_GROUP-2, groupId=offsetChecker_RETRANSMISSION_GROUP] Seeking to offset 3 for partition com.example.events.clicks2-4
11:14:26.582 org.apache.kafka.clients.Metadata        : [Consumer clientId=consumer-offsetChecker_RETRANSMISSION_GROUP-2, groupId=offsetChecker_RETRANSMISSION_GROUP] Cluster ID: WTRzZ6cFRfa2NkooxGWIuA

11:14:26.624 p.a.t.h.m.i.k.s.KafkaRawMessageReader    : Cannot find message [offset 3, kafka_topic com.example.events.clicks2, partition 4]
11:14:26.630 p.a.t.h.m.i.k.s.KafkaRawMessageReader    : Error during polling kafka message [offset 3, kafka_topic com.example.events.clicks2, partition 4]
```

You can see that consumer `consumer-offsetChecker_RETRANSMISSION_GROUP-1` is removed, and new consumer `consumer-offsetChecker_RETRANSMISSION_GROUP-2` (for the same consumer group `offsetChecker_RETRANSMISSION_GROUP`) is created. But this consumer cannot find any record during poll! Why?

According to [*"Kafka: The Definitive Guide"* by Neha Narkhede, Gwen Shapira, Todd Palino](https://www.oreilly.com/library/view/kafka-the-definitive/9781491936153/ch04.html) | *Chapter 4. Kafka Consumers: Reading Data from Kafka -> Consuming Records with Specific Offsets*

```java
consumer.subscribe(topics, new SaveOffsetOnRebalance(consumer));
consumer.poll(0);

for (TopicPartition partition: consumer.assignment())
    consumer.seek(partition, getOffsetFromDB(partition));

while (true) {
    ConsumerRecords<String, String> records =
        consumer.poll(100);
    ...
}
```

*"When the consumer first starts, after we subscribe to topics, ***we call poll() once to make sure we join a consumer group and get assigned partitions***, and then we immediately seek() to the correct offset in the partitions we are assigned to."*

This first `consumer.poll(0);` is crucial for this function to work. Seek operation might not work immediately after `subscribe()` operation.

It occurs to be known problem in other projects:
- https://github.com/apache/drill/blob/master/contrib/storage-kafka/src/main/java/org/apache/drill/exec/store/kafka/KafkaGroupScan.java#L185

And of course on Stack Overflow :)
- https://stackoverflow.com/questions/54988037/kafks-consumer-poll-returns-no-data
- https://stackoverflow.com/questions/53089007/apache-kafka-seek-and-assignment-reliable-read-from-beginning

## Additional comment
Using `kafkaConumer.poll(0)` is not ideal - `poll(long)` method is deprecated, but we cannot use `poll(Duration)`. Why? It is because _poll(long)_ is blocking when waiting for consumer assignement. _poll(Duration)_, is blocking as long as defined in the Duration, whether or not there is a consumer assignment. More informations about this issue can be found in this article: https://www.jesse-anderson.com/2020/09/kafkas-got-a-brand-new-poll/ and Kafka's JIRA ticket: https://issues.apache.org/jira/browse/KAFKA-9882.