### PR TITLE
Fix some CI failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ jobs:
       matrix:
         java: [ '8','11' ]
         tests: [ 'check', 'integrationTest', 'jmh -Pjmh.iterations=1 -Pjmh.timeOnIteration=5s -Pjmh.warmupIterations=0' ]
+      fail-fast: false
     name: Java ${{ matrix.java }} ${{ matrix.tests }}
 
     steps:

--- a/hermes-api/src/main/java/pl/allegro/tech/hermes/api/Owner.java
+++ b/hermes-api/src/main/java/pl/allegro/tech/hermes/api/Owner.java
@@ -8,6 +8,12 @@ public class Owner {
     private final String name;
     private final String url;
 
+    public Owner() {
+        this.id = null;
+        this.name = null;
+        this.url = null;
+    }
+
     public Owner(String id, String name) {
         this.id = id;
         this.name = name;

--- a/hermes-test-helper/build.gradle
+++ b/hermes-test-helper/build.gradle
@@ -25,7 +25,7 @@ dependencies {
     compile group: 'org.assertj', name: 'assertj-core', version: '3.3.0'
     compile group: 'net.javacrumbs.json-unit', name: 'json-unit-fluent', version: '1.5.5'
     compile group: 'junit', name: 'junit', version: '4.11'
-    compile group: 'org.testng', name: 'testng', version: '6.8.8'
+    compile group: 'org.testng', name: 'testng', version: '7.4.0'
     compile group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.13'
     compile group: 'com.jayway.jsonpath', name: 'json-path', version: '2.5.0'
     compile group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: versions.jackson

--- a/hermes-test-helper/src/main/java/pl/allegro/tech/hermes/test/helper/retry/Retry.java
+++ b/hermes-test-helper/src/main/java/pl/allegro/tech/hermes/test/helper/retry/Retry.java
@@ -1,5 +1,7 @@
 package pl.allegro.tech.hermes.test.helper.retry;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.testng.IRetryAnalyzer;
 import org.testng.ITestResult;
 
@@ -7,10 +9,12 @@ import static java.lang.Integer.parseInt;
 
 public class Retry implements IRetryAnalyzer {
     private int retryCount = 0;
-    private static int maxRetryCount = parseInt(System.getProperty("tests.retry.count", "2"));
+    private static final int maxRetryCount = parseInt(System.getProperty("tests.retry.count", "2"));
+    private static final Logger logger = LoggerFactory.getLogger(Retry.class);
 
     @Override
     public boolean retry(ITestResult result) {
+        logger.error("Retrying test {}.{}", result.getTestClass().getName(), result.getMethod().getMethodName(), result.getThrowable());
         if (isRetryAvailable()) {
             retryCount++;
             return true;

--- a/hermes-test-helper/src/main/java/pl/allegro/tech/hermes/test/helper/retry/RetryListener.java
+++ b/hermes-test-helper/src/main/java/pl/allegro/tech/hermes/test/helper/retry/RetryListener.java
@@ -9,7 +9,7 @@ public class RetryListener extends TestListenerAdapter {
 
     @Override
     public void onTestFailure(ITestResult result) {
-        IRetryAnalyzer analyzer = result.getMethod().getRetryAnalyzer();
+        IRetryAnalyzer analyzer = result.getMethod().getRetryAnalyzer(result);
         if (analyzer != null && analyzer instanceof Retry) {
             result.setStatus(((Retry) analyzer).isRetryAvailable()? ITestResult.SKIP : ITestResult.FAILURE);
             Reporter.setCurrentTestResult(result);

--- a/hermes-tracker/src/test/java/pl/allegro/tech/hermes/tracker/consumers/AbstractLogRepositoryTest.java
+++ b/hermes-tracker/src/test/java/pl/allegro/tech/hermes/tracker/consumers/AbstractLogRepositoryTest.java
@@ -24,7 +24,7 @@ public abstract class AbstractLogRepositoryTest {
     @BeforeSuite
     public void setUpRetry(ITestContext context) {
         for (ITestNGMethod method : context.getAllTestMethods()) {
-            method.setRetryAnalyzer(new Retry());
+            method.setRetryAnalyzerClass(Retry.class);
         }
     }
 

--- a/hermes-tracker/src/test/java/pl/allegro/tech/hermes/tracker/frontend/AbstractLogRepositoryTest.java
+++ b/hermes-tracker/src/test/java/pl/allegro/tech/hermes/tracker/frontend/AbstractLogRepositoryTest.java
@@ -23,7 +23,7 @@ public abstract class AbstractLogRepositoryTest {
     @BeforeSuite
     public void setUpRetry(ITestContext context) {
         for (ITestNGMethod method : context.getAllTestMethods()) {
-            method.setRetryAnalyzer(new Retry());
+            method.setRetryAnalyzerClass(Retry.class);
         }
     }
 

--- a/integration/src/integration/java/pl/allegro/tech/hermes/integration/PublishingTest.java
+++ b/integration/src/integration/java/pl/allegro/tech/hermes/integration/PublishingTest.java
@@ -126,6 +126,7 @@ public class PublishingTest extends IntegrationTest {
         wait.untilSubscriptionIsActivated(topic, subscription);
         operations.suspendSubscription(topic, subscription);
         wait.untilSubscriptionIsSuspended(topic, subscription);
+        remoteService.reset();
 
         // when
         Response response = publisher.publish(topic.getQualifiedName(), TestMessage.of("hello", "world").body());

--- a/integration/src/integration/java/pl/allegro/tech/hermes/integration/auth/FrontendAuthenticationConfigurationTest.java
+++ b/integration/src/integration/java/pl/allegro/tech/hermes/integration/auth/FrontendAuthenticationConfigurationTest.java
@@ -4,6 +4,8 @@ import com.google.common.collect.Lists;
 import com.google.common.io.Files;
 import io.undertow.security.impl.BasicAuthenticationMechanism;
 import io.undertow.util.StatusCodes;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
@@ -31,6 +33,7 @@ public class FrontendAuthenticationConfigurationTest extends IntegrationTest {
     public static final int FRONTEND_PORT = Ports.nextAvailable();
     public static final String FRONTEND_URL = "http://127.0.0.1:" + FRONTEND_PORT;
 
+    private static final Logger logger = LoggerFactory.getLogger(FrontendAuthenticationConfigurationTest.class);
     private static final String USERNAME = "someUser";
     private static final String PASSWORD = "somePassword123";
     private static final String MESSAGE = TestMessage.of("hello", "world").body();
@@ -88,6 +91,7 @@ public class FrontendAuthenticationConfigurationTest extends IntegrationTest {
         Response response = publisher.publish("someGroup.topicWithAuthorization", MESSAGE, headers);
 
         //then
+        logger.info("Expecting SUCCESSFUL status. Actual {}", response.getStatusInfo().getStatusCode());
         assertThat(response.getStatusInfo().getFamily()).isEqualTo(SUCCESSFUL);
     }
 

--- a/integration/src/integration/java/pl/allegro/tech/hermes/integration/env/HermesIntegrationEnvironment.java
+++ b/integration/src/integration/java/pl/allegro/tech/hermes/integration/env/HermesIntegrationEnvironment.java
@@ -107,7 +107,7 @@ public class HermesIntegrationEnvironment implements EnvironmentAware {
             frontendStarter.start();
 
             for (ITestNGMethod method : context.getAllTestMethods()) {
-                method.setRetryAnalyzer(new Retry());
+                method.setRetryAnalyzerClass(Retry.class);
             }
 
             SharedServices.initialize(STARTERS, zookeeper);


### PR DESCRIPTION
In this PR I'm trying to resolve issues with failing CI.

1. Fixed issue with failing CrowdOwnerSourceIntegrationTest.shouldCrowdServiceBeCalledOnce and CrowdOwnerSourceIntegrationTest.shouldReturnTwoResultsFromCrowd tests
2. [Turned off fast-failing CI](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategyfail-fast)
3. Fixed possible issue in `PublishingTest.shouldNotConsumeMessagesWhenSubscriptionIsSuspended` test which looked this way:
```
2022-01-31T15:57:14.6136865Z Gradle suite > Gradle test > pl.allegro.tech.hermes.integration.PublishingTest.shouldNotConsumeMessagesWhenSubscriptionIsSuspended SKIPPED
2022-01-31T15:57:17.5130401Z 
2022-01-31T15:57:17.5131668Z Gradle suite > Gradle test > pl.allegro.tech.hermes.integration.PublishingTest.shouldNotConsumeMessagesWhenSubscriptionIsSuspended SKIPPED
2022-01-31T15:57:19.8130553Z 
2022-01-31T15:57:19.8131610Z Gradle suite > Gradle test > pl.allegro.tech.hermes.integration.PublishingTest.shouldNotConsumeMessagesWhenSubscriptionIsSuspended FAILED
2022-01-31T15:57:19.8133482Z     java.lang.AssertionError: 
2022-01-31T15:57:19.8133899Z     Expecting empty but was:<[{
2022-01-31T15:57:19.8134272Z       "url" : "/",
2022-01-31T15:57:19.8134693Z       "absoluteUrl" : "http://localhost:18081/",
2022-01-31T15:57:19.8135330Z       "method" : "POST",
2022-01-31T15:57:19.8135823Z       "clientIp" : "127.0.0.1",
2022-01-31T15:57:19.8136179Z       "headers" : {
2022-01-31T15:57:19.8136839Z         "Keep-Alive" : "true",
2022-01-31T15:57:19.8137444Z         "Hermes-Batch-Id" : "b97dd5a9-7faf-4c06-9843-1fa1b6e1c089",
2022-01-31T15:57:19.8137978Z         "Hermes-Retry-Count" : "0",
2022-01-31T15:57:19.8138453Z         "Connection" : "keep-alive",
2022-01-31T15:57:19.8138971Z         "User-Agent" : "Apache-HttpClient/4.5.13 (Java/1.8.0_292)",
2022-01-31T15:57:19.8139386Z         "Host" : "localhost:18081",
2022-01-31T15:57:19.8139814Z         "Content-Length" : "0",
2022-01-31T15:57:19.8140285Z         "Content-Type" : "application/json"
2022-01-31T15:57:19.8140628Z       },
2022-01-31T15:57:19.8140950Z       "cookies" : { },
2022-01-31T15:57:19.8141314Z       "browserProxyRequest" : false,
2022-01-31T15:57:19.8141691Z       "loggedDate" : 1643644638513,
2022-01-31T15:57:19.8142030Z       "bodyAsBase64" : "",
2022-01-31T15:57:19.8142366Z       "body" : "",
2022-01-31T15:57:19.8142698Z       "scheme" : "http",
2022-01-31T15:57:19.8143059Z       "host" : "localhost",
2022-01-31T15:57:19.8143385Z       "port" : 18081,
2022-01-31T15:57:19.8143857Z       "loggedDateString" : "2022-01-31T15:57:18Z",
2022-01-31T15:57:19.8144614Z       "queryParams" : { }
2022-01-31T15:57:19.8150603Z     }]>
2022-01-31T15:57:19.8151341Z         at pl.allegro.tech.hermes.test.helper.endpoint.RemoteServiceEndpoint.makeSureNoneReceived(RemoteServiceEndpoint.java:165)
2022-01-31T15:57:19.8152508Z         at pl.allegro.tech.hermes.integration.PublishingTest.shouldNotConsumeMessagesWhenSubscriptionIsSuspended(PublishingTest.java:135)
```
4. I've bumped TestNG version from __6.8.8__ to __7.4.0__
5. I've added logging to `shouldAuthenticateUsingBasicAuth` test method, as I was unable to reproduce bug locally (issue: #1431)