### PR TITLE
Added possibility to define a clickable link to topic and subscription owner

### DIFF
--- a/hermes-api/src/main/java/pl/allegro/tech/hermes/api/Owner.java
+++ b/hermes-api/src/main/java/pl/allegro/tech/hermes/api/Owner.java
@@ -1,19 +1,23 @@
 package pl.allegro.tech.hermes.api;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
-
 import java.util.Objects;
 
 public class Owner {
 
     private final String id;
     private final String name;
+    private final String url;
 
-    @JsonCreator
-    public Owner(@JsonProperty("id") String id, @JsonProperty("name") String name) {
+    public Owner(String id, String name) {
         this.id = id;
         this.name = name;
+        this.url = null;
+    }
+
+    public Owner(String id, String name, String url) {
+        this.id = id;
+        this.name = name;
+        this.url = url;
     }
 
     public String getId() {
@@ -24,18 +28,21 @@ public class Owner {
         return name;
     }
 
+    public String getUrl() {
+        return url;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-        Owner that = (Owner) o;
-        return Objects.equals(id, that.id) &&
-                Objects.equals(name, that.name);
+        Owner owner = (Owner) o;
+        return Objects.equals(id, owner.id) && Objects.equals(name, owner.name) && Objects.equals(url, owner.url);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, name);
+        return Objects.hash(id, name, url);
     }
 
     @Override
@@ -43,7 +50,7 @@ public class Owner {
         return "Owner{" +
                 "id='" + id + '\'' +
                 ", name='" + name + '\'' +
+                ", url='" + url + '\'' +
                 '}';
     }
-
 }

--- a/hermes-console/static/js/console/owner/OwnerName.js
+++ b/hermes-console/static/js/console/owner/OwnerName.js
@@ -4,9 +4,11 @@ owner.controller('OwnerNameController', ['$scope', 'OwnerRepository', function (
         if (newOwner !== undefined && newOwner.id && newOwner.source) {
             ownerRepository.getOwner(newOwner.source, newOwner.id).then(function (owner) {
                 $scope.name = owner.name;
+                $scope.url = owner.url ? owner.url : null;
             });
         } else {
             $scope.name = "";
+            $scope.url = null;
         }
     }, true);
 }]);
@@ -14,7 +16,7 @@ owner.directive('ownerName', function () {
     return {
         controller: 'OwnerNameController',
         restrict: 'E',
-        template: '{{name}}',
+        templateUrl: 'partials/ownerName.html',
         scope: {
             owner: '='
         }

--- a/hermes-console/static/partials/ownerName.html
+++ b/hermes-console/static/partials/ownerName.html
@@ -1,0 +1,2 @@
+<a ng-if="!url" style="pointer-events: none; cursor: default; color: inherit">{{name}}</a>
+<a ng-if="url" ng-href="{{url}}">{{name}}</a>


### PR DESCRIPTION
This PR adds possibility for `OwnerSource` to define url for each returned `Owner`. Owner's url is used in _hermes-console_ in _topic_ and _subscription_ views. 

**How it looks?**

When there is no url provided, then owner is not-clickable:
<img width="585" alt="Screenshot 2022-01-27 at 11 36 41" src="https://user-images.githubusercontent.com/16356036/151344736-74d64b30-0fcf-4c12-9e11-7e12c283cc6d.png">

But if call to `/sources/{source}/{id}` will return Owner with url, then owner has a proper link:
<img width="589" alt="Screenshot 2022-01-27 at 11 35 51" src="https://user-images.githubusercontent.com/16356036/151345014-727d12ad-74b5-4e84-aa3b-dc9712c2c874.png">
