### PR TITLE
During read-only mode admin can perform changes is hermes-console

### DIFF
--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/common/exception/RepositoryNotAvailableException.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/common/exception/RepositoryNotAvailableException.java
@@ -1,0 +1,9 @@
+package pl.allegro.tech.hermes.common.exception;
+
+public class RepositoryNotAvailableException extends InternalProcessingException {
+
+    public RepositoryNotAvailableException(String message) {
+        super(message);
+    }
+
+}

--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/infrastructure/zookeeper/ZookeeperBasedRepository.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/infrastructure/zookeeper/ZookeeperBasedRepository.java
@@ -9,6 +9,7 @@ import org.apache.zookeeper.data.Stat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import pl.allegro.tech.hermes.common.exception.InternalProcessingException;
+import pl.allegro.tech.hermes.common.exception.RepositoryNotAvailableException;
 import pl.allegro.tech.hermes.infrastructure.MalformedDataException;
 
 import java.io.IOException;
@@ -38,7 +39,7 @@ public abstract class ZookeeperBasedRepository {
 
     protected void ensureConnected() {
         if (!zookeeper.getZookeeperClient().isConnected()) {
-            throw new InternalProcessingException("Could not establish connection to a Zookeeper instance");
+            throw new RepositoryNotAvailableException("Could not establish connection to a Zookeeper instance");
         }
     }
 

--- a/hermes-console/static/js/console/Visibility.js
+++ b/hermes-console/static/js/console/Visibility.js
@@ -36,7 +36,7 @@ rolesModule.factory('Visibility', ['DiscoveryService', '$resource', '$rootScope'
                     const rolesList = commaSeparatedRoles.toString().split(',');
                     $rootScope.admin = isAdmin(rolesList);
                     $rootScope.userHasSufficientPrivileges = hasSufficientPrivileges(rolesList);
-                    $rootScope.userWithoutAccess = !$rootScope.userHasSufficientPrivileges || $rootScope.readOnly;
+                    $rootScope.userWithoutAccess = $rootScope.readOnly ? !$rootScope.admin : !$rootScope.userHasSufficientPrivileges;
                 },
                 function() {
                     $rootScope.admin = false;

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/api/BlacklistEndpoint.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/api/BlacklistEndpoint.java
@@ -6,6 +6,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import pl.allegro.tech.hermes.api.BlacklistStatus;
 import pl.allegro.tech.hermes.management.api.auth.Roles;
+import pl.allegro.tech.hermes.management.domain.auth.RequestUser;
 import pl.allegro.tech.hermes.management.domain.blacklist.TopicBlacklistService;
 
 import javax.annotation.security.RolesAllowed;
@@ -17,7 +18,9 @@ import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
+import javax.ws.rs.core.SecurityContext;
 import java.util.List;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
@@ -59,8 +62,11 @@ public class BlacklistEndpoint {
     @Path("/topics")
     @RolesAllowed(Roles.ADMIN)
     @ApiOperation(value = "Blacklist topics", httpMethod = HttpMethod.POST)
-    public Response blacklistTopics(List<String> qualifiedTopicNames) {
-        qualifiedTopicNames.forEach(topicBlacklistService::blacklist);
+    public Response blacklistTopics(
+            List<String> qualifiedTopicNames,
+            @Context SecurityContext securityContext) {
+        RequestUser blacklistRequester = RequestUser.fromSecurityContext(securityContext);
+        qualifiedTopicNames.forEach(topicName -> topicBlacklistService.blacklist(topicName, blacklistRequester));
         return status(Response.Status.OK).build();
     }
 
@@ -69,8 +75,11 @@ public class BlacklistEndpoint {
     @Path("/topics/{topicName}")
     @RolesAllowed(Roles.ADMIN)
     @ApiOperation(value = "Unblacklist topic", httpMethod = HttpMethod.DELETE)
-    public Response unblacklistTopic(@PathParam("topicName") String qualifiedTopicName) {
-        topicBlacklistService.unblacklist(qualifiedTopicName);
+    public Response unblacklistTopic(
+            @PathParam("topicName") String qualifiedTopicName,
+            @Context SecurityContext securityContext) {
+        RequestUser unblacklistRequester = RequestUser.fromSecurityContext(securityContext);
+        topicBlacklistService.unblacklist(qualifiedTopicName, unblacklistRequester);
         return status(Response.Status.OK).build();
     }
 }

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/api/GroupsEndpoint.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/api/GroupsEndpoint.java
@@ -9,6 +9,7 @@ import pl.allegro.tech.hermes.api.PatchData;
 import pl.allegro.tech.hermes.management.api.auth.ManagementRights;
 import pl.allegro.tech.hermes.management.api.auth.Roles;
 import pl.allegro.tech.hermes.management.api.validator.ApiPreconditions;
+import pl.allegro.tech.hermes.management.domain.auth.RequestUser;
 import pl.allegro.tech.hermes.management.domain.group.GroupService;
 
 import javax.annotation.security.RolesAllowed;
@@ -71,7 +72,7 @@ public class GroupsEndpoint {
     @RolesAllowed(Roles.ANY)
     public Response create(Group group, @Context SecurityContext securityContext, @Context ContainerRequestContext requestContext) {
         preconditions.checkConstraints(group, false);
-        groupService.createGroup(group, securityContext.getUserPrincipal().getName(), managementRights.getGroupCreatorRights(requestContext));
+        groupService.createGroup(group, RequestUser.fromSecurityContext(securityContext), managementRights.getGroupCreatorRights(requestContext));
         return Response.status(Response.Status.CREATED).build();
     }
 
@@ -84,7 +85,7 @@ public class GroupsEndpoint {
     public Response update(@PathParam("groupName") String groupName,
                            PatchData patch,
                            @Context SecurityContext securityContext) {
-        groupService.updateGroup(groupName, patch, securityContext.getUserPrincipal().getName());
+        groupService.updateGroup(groupName, patch, RequestUser.fromSecurityContext(securityContext));
         return responseStatus(Response.Status.NO_CONTENT);
     }
 
@@ -93,7 +94,7 @@ public class GroupsEndpoint {
     @ApiOperation(value = "Remove group", response = String.class, httpMethod = HttpMethod.DELETE)
     @RolesAllowed(Roles.ADMIN)
     public Response delete(@PathParam("groupName") String groupName, @Context SecurityContext securityContext) {
-        groupService.removeGroup(groupName, securityContext.getUserPrincipal().getName());
+        groupService.removeGroup(groupName, RequestUser.fromSecurityContext(securityContext));
         return responseStatus(Response.Status.OK);
     }
 

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/api/OAuthProvidersEndpoint.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/api/OAuthProvidersEndpoint.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Component;
 import pl.allegro.tech.hermes.api.OAuthProvider;
 import pl.allegro.tech.hermes.api.PatchData;
 import pl.allegro.tech.hermes.management.api.auth.Roles;
+import pl.allegro.tech.hermes.management.domain.auth.RequestUser;
 import pl.allegro.tech.hermes.management.domain.oauth.OAuthProviderService;
 
 import javax.annotation.security.RolesAllowed;
@@ -61,7 +62,7 @@ public class OAuthProvidersEndpoint {
     @ApiOperation(value = "Create OAuth provider", httpMethod = HttpMethod.POST)
     public Response create(OAuthProvider oAuthProvider,
                            @Context SecurityContext securityContext) {
-        service.createOAuthProvider(oAuthProvider, securityContext.getUserPrincipal().getName());
+        service.createOAuthProvider(oAuthProvider, RequestUser.fromSecurityContext(securityContext));
         return status(Response.Status.CREATED).build();
     }
 
@@ -73,7 +74,7 @@ public class OAuthProvidersEndpoint {
     @ApiOperation(value = "Update OAuth provider", httpMethod = HttpMethod.PUT)
     public Response update(@PathParam("oAuthProviderName") String oAuthProviderName, PatchData patch,
                            @Context SecurityContext securityContext) {
-        service.updateOAuthProvider(oAuthProviderName, patch, securityContext.getUserPrincipal().getName());
+        service.updateOAuthProvider(oAuthProviderName, patch, RequestUser.fromSecurityContext(securityContext));
         return status(Response.Status.OK).build();
     }
 
@@ -84,7 +85,7 @@ public class OAuthProvidersEndpoint {
     @ApiOperation(value = "Remove OAuth provider", httpMethod = HttpMethod.DELETE)
     public Response remove(@PathParam("oAuthProviderName") String oAuthProviderName,
                            @Context SecurityContext securityContext) {
-        service.removeOAuthProvider(oAuthProviderName, securityContext.getUserPrincipal().getName());
+        service.removeOAuthProvider(oAuthProviderName, RequestUser.fromSecurityContext(securityContext));
         return status(Response.Status.OK).build();
     }
 }

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/api/SubscriptionsEndpoint.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/api/SubscriptionsEndpoint.java
@@ -220,13 +220,15 @@ public class SubscriptionsEndpoint {
     public Response retransmit(@PathParam("topicName") String qualifiedTopicName,
                                @PathParam("subscriptionName") String subscriptionName,
                                @DefaultValue("false") @QueryParam("dryRun") boolean dryRun,
-                               @Valid OffsetRetransmissionDate offsetRetransmissionDate) {
+                               @Valid OffsetRetransmissionDate offsetRetransmissionDate,
+                               @Context SecurityContext securityContext) {
 
         MultiDCOffsetChangeSummary summary = multiDCAwareService.moveOffset(
                 topicService.getTopicDetails(TopicName.fromQualifiedName(qualifiedTopicName)),
                 subscriptionName,
                 offsetRetransmissionDate.getRetransmissionDate().toInstant().toEpochMilli(),
-                dryRun);
+                dryRun,
+                RequestUser.fromSecurityContext(securityContext));
 
         return Response.status(OK).entity(summary).build();
     }

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/api/SubscriptionsEndpoint.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/api/SubscriptionsEndpoint.java
@@ -16,6 +16,7 @@ import pl.allegro.tech.hermes.api.Topic;
 import pl.allegro.tech.hermes.api.TopicName;
 import pl.allegro.tech.hermes.management.api.auth.ManagementRights;
 import pl.allegro.tech.hermes.management.api.auth.Roles;
+import pl.allegro.tech.hermes.management.domain.auth.RequestUser;
 import pl.allegro.tech.hermes.management.domain.subscription.SubscriptionService;
 import pl.allegro.tech.hermes.management.domain.topic.TopicService;
 import pl.allegro.tech.hermes.management.infrastructure.kafka.MultiDCAwareService;
@@ -95,7 +96,7 @@ public class SubscriptionsEndpoint {
     public Response create(@PathParam("topicName") String qualifiedTopicName,
                            Subscription subscription,
                            @Context ContainerRequestContext requestContext) {
-        subscriptionService.createSubscription(subscription, requestContext.getSecurityContext().getUserPrincipal().getName(),
+        subscriptionService.createSubscription(subscription, RequestUser.fromSecurityContext(requestContext.getSecurityContext()),
                 managementRights.getSubscriptionCreatorRights(requestContext), qualifiedTopicName);
         return responseStatus(Response.Status.CREATED);
     }
@@ -180,7 +181,7 @@ public class SubscriptionsEndpoint {
                                 Subscription.State state,
                                 @Context SecurityContext securityContext) {
         subscriptionService.updateSubscriptionState(fromQualifiedName(qualifiedTopicName),
-                subscriptionName, state, securityContext.getUserPrincipal().getName());
+                subscriptionName, state, RequestUser.fromSecurityContext(securityContext));
         return responseStatus(OK);
     }
 
@@ -192,7 +193,7 @@ public class SubscriptionsEndpoint {
                            @PathParam("subscriptionName") String subscriptionId,
                            @Context SecurityContext securityContext) {
         subscriptionService.removeSubscription(fromQualifiedName(qualifiedTopicName),
-                subscriptionId, securityContext.getUserPrincipal().getName());
+                subscriptionId, RequestUser.fromSecurityContext(securityContext));
         return responseStatus(OK);
     }
 
@@ -206,7 +207,7 @@ public class SubscriptionsEndpoint {
                            PatchData patch,
                            @Context SecurityContext securityContext) {
         subscriptionService.updateSubscription(TopicName.fromQualifiedName(qualifiedTopicName),
-                subscriptionName, patch, securityContext.getUserPrincipal().getName());
+                subscriptionName, patch, RequestUser.fromSecurityContext(securityContext));
         return responseStatus(OK);
     }
 

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/api/TopicsEndpoint.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/api/TopicsEndpoint.java
@@ -19,9 +19,9 @@ import pl.allegro.tech.hermes.management.domain.owner.OwnerSource;
 import pl.allegro.tech.hermes.management.domain.owner.OwnerSourceNotFound;
 import pl.allegro.tech.hermes.management.domain.owner.OwnerSources;
 import pl.allegro.tech.hermes.management.domain.topic.CreatorRights;
+import pl.allegro.tech.hermes.management.domain.auth.RequestUser;
 import pl.allegro.tech.hermes.management.domain.topic.SingleMessageReaderException;
 import pl.allegro.tech.hermes.management.domain.topic.TopicService;
-import pl.allegro.tech.hermes.management.domain.topic.TopicManipulatorUser;
 
 import javax.annotation.security.RolesAllowed;
 import javax.ws.rs.Consumes;
@@ -97,9 +97,9 @@ public class TopicsEndpoint {
     @RolesAllowed(Roles.ANY)
     @ApiOperation(value = "Create topic", httpMethod = HttpMethod.POST)
     public Response create(TopicWithSchema topicWithSchema, @Context ContainerRequestContext requestContext) {
-        TopicManipulatorUser topicManipulatorUser = TopicManipulatorUser.fromSecurityContext(requestContext.getSecurityContext());
+        RequestUser requestUser = RequestUser.fromSecurityContext(requestContext.getSecurityContext());
         CreatorRights isAllowedToManage = checkedTopic -> managementRights.isUserAllowedToManageTopic(checkedTopic, requestContext);
-        topicService.createTopicWithSchema(topicWithSchema, topicManipulatorUser, isAllowedToManage);
+        topicService.createTopicWithSchema(topicWithSchema, requestUser, isAllowedToManage);
         return status(Response.Status.CREATED).build();
     }
 
@@ -109,9 +109,9 @@ public class TopicsEndpoint {
     @RolesAllowed({Roles.ADMIN, Roles.TOPIC_OWNER})
     @ApiOperation(value = "Remove topic", httpMethod = HttpMethod.DELETE)
     public Response remove(@PathParam("topicName") String qualifiedTopicName, @Context SecurityContext securityContext) {
-        TopicManipulatorUser topicManipulatorUser = TopicManipulatorUser.fromSecurityContext(securityContext);
+        RequestUser requestUser = RequestUser.fromSecurityContext(securityContext);
         topicService.removeTopicWithSchema(topicService.getTopicDetails(TopicName.fromQualifiedName(qualifiedTopicName)),
-                topicManipulatorUser);
+                requestUser);
         return status(Response.Status.OK).build();
     }
 
@@ -123,8 +123,8 @@ public class TopicsEndpoint {
     @ApiOperation(value = "Update topic", httpMethod = HttpMethod.PUT)
     public Response update(@PathParam("topicName") String qualifiedTopicName, PatchData patch,
                            @Context SecurityContext securityContext) {
-        TopicManipulatorUser topicManipulatorUser = TopicManipulatorUser.fromSecurityContext(securityContext);
-        topicService.updateTopicWithSchema(TopicName.fromQualifiedName(qualifiedTopicName), patch, topicManipulatorUser);
+        RequestUser requestUser = RequestUser.fromSecurityContext(securityContext);
+        topicService.updateTopicWithSchema(TopicName.fromQualifiedName(qualifiedTopicName), patch, requestUser);
         return status(Response.Status.OK).build();
     }
 

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/api/WorkloadConstraintsEndpoint.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/api/WorkloadConstraintsEndpoint.java
@@ -9,6 +9,7 @@ import pl.allegro.tech.hermes.api.TopicConstraints;
 import pl.allegro.tech.hermes.api.TopicName;
 import pl.allegro.tech.hermes.domain.workload.constraints.ConsumersWorkloadConstraints;
 import pl.allegro.tech.hermes.management.api.auth.Roles;
+import pl.allegro.tech.hermes.management.domain.auth.RequestUser;
 import pl.allegro.tech.hermes.management.domain.workload.constraints.WorkloadConstraintsService;
 
 import javax.annotation.security.RolesAllowed;
@@ -21,7 +22,9 @@ import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
+import javax.ws.rs.core.SecurityContext;
 
 import java.util.List;
 
@@ -54,12 +57,15 @@ public class WorkloadConstraintsEndpoint {
     @Produces(APPLICATION_JSON)
     @RolesAllowed(Roles.ADMIN)
     @ApiOperation(value = "Create or update topic constraints", response = String.class, httpMethod = HttpMethod.PUT)
-    public Response createOrUpdateTopicConstraints(@Valid TopicConstraints topicConstraints) {
+    public Response createOrUpdateTopicConstraints(
+            @Valid TopicConstraints topicConstraints,
+            @Context SecurityContext securityContext) {
+        RequestUser requestUser = RequestUser.fromSecurityContext(securityContext);
         if (service.constraintsExist(topicConstraints.getTopicName())) {
-            service.updateConstraints(topicConstraints.getTopicName(), topicConstraints.getConstraints());
+            service.updateConstraints(topicConstraints.getTopicName(), topicConstraints.getConstraints(), requestUser);
             return Response.status(OK).build();
         } else {
-            service.createConstraints(topicConstraints.getTopicName(), topicConstraints.getConstraints());
+            service.createConstraints(topicConstraints.getTopicName(), topicConstraints.getConstraints(), requestUser);
             return Response.status(CREATED).build();
         }
     }
@@ -68,8 +74,10 @@ public class WorkloadConstraintsEndpoint {
     @Path("/topic/{topicName}")
     @RolesAllowed(Roles.ADMIN)
     @ApiOperation(value = "Remove topic constraints", response = String.class, httpMethod = HttpMethod.DELETE)
-    public Response deleteTopicConstraints(@PathParam("topicName") String topicName) {
-        service.deleteConstraints(TopicName.fromQualifiedName(topicName));
+    public Response deleteTopicConstraints(
+            @PathParam("topicName") String topicName,
+            @Context SecurityContext securityContext) {
+        service.deleteConstraints(TopicName.fromQualifiedName(topicName), RequestUser.fromSecurityContext(securityContext));
         return Response.status(OK).build();
     }
 
@@ -79,12 +87,15 @@ public class WorkloadConstraintsEndpoint {
     @Produces(APPLICATION_JSON)
     @RolesAllowed(Roles.ADMIN)
     @ApiOperation(value = "Create or update subscription constraints", response = String.class, httpMethod = HttpMethod.PUT)
-    public Response createOrUpdateSubscriptionConstraints(@Valid SubscriptionConstraints subscriptionConstraints) {
+    public Response createOrUpdateSubscriptionConstraints(
+            @Valid SubscriptionConstraints subscriptionConstraints,
+            @Context SecurityContext securityContext) {
+        RequestUser requestUser = RequestUser.fromSecurityContext(securityContext);
         if (service.constraintsExist(subscriptionConstraints.getSubscriptionName())) {
-            service.updateConstraints(subscriptionConstraints.getSubscriptionName(), subscriptionConstraints.getConstraints());
+            service.updateConstraints(subscriptionConstraints.getSubscriptionName(), subscriptionConstraints.getConstraints(), requestUser);
             return Response.status(OK).build();
         } else {
-            service.createConstraints(subscriptionConstraints.getSubscriptionName(), subscriptionConstraints.getConstraints());
+            service.createConstraints(subscriptionConstraints.getSubscriptionName(), subscriptionConstraints.getConstraints(), requestUser);
             return Response.status(CREATED).build();
         }
     }
@@ -94,8 +105,9 @@ public class WorkloadConstraintsEndpoint {
     @RolesAllowed(Roles.ADMIN)
     @ApiOperation(value = "Remove subscription constraints", response = String.class, httpMethod = HttpMethod.DELETE)
     public Response deleteSubscriptionConstraints(@PathParam("topicName") String topicName,
-                                                  @PathParam("subscriptionName") String subscriptionName) {
-        service.deleteConstraints(new SubscriptionName(subscriptionName, TopicName.fromQualifiedName(topicName)));
+                                                  @PathParam("subscriptionName") String subscriptionName,
+                                                  @Context SecurityContext securityContext) {
+        service.deleteConstraints(new SubscriptionName(subscriptionName, TopicName.fromQualifiedName(topicName)), RequestUser.fromSecurityContext(securityContext));
         return Response.status(OK).build();
     }
 }

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/config/storage/StorageConfiguration.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/config/storage/StorageConfiguration.java
@@ -26,6 +26,7 @@ import pl.allegro.tech.hermes.infrastructure.zookeeper.ZookeeperWorkloadConstrai
 import pl.allegro.tech.hermes.management.domain.blacklist.TopicBlacklistRepository;
 import pl.allegro.tech.hermes.management.domain.dc.MultiDatacenterRepositoryCommandExecutor;
 import pl.allegro.tech.hermes.management.domain.dc.MultiDatacenterRepositoryQueryExecutor;
+import pl.allegro.tech.hermes.management.domain.mode.ModeService;
 import pl.allegro.tech.hermes.management.domain.retransmit.OfflineRetransmissionRepository;
 import pl.allegro.tech.hermes.management.infrastructure.blacklist.ZookeeperTopicBlacklistRepository;
 import pl.allegro.tech.hermes.management.infrastructure.dc.DatacenterNameProvider;
@@ -86,9 +87,14 @@ public class StorageConfiguration {
 
     @Bean
     MultiDatacenterRepositoryCommandExecutor multiDcRepositoryCommandExecutor(
-            ZookeeperGroupRepositoryFactory zookeeperGroupRepositoryFactory) {
-        return new MultiDatacenterRepositoryCommandExecutor(repositoryManager(zookeeperGroupRepositoryFactory),
-                storageClustersProperties.isTransactional());
+            ZookeeperGroupRepositoryFactory zookeeperGroupRepositoryFactory,
+            ModeService modeService
+    ) {
+        return new MultiDatacenterRepositoryCommandExecutor(
+                repositoryManager(zookeeperGroupRepositoryFactory),
+                storageClustersProperties.isTransactional(),
+                modeService
+        );
     }
 
     @Bean

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/domain/auth/RequestUser.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/domain/auth/RequestUser.java
@@ -1,23 +1,23 @@
-package pl.allegro.tech.hermes.management.domain.topic;
+package pl.allegro.tech.hermes.management.domain.auth;
 
 import pl.allegro.tech.hermes.management.api.auth.Roles;
 
 import javax.ws.rs.core.SecurityContext;
 import java.util.Objects;
 
-public class TopicManipulatorUser {
+public class RequestUser {
     private final String username;
     private final boolean isAdmin;
 
-    public TopicManipulatorUser(String username, boolean isAdmin) {
+    public RequestUser(String username, boolean isAdmin) {
         this.username = username;
         this.isAdmin = isAdmin;
     }
 
-    public static TopicManipulatorUser fromSecurityContext(SecurityContext securityContext) {
+    public static RequestUser fromSecurityContext(SecurityContext securityContext) {
         String username = securityContext.getUserPrincipal().getName();
         boolean isAdmin = securityContext.isUserInRole(Roles.ADMIN);
-        return new TopicManipulatorUser(username, isAdmin);
+        return new RequestUser(username, isAdmin);
     }
 
     public String getUsername() {
@@ -32,8 +32,8 @@ public class TopicManipulatorUser {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-        TopicManipulatorUser topicManipulatorUser = (TopicManipulatorUser) o;
-        return isAdmin == topicManipulatorUser.isAdmin && Objects.equals(username, topicManipulatorUser.username);
+        RequestUser requestUser = (RequestUser) o;
+        return isAdmin == requestUser.isAdmin && Objects.equals(username, requestUser.username);
     }
 
     @Override

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/domain/blacklist/TopicBlacklistService.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/domain/blacklist/TopicBlacklistService.java
@@ -2,6 +2,7 @@ package pl.allegro.tech.hermes.management.domain.blacklist;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import pl.allegro.tech.hermes.management.domain.auth.RequestUser;
 import pl.allegro.tech.hermes.management.domain.blacklist.commands.AddTopicToBlacklistRepositoryCommand;
 import pl.allegro.tech.hermes.management.domain.blacklist.commands.RemoveTopicFromBlacklistRepositoryCommand;
 import pl.allegro.tech.hermes.management.domain.dc.MultiDatacenterRepositoryCommandExecutor;
@@ -21,12 +22,12 @@ public class TopicBlacklistService {
         this.multiDcExecutor = multiDcExecutor;
     }
 
-    public void blacklist(String qualifiedTopicName) {
-        multiDcExecutor.execute(new AddTopicToBlacklistRepositoryCommand(qualifiedTopicName));
+    public void blacklist(String qualifiedTopicName, RequestUser blacklistRequester) {
+        multiDcExecutor.executeByUser(new AddTopicToBlacklistRepositoryCommand(qualifiedTopicName), blacklistRequester);
     }
 
-    public void unblacklist(String qualifiedTopicName) {
-        multiDcExecutor.execute(new RemoveTopicFromBlacklistRepositoryCommand(qualifiedTopicName));
+    public void unblacklist(String qualifiedTopicName, RequestUser unblacklistRequester) {
+        multiDcExecutor.executeByUser(new RemoveTopicFromBlacklistRepositoryCommand(qualifiedTopicName), unblacklistRequester);
     }
 
     public boolean isBlacklisted(String qualifiedTopicName) {

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/domain/dc/MultiDatacenterRepositoryCommandExecutor.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/domain/dc/MultiDatacenterRepositoryCommandExecutor.java
@@ -5,6 +5,7 @@ import org.slf4j.LoggerFactory;
 import pl.allegro.tech.hermes.common.exception.InternalProcessingException;
 import pl.allegro.tech.hermes.common.exception.RepositoryNotAvailableException;
 import pl.allegro.tech.hermes.management.domain.auth.RequestUser;
+import pl.allegro.tech.hermes.management.domain.mode.ModeService;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -16,14 +17,16 @@ public class MultiDatacenterRepositoryCommandExecutor {
 
     private final RepositoryManager repositoryManager;
     private final boolean rollbackEnabled;
+    private final ModeService modeService;
 
-    public MultiDatacenterRepositoryCommandExecutor(RepositoryManager repositoryManager, boolean rollbackEnabled) {
+    public MultiDatacenterRepositoryCommandExecutor(RepositoryManager repositoryManager, boolean rollbackEnabled, ModeService modeService) {
         this.repositoryManager = repositoryManager;
         this.rollbackEnabled = rollbackEnabled;
+        this.modeService = modeService;
     }
 
     public <T> void executeByUser(RepositoryCommand<T> command, RequestUser requestUser) {
-        if (requestUser.isAdmin()) execute(command, false, false);
+        if (requestUser.isAdmin() && modeService.isReadOnlyEnabled()) execute(command, false, false);
         else execute(command);
     }
 

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/domain/oauth/OAuthProviderService.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/domain/oauth/OAuthProviderService.java
@@ -8,6 +8,7 @@ import pl.allegro.tech.hermes.api.helpers.Patch;
 import pl.allegro.tech.hermes.domain.oauth.OAuthProviderRepository;
 import pl.allegro.tech.hermes.management.api.validator.ApiPreconditions;
 import pl.allegro.tech.hermes.management.domain.Auditor;
+import pl.allegro.tech.hermes.management.domain.auth.RequestUser;
 import pl.allegro.tech.hermes.management.domain.dc.MultiDatacenterRepositoryCommandExecutor;
 import pl.allegro.tech.hermes.management.domain.oauth.commands.CreateOAuthProviderRepositoryCommand;
 import pl.allegro.tech.hermes.management.domain.oauth.commands.RemoveOAuthProviderRepositoryCommand;
@@ -40,24 +41,24 @@ public class OAuthProviderService {
         return repository.getOAuthProviderDetails(oAuthProviderName).anonymize();
     }
 
-    public void createOAuthProvider(OAuthProvider oAuthProvider, String createdBy) {
+    public void createOAuthProvider(OAuthProvider oAuthProvider, RequestUser createdBy) {
         preconditions.checkConstraints(oAuthProvider, false);
-        multiDcExecutor.execute(new CreateOAuthProviderRepositoryCommand(oAuthProvider));
-        auditor.objectCreated(createdBy, oAuthProvider);
+        multiDcExecutor.executeByUser(new CreateOAuthProviderRepositoryCommand(oAuthProvider), createdBy);
+        auditor.objectCreated(createdBy.getUsername(), oAuthProvider);
     }
 
-    public void removeOAuthProvider(String oAuthProviderName, String removedBy) {
+    public void removeOAuthProvider(String oAuthProviderName, RequestUser removedBy) {
         OAuthProvider oAuthProvider = repository.getOAuthProviderDetails(oAuthProviderName);
-        multiDcExecutor.execute(new RemoveOAuthProviderRepositoryCommand(oAuthProviderName));
-        auditor.objectRemoved(removedBy, oAuthProvider);
+        multiDcExecutor.executeByUser(new RemoveOAuthProviderRepositoryCommand(oAuthProviderName), removedBy);
+        auditor.objectRemoved(removedBy.getUsername(), oAuthProvider);
     }
 
-    public void updateOAuthProvider(String oAuthProviderName, PatchData patch, String updatedBy) {
+    public void updateOAuthProvider(String oAuthProviderName, PatchData patch, RequestUser updatedBy) {
         OAuthProvider retrieved = repository.getOAuthProviderDetails(oAuthProviderName);
         OAuthProvider updated = Patch.apply(retrieved, patch);
         preconditions.checkConstraints(updated, false);
 
-        multiDcExecutor.execute(new UpdateOAuthProviderRepositoryCommand(updated));
-        auditor.objectUpdated(updatedBy, retrieved, updated);
+        multiDcExecutor.executeByUser(new UpdateOAuthProviderRepositoryCommand(updated), updatedBy);
+        auditor.objectUpdated(updatedBy.getUsername(), retrieved, updated);
     }
 }

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/domain/topic/TopicService.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/domain/topic/TopicService.java
@@ -184,7 +184,7 @@ public class TopicService {
             throw new TopicRemovalDisabledException(topic);
         }
         if (topicBlacklistService.isBlacklisted(topic.getQualifiedName())) {
-            topicBlacklistService.unblacklist(topic.getQualifiedName());
+            topicBlacklistService.unblacklist(topic.getQualifiedName(), removedBy);
         }
         removeTopic(topic, removedBy);
     }

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/domain/topic/TopicService.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/domain/topic/TopicService.java
@@ -240,7 +240,7 @@ public class TopicService {
                 topicContentTypeMigrationService.waitUntilAllSubscriptionsHasConsumersAssigned(modified,
                         Duration.ofSeconds(topicProperties.getSubscriptionsAssignmentsCompletedTimeoutSeconds()));
                 logger.info("Notifying subscriptions' consumers about changes in topic {} content type...", topicName.qualifiedName());
-                topicContentTypeMigrationService.notifySubscriptions(modified, beforeMigrationInstant);
+                topicContentTypeMigrationService.notifySubscriptions(modified, beforeMigrationInstant, modifiedBy);
             }
             auditor.objectUpdated(modifiedBy.getUsername(), retrieved, modified);
             topicOwnerCache.onUpdatedTopic(retrieved, modified);

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/domain/topic/validator/TopicValidator.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/domain/topic/validator/TopicValidator.java
@@ -7,7 +7,7 @@ import pl.allegro.tech.hermes.api.Topic;
 import pl.allegro.tech.hermes.management.api.validator.ApiPreconditions;
 import pl.allegro.tech.hermes.management.domain.topic.CreatorRights;
 import pl.allegro.tech.hermes.management.domain.owner.validator.OwnerIdValidator;
-import pl.allegro.tech.hermes.management.domain.topic.TopicManipulatorUser;
+import pl.allegro.tech.hermes.management.domain.auth.RequestUser;
 import pl.allegro.tech.hermes.schema.CouldNotLoadSchemaException;
 import pl.allegro.tech.hermes.schema.SchemaNotFoundException;
 import pl.allegro.tech.hermes.schema.SchemaRepository;
@@ -34,7 +34,7 @@ public class TopicValidator {
         this.apiPreconditions = apiPreconditions;
     }
 
-    public void ensureCreatedTopicIsValid(Topic created, TopicManipulatorUser createdBy, CreatorRights creatorRights) {
+    public void ensureCreatedTopicIsValid(Topic created, RequestUser createdBy, CreatorRights creatorRights) {
         apiPreconditions.checkConstraints(created, createdBy.isAdmin());
         checkOwner(created);
         checkContentType(created);
@@ -49,7 +49,7 @@ public class TopicValidator {
         }
     }
 
-    public void ensureUpdatedTopicIsValid(Topic updated, Topic previous, TopicManipulatorUser modifiedBy) {
+    public void ensureUpdatedTopicIsValid(Topic updated, Topic previous, RequestUser modifiedBy) {
         apiPreconditions.checkConstraints(updated, modifiedBy.isAdmin());
         checkOwner(updated);
         checkTopicLabels(updated);

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/domain/workload/constraints/WorkloadConstraintsService.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/domain/workload/constraints/WorkloadConstraintsService.java
@@ -6,6 +6,7 @@ import pl.allegro.tech.hermes.api.SubscriptionName;
 import pl.allegro.tech.hermes.api.TopicName;
 import pl.allegro.tech.hermes.domain.workload.constraints.ConsumersWorkloadConstraints;
 import pl.allegro.tech.hermes.domain.workload.constraints.WorkloadConstraintsRepository;
+import pl.allegro.tech.hermes.management.domain.auth.RequestUser;
 import pl.allegro.tech.hermes.management.domain.dc.MultiDatacenterRepositoryCommandExecutor;
 import pl.allegro.tech.hermes.management.domain.workload.constraints.command.CreateSubscriptionConstraintsRepositoryCommand;
 import pl.allegro.tech.hermes.management.domain.workload.constraints.command.CreateTopicConstraintsRepositoryCommand;
@@ -30,28 +31,28 @@ public class WorkloadConstraintsService {
         return workloadConstraintsRepository.getConsumersWorkloadConstraints();
     }
 
-    public void createConstraints(TopicName topicName, Constraints constraints) {
-        commandExecutor.execute(new CreateTopicConstraintsRepositoryCommand(topicName, constraints));
+    public void createConstraints(TopicName topicName, Constraints constraints, RequestUser requester) {
+        commandExecutor.executeByUser(new CreateTopicConstraintsRepositoryCommand(topicName, constraints), requester);
     }
 
-    public void createConstraints(SubscriptionName subscriptionName, Constraints constraints) {
-        commandExecutor.execute(new CreateSubscriptionConstraintsRepositoryCommand(subscriptionName, constraints));
+    public void createConstraints(SubscriptionName subscriptionName, Constraints constraints, RequestUser requester) {
+        commandExecutor.executeByUser(new CreateSubscriptionConstraintsRepositoryCommand(subscriptionName, constraints), requester);
     }
 
-    public void updateConstraints(TopicName topicName, Constraints constraints) {
-        commandExecutor.execute(new UpdateTopicConstraintsRepositoryCommand(topicName, constraints));
+    public void updateConstraints(TopicName topicName, Constraints constraints, RequestUser requester) {
+        commandExecutor.executeByUser(new UpdateTopicConstraintsRepositoryCommand(topicName, constraints), requester);
     }
 
-    public void updateConstraints(SubscriptionName subscriptionName, Constraints constraints) {
-        commandExecutor.execute(new UpdateSubscriptionConstraintsRepositoryCommand(subscriptionName, constraints));
+    public void updateConstraints(SubscriptionName subscriptionName, Constraints constraints, RequestUser requester) {
+        commandExecutor.executeByUser(new UpdateSubscriptionConstraintsRepositoryCommand(subscriptionName, constraints), requester);
     }
 
-    public void deleteConstraints(TopicName topicName) {
-        commandExecutor.execute(new DeleteTopicConstraintsRepositoryCommand(topicName));
+    public void deleteConstraints(TopicName topicName, RequestUser requester) {
+        commandExecutor.executeByUser(new DeleteTopicConstraintsRepositoryCommand(topicName), requester);
     }
 
-    public void deleteConstraints(SubscriptionName subscriptionName) {
-        commandExecutor.execute(new DeleteSubscriptionConstraintsRepositoryCommand(subscriptionName));
+    public void deleteConstraints(SubscriptionName subscriptionName, RequestUser requester) {
+        commandExecutor.executeByUser(new DeleteSubscriptionConstraintsRepositoryCommand(subscriptionName), requester);
     }
 
     public boolean constraintsExist(TopicName topicName) {

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/migration/owner/SupportTeamToOwnerMigrator.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/migration/owner/SupportTeamToOwnerMigrator.java
@@ -65,7 +65,7 @@ public class SupportTeamToOwnerMigrator {
     private void migrateSubscription(Subscription subscription, String sourceName, OwnerExistsStrategy strategy, EntityMigrationCounters subscriptionCounters) {
         if (subscription.getOwner() == null || strategy == OwnerExistsStrategy.OVERRIDE) {
             migrateEntity(subscriptionCounters, "subscription " + subscription.getQualifiedName(),
-                    () -> subscriptionService.updateSubscription(subscription.getTopicName(), subscription.getName(), patchWithOwner(sourceName, subscription.getSupportTeam()), MIGRATION_USER)
+                    () -> subscriptionService.updateSubscription(subscription.getTopicName(), subscription.getName(), patchWithOwner(sourceName, subscription.getSupportTeam()), new RequestUser(MIGRATION_USER, false))
             );
         } else {
             subscriptionCounters.markSkipped(OWNER_ALREADY_EXISTED_REASON);

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/migration/owner/SupportTeamToOwnerMigrator.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/migration/owner/SupportTeamToOwnerMigrator.java
@@ -10,7 +10,7 @@ import org.springframework.stereotype.Component;
 import pl.allegro.tech.hermes.api.*;
 import pl.allegro.tech.hermes.management.domain.group.GroupService;
 import pl.allegro.tech.hermes.management.domain.subscription.SubscriptionService;
-import pl.allegro.tech.hermes.management.domain.topic.TopicManipulatorUser;
+import pl.allegro.tech.hermes.management.domain.auth.RequestUser;
 import pl.allegro.tech.hermes.management.domain.topic.TopicService;
 
 import java.util.HashMap;
@@ -75,7 +75,7 @@ public class SupportTeamToOwnerMigrator {
     private void migrateTopic(Topic topic, Group group, String sourceName, OwnerExistsStrategy strategy, EntityMigrationCounters topicCounters) {
         if (topic.getOwner() == null || strategy == OwnerExistsStrategy.OVERRIDE) {
             migrateEntity(topicCounters, "topic " + topic.getQualifiedName(),
-                    () -> topicService.updateTopic(topic.getName(), patchWithOwner(sourceName, group.getSupportTeam()), new TopicManipulatorUser(MIGRATION_USER, true))
+                    () -> topicService.updateTopic(topic.getName(), patchWithOwner(sourceName, group.getSupportTeam()), new RequestUser(MIGRATION_USER, true))
             );
         } else {
             topicCounters.markSkipped(OWNER_ALREADY_EXISTED_REASON);

--- a/hermes-management/src/test/groovy/pl/allegro/tech/hermes/management/domain/topic/validator/TopicValidatorTest.groovy
+++ b/hermes-management/src/test/groovy/pl/allegro/tech/hermes/management/domain/topic/validator/TopicValidatorTest.groovy
@@ -8,7 +8,7 @@ import pl.allegro.tech.hermes.management.api.validator.ApiPreconditions
 import pl.allegro.tech.hermes.management.config.TopicProperties
 import pl.allegro.tech.hermes.management.domain.owner.validator.OwnerIdValidationException
 import pl.allegro.tech.hermes.management.domain.owner.validator.OwnerIdValidator
-import pl.allegro.tech.hermes.management.domain.topic.TopicManipulatorUser
+import pl.allegro.tech.hermes.management.domain.auth.RequestUser
 import pl.allegro.tech.hermes.schema.CompiledSchema
 import pl.allegro.tech.hermes.schema.CouldNotLoadSchemaException
 import pl.allegro.tech.hermes.schema.SchemaRepository
@@ -25,7 +25,7 @@ class TopicValidatorTest extends Specification {
 
     static MANAGABLE = { true }
     static NOT_MANAGABLE = { false }
-    private static USER = new TopicManipulatorUser("username", false)
+    private static USER = new RequestUser("username", false)
 
     static Set<TopicLabel> allowedLabels
 

--- a/hermes-management/src/test/groovy/pl/allegro/tech/hermes/management/domain/topic/validator/TopicValidatorWithRealApiPreconditionsTest.groovy
+++ b/hermes-management/src/test/groovy/pl/allegro/tech/hermes/management/domain/topic/validator/TopicValidatorWithRealApiPreconditionsTest.groovy
@@ -3,7 +3,7 @@ package pl.allegro.tech.hermes.management.domain.topic.validator
 import pl.allegro.tech.hermes.api.RetentionTime
 import pl.allegro.tech.hermes.management.api.validator.ApiPreconditions
 import pl.allegro.tech.hermes.management.domain.owner.validator.OwnerIdValidator
-import pl.allegro.tech.hermes.management.domain.topic.TopicManipulatorUser
+import pl.allegro.tech.hermes.management.domain.auth.RequestUser
 import pl.allegro.tech.hermes.schema.SchemaRepository
 import spock.lang.Specification
 import spock.lang.Subject
@@ -19,8 +19,8 @@ class TopicValidatorWithRealApiPreconditionsTest extends Specification {
     private static MANAGEABLE = { true }
     private static retentionTime7Days = new RetentionTime(7, DAYS)
     private static retentionTime8Days = new RetentionTime(8, DAYS)
-    private static regularUser = new TopicManipulatorUser("regularUser", false)
-    private static admin = new TopicManipulatorUser("admin", true)
+    private static regularUser = new RequestUser("regularUser", false)
+    private static admin = new RequestUser("admin", true)
 
     def schemaRepository = Stub(SchemaRepository)
     def ownerDescriptorValidator = Stub(OwnerIdValidator)

--- a/hermes-management/src/test/groovy/pl/allegro/tech/hermes/management/domain/workload/constraints/WorkloadConstraintsServiceTest.groovy
+++ b/hermes-management/src/test/groovy/pl/allegro/tech/hermes/management/domain/workload/constraints/WorkloadConstraintsServiceTest.groovy
@@ -14,6 +14,7 @@ import pl.allegro.tech.hermes.domain.workload.constraints.WorkloadConstraintsRep
 import pl.allegro.tech.hermes.infrastructure.zookeeper.ZookeeperPaths
 import pl.allegro.tech.hermes.infrastructure.zookeeper.ZookeeperWorkloadConstraintsRepository
 import pl.allegro.tech.hermes.management.config.storage.DefaultZookeeperGroupRepositoryFactory
+import pl.allegro.tech.hermes.management.domain.auth.RequestUser
 import pl.allegro.tech.hermes.management.domain.dc.MultiDatacenterRepositoryCommandExecutor
 import pl.allegro.tech.hermes.management.infrastructure.zookeeper.ZookeeperClient
 import pl.allegro.tech.hermes.management.infrastructure.zookeeper.ZookeeperClientManager
@@ -23,6 +24,7 @@ import pl.allegro.tech.hermes.management.utils.MultiZookeeperIntegrationTest
 class WorkloadConstraintsServiceTest extends MultiZookeeperIntegrationTest {
 
     static WORKLOAD_CONSTRAINTS_PATH = '/hermes/consumers-workload-constraints'
+    static USER = new RequestUser("username", false);
     ZookeeperClientManager manager
     WorkloadConstraintsService service
     WorkloadConstraintsRepository repository
@@ -68,7 +70,7 @@ class WorkloadConstraintsServiceTest extends MultiZookeeperIntegrationTest {
 
     def "should create topic constraints in all zk clusters"() {
         when:
-        service.createConstraints(TopicName.fromQualifiedName('group.topic'), new Constraints(1))
+        service.createConstraints(TopicName.fromQualifiedName('group.topic'), new Constraints(1), USER)
 
         then:
         assertNodesContains('group.topic', new Constraints(1))
@@ -76,7 +78,7 @@ class WorkloadConstraintsServiceTest extends MultiZookeeperIntegrationTest {
 
     def "should create subscription constraints in all zk clusters"() {
         when:
-        service.createConstraints(SubscriptionName.fromString('group.topic$sub'), new Constraints(1))
+        service.createConstraints(SubscriptionName.fromString('group.topic$sub'), new Constraints(1), USER)
 
         then:
         assertNodesContains('group.topic$sub', new Constraints(1))
@@ -88,7 +90,7 @@ class WorkloadConstraintsServiceTest extends MultiZookeeperIntegrationTest {
         ensureCacheWasUpdated()
 
         when:
-        service.createConstraints(TopicName.fromQualifiedName('group.topic'), new Constraints(1))
+        service.createConstraints(TopicName.fromQualifiedName('group.topic'), new Constraints(1), USER)
 
         then:
         def e = thrown(TopicConstraintsAlreadyExistException)
@@ -104,7 +106,7 @@ class WorkloadConstraintsServiceTest extends MultiZookeeperIntegrationTest {
         ensureCacheWasUpdated()
 
         when:
-        service.createConstraints(SubscriptionName.fromString('group.topic$sub'), new Constraints(1))
+        service.createConstraints(SubscriptionName.fromString('group.topic$sub'), new Constraints(1), USER)
 
         then:
         def e = thrown(SubscriptionConstraintsAlreadyExistException)
@@ -119,7 +121,7 @@ class WorkloadConstraintsServiceTest extends MultiZookeeperIntegrationTest {
         zookeeper2.stop()
 
         when:
-        service.createConstraints(TopicName.fromQualifiedName('group.topic'), new Constraints(1))
+        service.createConstraints(TopicName.fromQualifiedName('group.topic'), new Constraints(1), USER)
 
         then:
         def e = thrown(InternalProcessingException)
@@ -134,7 +136,7 @@ class WorkloadConstraintsServiceTest extends MultiZookeeperIntegrationTest {
         zookeeper2.stop()
 
         when:
-        service.createConstraints(SubscriptionName.fromString('group.topic$sub'), new Constraints(1))
+        service.createConstraints(SubscriptionName.fromString('group.topic$sub'), new Constraints(1), USER)
 
         then:
         def e = thrown(InternalProcessingException)
@@ -149,7 +151,7 @@ class WorkloadConstraintsServiceTest extends MultiZookeeperIntegrationTest {
         setupNodes('group.topic', new Constraints(1))
 
         when:
-        service.updateConstraints(TopicName.fromQualifiedName('group.topic'), new Constraints(2))
+        service.updateConstraints(TopicName.fromQualifiedName('group.topic'), new Constraints(2), USER)
 
         then:
         assertNodesContains('group.topic', new Constraints(2))
@@ -160,7 +162,7 @@ class WorkloadConstraintsServiceTest extends MultiZookeeperIntegrationTest {
         setupNodes('group.topic$sub', new Constraints(1))
 
         when:
-        service.updateConstraints(SubscriptionName.fromString('group.topic$sub'), new Constraints(2))
+        service.updateConstraints(SubscriptionName.fromString('group.topic$sub'), new Constraints(2), USER)
 
         then:
         assertNodesContains('group.topic$sub', new Constraints(2))
@@ -172,7 +174,7 @@ class WorkloadConstraintsServiceTest extends MultiZookeeperIntegrationTest {
         ensureCacheWasUpdated()
 
         when:
-        service.updateConstraints(TopicName.fromQualifiedName('group.topic'), new Constraints(1))
+        service.updateConstraints(TopicName.fromQualifiedName('group.topic'), new Constraints(1), USER)
 
         then:
         def e = thrown(TopicConstraintsDoNotExistException)
@@ -189,7 +191,7 @@ class WorkloadConstraintsServiceTest extends MultiZookeeperIntegrationTest {
         ensureCacheWasUpdated()
 
         when:
-        service.updateConstraints(SubscriptionName.fromString('group.topic$sub'), new Constraints(1))
+        service.updateConstraints(SubscriptionName.fromString('group.topic$sub'), new Constraints(1), USER)
 
         then:
         def e = thrown(SubscriptionConstraintsDoNotExistException)
@@ -207,7 +209,7 @@ class WorkloadConstraintsServiceTest extends MultiZookeeperIntegrationTest {
         zookeeper2.stop()
 
         when:
-        service.updateConstraints(TopicName.fromQualifiedName('group.topic'), new Constraints(1))
+        service.updateConstraints(TopicName.fromQualifiedName('group.topic'), new Constraints(1), USER)
 
         then:
         def e = thrown(InternalProcessingException)
@@ -224,7 +226,7 @@ class WorkloadConstraintsServiceTest extends MultiZookeeperIntegrationTest {
         zookeeper2.stop()
 
         when:
-        service.updateConstraints(SubscriptionName.fromString('group.topic$sub'), new Constraints(1))
+        service.updateConstraints(SubscriptionName.fromString('group.topic$sub'), new Constraints(1), USER)
 
         then:
         def e = thrown(InternalProcessingException)
@@ -239,7 +241,7 @@ class WorkloadConstraintsServiceTest extends MultiZookeeperIntegrationTest {
         setupNodes('group.topic', new Constraints(1))
 
         when:
-        service.deleteConstraints(TopicName.fromQualifiedName('group.topic'))
+        service.deleteConstraints(TopicName.fromQualifiedName('group.topic'), USER)
 
         then:
         assertNodesDoNotExist('group.topic')
@@ -250,7 +252,7 @@ class WorkloadConstraintsServiceTest extends MultiZookeeperIntegrationTest {
         setupNodes('group.topic$sub', new Constraints(1))
 
         when:
-        service.deleteConstraints(SubscriptionName.fromString('group.topic$sub'))
+        service.deleteConstraints(SubscriptionName.fromString('group.topic$sub'), USER)
 
         then:
         assertNodesDoNotExist('group.topic$sub')
@@ -264,7 +266,7 @@ class WorkloadConstraintsServiceTest extends MultiZookeeperIntegrationTest {
         assert assertNodeDoesNotExist(DC_2_NAME, 'group.topic')
 
         when:
-        service.deleteConstraints(TopicName.fromQualifiedName('group.topic'))
+        service.deleteConstraints(TopicName.fromQualifiedName('group.topic'), USER)
 
         then:
         noExceptionThrown()
@@ -281,7 +283,7 @@ class WorkloadConstraintsServiceTest extends MultiZookeeperIntegrationTest {
         assert assertNodeDoesNotExist(DC_2_NAME, 'group.topic$sub')
 
         when:
-        service.deleteConstraints(SubscriptionName.fromString('group.topic$sub'))
+        service.deleteConstraints(SubscriptionName.fromString('group.topic$sub'), USER)
 
         then:
         noExceptionThrown()
@@ -297,7 +299,7 @@ class WorkloadConstraintsServiceTest extends MultiZookeeperIntegrationTest {
         zookeeper2.stop()
 
         when:
-        service.deleteConstraints(TopicName.fromQualifiedName('group.topic'))
+        service.deleteConstraints(TopicName.fromQualifiedName('group.topic'), USER)
 
         then:
         def e = thrown(InternalProcessingException)
@@ -314,7 +316,7 @@ class WorkloadConstraintsServiceTest extends MultiZookeeperIntegrationTest {
         zookeeper2.stop()
 
         when:
-        service.deleteConstraints(SubscriptionName.fromString('group.topic$sub'))
+        service.deleteConstraints(SubscriptionName.fromString('group.topic$sub'), USER)
 
         then:
         def e = thrown(InternalProcessingException)

--- a/hermes-management/src/test/groovy/pl/allegro/tech/hermes/management/domain/workload/constraints/WorkloadConstraintsServiceTest.groovy
+++ b/hermes-management/src/test/groovy/pl/allegro/tech/hermes/management/domain/workload/constraints/WorkloadConstraintsServiceTest.groovy
@@ -16,6 +16,7 @@ import pl.allegro.tech.hermes.infrastructure.zookeeper.ZookeeperWorkloadConstrai
 import pl.allegro.tech.hermes.management.config.storage.DefaultZookeeperGroupRepositoryFactory
 import pl.allegro.tech.hermes.management.domain.auth.RequestUser
 import pl.allegro.tech.hermes.management.domain.dc.MultiDatacenterRepositoryCommandExecutor
+import pl.allegro.tech.hermes.management.domain.mode.ModeService
 import pl.allegro.tech.hermes.management.infrastructure.zookeeper.ZookeeperClient
 import pl.allegro.tech.hermes.management.infrastructure.zookeeper.ZookeeperClientManager
 import pl.allegro.tech.hermes.management.infrastructure.zookeeper.ZookeeperRepositoryManager
@@ -29,6 +30,7 @@ class WorkloadConstraintsServiceTest extends MultiZookeeperIntegrationTest {
     WorkloadConstraintsService service
     WorkloadConstraintsRepository repository
     ZookeeperRepositoryManager repositoryManager
+    ModeService modeService
     MultiDatacenterRepositoryCommandExecutor executor
 
     def objectMapper = new ObjectMapper()
@@ -44,7 +46,8 @@ class WorkloadConstraintsServiceTest extends MultiZookeeperIntegrationTest {
                 manager, new TestDatacenterNameProvider(DC_1_NAME), objectMapper,
                 paths, new DefaultZookeeperGroupRepositoryFactory(), 180000)
         repositoryManager.start()
-        executor = new MultiDatacenterRepositoryCommandExecutor(repositoryManager, true)
+        modeService = new ModeService()
+        executor = new MultiDatacenterRepositoryCommandExecutor(repositoryManager, true, modeService)
         service = new WorkloadConstraintsService(repository, executor)
     }
 


### PR DESCRIPTION
Until now when _hermes-management_ was in `readOnly || readOnlyAdmin` mode, no one could edit topics, subscriptions or groups from _hermes-console_. Change introduced in this PR allows admin to perform __write__ operations using _hermes-console_ UI on topics, subscriptions and groups, even when _hermes-management_ is in read only mode.