### PR TITLE
Consumers spring DI - part 2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,7 +59,7 @@ allprojects {
             kafka             : '2.7.0',
             guava             : '23.0',
             jackson           : '2.11.4',
-            jersey            : '2.26',
+            jersey            : '2.35',
             jetty             : '9.4.19.v20190610',
             curator           : '2.12.0',
             dropwizard_metrics: '4.1.0',

--- a/docs/docs/configuration/custom-protocol.md
+++ b/docs/docs/configuration/custom-protocol.md
@@ -6,17 +6,18 @@ it is possible to implement support for any custom protocol.
 ## Creating message sender
 
 The most important bit is creating the `ProtocolMessageSenderProvider` which acts as a *factory* that produces the
-instance of `MessageSender`. This should be registered on application startup via `HermesConsumerBuilder`:
+instance of `MessageSender`. This should be registered as a bean:
 
 ```java
-builder.withMessageSenderProvider("myProtocol", (serviceLocator) -> {
-    new MyProtocolMessageSenderProvider()
-});
-```
+@Configuration
+public class CustomHermesConsumersConfiguration {
 
-The `HermesConsumerBuilder#withMessageSenderProvider` method accepts a lazy evaluated function which gives access to
-containers `ServiceLocator`. In some more advanced cases it might be beneficial to use some internal components,
-however there are no compatibility guarantees.
+    @Bean
+    public ProtocolMessageSenderProvider myProtocolMessageSenderProvider() {
+        return new MyProtocolMessageSenderProvider();
+    }
+}
+```
 
 ### Extending HTTP message sender
 
@@ -27,17 +28,18 @@ This example shows how to implement the `service://` pseudo protocol. We use it 
 Discovery: `service://my-service` means that address of the endpoint should be resolved by querying Service Discovery
 for instances of `my-service` service.
 
-To achieve this, implement `EndpointAddressResolver` interface and inject the implementation into the new instance of
-`JettyHttpMessageSenderProvider`:
+To achieve this, implement `EndpointAddressResolver` interface and register the implementation as a bean:
 
 ```java
-builder.withMessageSenderProvider("http", (s) ->
-                        new JettyHttpMessageSenderProvider(
-                            s.getService(HttpClient.class),
-                            s.getService(ConfigFactory.class),
-                            myCustomResolver,
-                            new DefaultHttpMetadataAppender())
-                        )
+@Configuration
+public class CustomHermesConsumersConfiguration {
+
+    @Bean
+    @Primary
+    public EndpointAddressResolver interpolatingEndpointAddressResolver() {
+        return new CustomEndpointAddressResolver();
+    }
+}
 ```
 
 ## Management support

--- a/docs/docs/configuration/internal-format.md
+++ b/docs/docs/configuration/internal-format.md
@@ -60,8 +60,7 @@ Hermes metadata is stored in `__metadata` field, which is specified as map of op
 
 Hermes allows to provide custom implementation of reading Kafka records, for example for reading metadata from Kafka headers.
 
-To do this, implement the interfaces `MessageContentReader` and `MessageContentReaderFactory`
-and inject the implementation of `MessageContentReaderFactory` into the builder.
+To do this, implement the interfaces `MessageContentReader` and `MessageContentReaderFactory`:
 
 ```java
 class CustomMessageContentReader implements MessageContentReader {
@@ -77,14 +76,18 @@ class CustomMessageContentReaderFactory implements MessageContentReaderFactory {
         return new CustomMessageContentReader();
     }
 }
+```
 
-public class CustomHermesConsumers {
-    public static void main(String[] args) {
-        MessageContentReaderFactory factory = new CustomMessageContentReaderFactory();
-        HermesConsumers hermesConsumers = HermesConsumers.consumers()
-                .withMessageContentReaderFactory(factory)
-                .build();
-        hermesConsumers.start();
+and register the implementation of `MessageContentReaderFactory` as a bean:
+
+```java
+@Configuration
+public class CustomHermesConsumersConfiguration {
+
+    @Bean
+    @Primary
+    public MessageContentReaderFactory customMessageContentReaderFactory() {
+        return new CustomMessageContentReaderFactory();
     }
 }
 ```

--- a/docs/docs/configuration/metrics.md
+++ b/docs/docs/configuration/metrics.md
@@ -27,19 +27,29 @@ metrics.prefix          | prefix for all metrics   | stats.tech.hermes
 
 ## Custom
 
-You can register any custom reporter that is compatible with Dropwizard `MetricRegistry`. Use programmatic API to do so.
-The code is the same for both Frontend and Consumers module.
+You can register any custom reporter that is compatible with Dropwizard `MetricRegistry`. 
+For the Frontend module use programmatic API to do so:
 
 ```java
 HermesFrontend.Builder builder = HermesFrontend.frontend();
-/*
-    or for Consumers:
-    HermesConsumerBuilder builder = HermesConsumers.consumers()
-*/
 
 builder.withStartupHook(serviceLocator -> {
     MyMetricsReporter reporter = new MyMetricsReporter(serviceLocator.getService(MetricRegistry.class));
     reporter.start();
 });
 
+```
+
+For the Consumers module register the reporter as a bean:
+
+```java
+@Configuration
+public class CustomHermesConsumersConfiguration {
+
+    @Bean
+    @Primary
+    public MetricRegistry myMetricRegistry(MetricRegistry metricRegistry) {
+        return new MyMetricsReporter(metricRegistry);
+    }
+}
 ```

--- a/docs/docs/deployment/packaging.md
+++ b/docs/docs/deployment/packaging.md
@@ -12,10 +12,6 @@ git clone https://github.com/allegro/hermes.git
 # build hermes
 cd hermes
 ./gradlew distZip -Pdistribution
-
-# build hermes-console
-cd hermes-console
-./package.sh
 ```
 
 This will cause distribution packages for all modules to build. Look for them in:
@@ -23,7 +19,6 @@ This will cause distribution packages for all modules to build. Look for them in
 * hermes-frontend/build/distribution/hermes-frontend-{version}.zip
 * hermes-consumers/build/distribution/hermes-consumers-{version}.zip
 * hermes-management/build/distribution/hermes-management-{version}.zip
-* hermes-console/dist/hermes-console.zip
 
 Having deployed Vanilla Hermes, you can only use configuration options to alter the behavior.
 
@@ -65,28 +60,25 @@ Create any type of runnable (*distZip* or *fatJar*) and deploy it.
 
 ### Consumers
 
-Add dependency on Consumers module:
+The Consumers module is a [Spring Boot](http://projects.spring.io/spring-boot/) project. Thus, it can be extended
+like any other Spring application.
 
 ```groovy
 compile group: 'pl.allegro.tech.hermes', name: 'hermes-consumers', version: versions.hermes
 ```
 
-Use `HermesConsumersBuilder` to create usable `HermesConsumers` instance and start it:
-
 ```java
+@ComponentScan(
+        basePackages = {"pl.allegro.tech.hermes.consumers", "com.example.my-hermes.consumers"},
+        excludeFilters = {@ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, value = HermesConsumers.class)}
+)
+@SpringBootApplication
 public class MyHermesConsumers {
 
-    private static final Logger logger = LoggerFactory.logger(MyHermesConsumers.class);
-
-    public static final void main(String... args) {
-        HermesConsumersBuilder builder = HermesConsumers.consumers()
-            .withStartupHook((serviceLocator) -> logger.info("Starting MyHermes"))
-            .withShutdownHook((serviceLocator) -> logger.info("Stopping MyHermes"));
-        /* introduce additional configuration like message senders etc */
-
-        HermesConsumers consumers = builder.build();
-        consumers.start();
+    public static void main(String... args) {
+        SpringApplication.run(MyHermesConsumers.class, args);
     }
+
 }
 ```
 
@@ -102,11 +94,11 @@ compile group: 'pl.allegro.tech.hermes', name: 'hermes-management', version: ver
 ```
 
 ```java
-@Configuration
 @ComponentScan(
         basePackages = {"pl.allegro.tech.hermes.management", "com.example.my-hermes.management"},
         excludeFilters = {@ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, value = HermesManagement.class)}
 )
+@SpringBootApplication
 public class MyHermesManagement {
 
     public static void main(String... args) {

--- a/hermes-api/build.gradle
+++ b/hermes-api/build.gradle
@@ -3,10 +3,11 @@ plugins {
 }
 
 dependencies {
-    compile group: 'org.hibernate', name: 'hibernate-validator', version: '5.0.0.Final'
+    compile group: 'org.hibernate.validator', name: 'hibernate-validator', version: '6.1.7.Final'
     compile group: 'javax.ws.rs', name: 'javax.ws.rs-api', version: '2.0'
     compile group: 'com.fasterxml.jackson.core', name: 'jackson-annotations', version: versions.jackson
     compile group: 'com.fasterxml.jackson.jaxrs', name: 'jackson-jaxrs-json-provider', version: versions.jackson
+    compile group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: versions.jackson
     compile group: 'com.google.guava', name: 'guava', version: versions.guava
     compile group: 'com.damnhandy', name: 'handy-uri-templates', version: '2.0.2'
     compile group: 'javax.xml.bind', name: 'jaxb-api', version: '2.3.1'

--- a/hermes-api/build.gradle
+++ b/hermes-api/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 dependencies {
-    compile group: 'org.hibernate.validator', name: 'hibernate-validator', version: '6.1.7.Final'
+    compile group: 'org.hibernate.validator', name: 'hibernate-validator', version: '6.2.2.Final'
     compile group: 'javax.ws.rs', name: 'javax.ws.rs-api', version: '2.0'
     compile group: 'com.fasterxml.jackson.core', name: 'jackson-annotations', version: versions.jackson
     compile group: 'com.fasterxml.jackson.jaxrs', name: 'jackson-jaxrs-json-provider', version: versions.jackson

--- a/hermes-api/src/main/java/pl/allegro/tech/hermes/api/helpers/Patch.java
+++ b/hermes-api/src/main/java/pl/allegro/tech/hermes/api/helpers/Patch.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import pl.allegro.tech.hermes.api.PatchData;
 
 import java.util.HashMap;
@@ -16,7 +17,8 @@ public class Patch {
     private static final ObjectMapper MAPPER = new ObjectMapper()
             .setSerializationInclusion(JsonInclude.Include.NON_NULL)
             .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
-            .disable(SerializationFeature.WRITE_NULL_MAP_VALUES);
+            .disable(SerializationFeature.WRITE_NULL_MAP_VALUES)
+            .registerModule(new JavaTimeModule());
 
     @SuppressWarnings("unchecked")
     public static <T> T apply(T object, PatchData patch) {

--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/common/di/factories/ObjectMapperFactory.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/common/di/factories/ObjectMapperFactory.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.InjectableValues;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.glassfish.hk2.api.Factory;
 import pl.allegro.tech.hermes.api.Topic;
 import pl.allegro.tech.hermes.common.config.ConfigFactory;
@@ -27,6 +28,7 @@ public class ObjectMapperFactory implements Factory<ObjectMapper> {
         objectMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
         objectMapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
         objectMapper.disable(SerializationFeature.WRITE_NULL_MAP_VALUES);
+        objectMapper.registerModule(new JavaTimeModule());
 
         final InjectableValues defaultSchemaIdAwareSerializationEnabled = new InjectableValues
                 .Std().addValue(Topic.DEFAULT_SCHEMA_ID_SERIALIZATION_ENABLED_KEY, configFactory.getBooleanProperty(Configs.SCHEMA_ID_SERIALIZATION_ENABLED));

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/config/ConsumerConfiguration.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/config/ConsumerConfiguration.java
@@ -218,7 +218,7 @@ public class ConsumerConfiguration {
         return new MessageBodyInterpolator();
     }
 
-    @Bean
+    @Bean(destroyMethod = "close")
     public Trackers trackers(List<LogRepository> repositories) {
         return new Trackers(repositories);
     }

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/config/ConsumerReceiverConfiguration.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/config/ConsumerReceiverConfiguration.java
@@ -45,9 +45,8 @@ public class ConsumerReceiverConfiguration {
     }
 
     @Bean
-    public BasicMessageContentReaderFactory basicMessageContentReaderFactory(MessageContentWrapper
-                                                                                     messageContentWrapper,
-                                                                             KafkaHeaderExtractor kafkaHeaderExtractor) {
+    public MessageContentReaderFactory messageContentReaderFactory(MessageContentWrapper messageContentWrapper,
+                                                                   KafkaHeaderExtractor kafkaHeaderExtractor) {
         return new BasicMessageContentReaderFactory(messageContentWrapper, kafkaHeaderExtractor);
     }
 

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/ConsumerMessageSenderFactory.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/ConsumerMessageSenderFactory.java
@@ -18,7 +18,6 @@ import pl.allegro.tech.hermes.consumers.consumer.sender.MessageSendingResult;
 import pl.allegro.tech.hermes.consumers.consumer.sender.timeout.FutureAsyncTimeout;
 import pl.allegro.tech.hermes.tracker.consumers.Trackers;
 
-import javax.inject.Inject;
 import java.time.Clock;
 import java.util.Arrays;
 import java.util.List;
@@ -40,7 +39,6 @@ public class ConsumerMessageSenderFactory {
     private final ConsumerAuthorizationHandler consumerAuthorizationHandler;
     private final ExecutorService rateLimiterReportingExecutor;
 
-    @Inject
     public ConsumerMessageSenderFactory(ConfigFactory configFactory, HermesMetrics hermesMetrics, MessageSenderFactory messageSenderFactory,
                                         Trackers trackers, FutureAsyncTimeout<MessageSendingResult> futureAsyncTimeout,
                                         UndeliveredMessageLog undeliveredMessageLog, Clock clock,

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/converter/AvroToJsonMessageConverter.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/converter/AvroToJsonMessageConverter.java
@@ -1,21 +1,12 @@
 package pl.allegro.tech.hermes.consumers.consumer.converter;
 
 import org.apache.avro.Schema;
-import org.apache.avro.generic.GenericDatumReader;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.generic.GenericRecordBuilder;
-import org.apache.avro.io.BinaryDecoder;
-import org.apache.avro.io.DecoderFactory;
 import pl.allegro.tech.hermes.api.ContentType;
 import pl.allegro.tech.hermes.api.Topic;
-import pl.allegro.tech.hermes.common.message.converter.AvroBinaryDecoders;
-import pl.allegro.tech.hermes.common.message.converter.AvroRecordToBytesConverter;
 import pl.allegro.tech.hermes.consumers.consumer.Message;
-import tech.allegro.schema.json2avro.converter.AvroConversionException;
 import tech.allegro.schema.json2avro.converter.JsonAvroConverter;
-
-import javax.inject.Inject;
-import java.io.IOException;
 
 import static java.util.stream.Collectors.toList;
 import static pl.allegro.tech.hermes.common.message.converter.AvroRecordToBytesConverter.bytesToRecord;
@@ -26,7 +17,6 @@ public class AvroToJsonMessageConverter implements MessageConverter {
 
     private final JsonAvroConverter converter;
 
-    @Inject
     public AvroToJsonMessageConverter() {
         this.converter = new JsonAvroConverter();
     }

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/converter/DefaultMessageConverterResolver.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/converter/DefaultMessageConverterResolver.java
@@ -4,14 +4,11 @@ import pl.allegro.tech.hermes.api.ContentType;
 import pl.allegro.tech.hermes.api.Subscription;
 import pl.allegro.tech.hermes.consumers.consumer.Message;
 
-import javax.inject.Inject;
-
 public class DefaultMessageConverterResolver implements MessageConverterResolver {
 
     private final AvroToJsonMessageConverter avroToJsonMessageConverter;
     private final NoOperationMessageConverter noOperationMessageConverter;
 
-    @Inject
     public DefaultMessageConverterResolver(AvroToJsonMessageConverter avroToJsonMessageConverter,
                                            NoOperationMessageConverter noOperationMessageConverter) {
         this.avroToJsonMessageConverter = avroToJsonMessageConverter;

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/oauth/OAuthAccessTokensLoader.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/oauth/OAuthAccessTokensLoader.java
@@ -12,8 +12,6 @@ import pl.allegro.tech.hermes.consumers.consumer.oauth.client.OAuthTokenRequest;
 import pl.allegro.tech.hermes.domain.oauth.OAuthProviderRepository;
 import pl.allegro.tech.hermes.domain.subscription.SubscriptionRepository;
 
-import javax.inject.Inject;
-
 import static pl.allegro.tech.hermes.api.SubscriptionOAuthPolicy.GrantType.USERNAME_PASSWORD;
 import static pl.allegro.tech.hermes.consumers.consumer.oauth.client.OAuthTokenRequest.oAuthTokenRequest;
 
@@ -27,7 +25,6 @@ public class OAuthAccessTokensLoader extends CacheLoader<SubscriptionName, OAuth
 
     private final HermesMetrics metrics;
 
-    @Inject
     public OAuthAccessTokensLoader(SubscriptionRepository subscriptionRepository,
                                    OAuthProviderRepository oAuthProviderRepository,
                                    OAuthClient oAuthClient,

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/oauth/OAuthConsumerAuthorizationHandler.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/oauth/OAuthConsumerAuthorizationHandler.java
@@ -12,7 +12,6 @@ import pl.allegro.tech.hermes.consumers.consumer.ConsumerAuthorizationHandler;
 import pl.allegro.tech.hermes.consumers.consumer.Message;
 import pl.allegro.tech.hermes.consumers.consumer.sender.MessageSendingResult;
 
-import javax.inject.Inject;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -29,7 +28,6 @@ public class OAuthConsumerAuthorizationHandler implements ConsumerAuthorizationH
 
     private final RateLimiter missingHandlersCreationRateLimiter;
 
-    @Inject
     public OAuthConsumerAuthorizationHandler(OAuthSubscriptionHandlerFactory handlerFactory,
                                              ConfigFactory configFactory,
                                              OAuthProvidersNotifyingCache oAuthProvidersCache) {

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/oauth/OAuthSubscriptionAccessTokens.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/oauth/OAuthSubscriptionAccessTokens.java
@@ -8,7 +8,6 @@ import pl.allegro.tech.hermes.api.SubscriptionName;
 import pl.allegro.tech.hermes.common.config.ConfigFactory;
 import pl.allegro.tech.hermes.common.config.Configs;
 
-import javax.inject.Inject;
 import java.util.Optional;
 
 public class OAuthSubscriptionAccessTokens implements OAuthAccessTokens {
@@ -19,7 +18,6 @@ public class OAuthSubscriptionAccessTokens implements OAuthAccessTokens {
 
     private final OAuthAccessTokensLoader tokenLoader;
 
-    @Inject
     public OAuthSubscriptionAccessTokens(OAuthAccessTokensLoader tokenLoader,
                                          ConfigFactory configFactory) {
         this.tokenLoader = tokenLoader;

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/oauth/OAuthSubscriptionHandlerFactory.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/oauth/OAuthSubscriptionHandlerFactory.java
@@ -6,7 +6,6 @@ import pl.allegro.tech.hermes.api.Subscription;
 import pl.allegro.tech.hermes.api.SubscriptionName;
 import pl.allegro.tech.hermes.domain.subscription.SubscriptionRepository;
 
-import javax.inject.Inject;
 import java.util.Optional;
 
 public class OAuthSubscriptionHandlerFactory {
@@ -19,7 +18,6 @@ public class OAuthSubscriptionHandlerFactory {
 
     private final OAuthTokenRequestRateLimiterFactory rateLimiterLoader;
 
-    @Inject
     public OAuthSubscriptionHandlerFactory(SubscriptionRepository subscriptionRepository,
                                            OAuthAccessTokens accessTokens,
                                            OAuthTokenRequestRateLimiterFactory rateLimiterLoader) {

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/oauth/OAuthTokenRequestRateLimiterFactory.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/oauth/OAuthTokenRequestRateLimiterFactory.java
@@ -6,8 +6,6 @@ import pl.allegro.tech.hermes.api.Subscription;
 import pl.allegro.tech.hermes.common.config.ConfigFactory;
 import pl.allegro.tech.hermes.domain.oauth.OAuthProviderRepository;
 
-import javax.inject.Inject;
-
 import static pl.allegro.tech.hermes.common.config.Configs.OAUTH_PROVIDERS_TOKEN_REQUEST_RATE_LIMITER_RATE_REDUCTION_FACTOR;
 
 public class OAuthTokenRequestRateLimiterFactory {
@@ -16,7 +14,6 @@ public class OAuthTokenRequestRateLimiterFactory {
 
     private final double rateReductionFactor;
 
-    @Inject
     public OAuthTokenRequestRateLimiterFactory(OAuthProviderRepository oAuthProviderRepository,
                                                ConfigFactory configFactory) {
         this.oAuthProviderRepository = oAuthProviderRepository;

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/oauth/client/OAuthHttpClient.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/oauth/client/OAuthHttpClient.java
@@ -9,10 +9,7 @@ import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.http.HttpMethod;
 import org.eclipse.jetty.http.HttpStatus;
 import pl.allegro.tech.hermes.consumers.consumer.oauth.OAuthAccessToken;
-import pl.allegro.tech.hermes.consumers.consumer.sender.http.HttpClientsFactory;
 
-import javax.inject.Inject;
-import javax.inject.Named;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -24,8 +21,7 @@ public class OAuthHttpClient implements OAuthClient {
 
     private final ObjectMapper objectMapper;
 
-    @Inject
-    public OAuthHttpClient(@Named("oauth-http-client") HttpClient httpClient, ObjectMapper objectMapper) {
+    public OAuthHttpClient(HttpClient httpClient, ObjectMapper objectMapper) {
         this.httpClient = httpClient;
         this.objectMapper = objectMapper;
     }

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/offset/OffsetQueue.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/offset/OffsetQueue.java
@@ -5,11 +5,9 @@ import pl.allegro.tech.hermes.common.config.ConfigFactory;
 import pl.allegro.tech.hermes.common.config.Configs;
 import pl.allegro.tech.hermes.common.metric.HermesMetrics;
 import pl.allegro.tech.hermes.consumers.queue.FullDrainMpscQueue;
+import pl.allegro.tech.hermes.consumers.queue.MonitoredMpscQueue;
 import pl.allegro.tech.hermes.consumers.queue.MpscQueue;
 import pl.allegro.tech.hermes.consumers.queue.WaitFreeDrainMpscQueue;
-import pl.allegro.tech.hermes.consumers.queue.MonitoredMpscQueue;
-
-import javax.inject.Inject;
 
 public class OffsetQueue {
 
@@ -17,7 +15,6 @@ public class OffsetQueue {
 
     private final MpscQueue<SubscriptionPartitionOffset> commitOffsetsQueue;
 
-    @Inject
     public OffsetQueue(HermesMetrics metrics, ConfigFactory configFactory) {
         int queueSize = configFactory.getIntProperty(Configs.CONSUMER_COMMIT_OFFSET_QUEUES_SIZE);
 

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/rate/ConsumerRateLimitSupervisor.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/rate/ConsumerRateLimitSupervisor.java
@@ -6,7 +6,6 @@ import org.slf4j.LoggerFactory;
 import pl.allegro.tech.hermes.common.config.ConfigFactory;
 import pl.allegro.tech.hermes.common.config.Configs;
 
-import javax.inject.Inject;
 import java.util.Collections;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -20,7 +19,6 @@ public class ConsumerRateLimitSupervisor implements Runnable {
 
     private final Set<ConsumerRateLimiter> consumerRateLimiters = Collections.newSetFromMap(new ConcurrentHashMap<>());
 
-    @Inject
     public ConsumerRateLimitSupervisor(ConfigFactory configFactory) {
         int period = configFactory.getIntProperty(Configs.CONSUMER_RATE_LIMITER_SUPERVISOR_PERIOD);
         ThreadFactory threadFactory = new ThreadFactoryBuilder().setNameFormat("rate-limit-supervisor-%d").build();

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/rate/calculator/OutputRateCalculatorFactory.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/rate/calculator/OutputRateCalculatorFactory.java
@@ -6,14 +6,11 @@ import pl.allegro.tech.hermes.consumers.consumer.rate.SendCounters;
 import pl.allegro.tech.hermes.consumers.consumer.rate.maxrate.MaxRateProvider;
 import pl.allegro.tech.hermes.consumers.consumer.rate.maxrate.MaxRateProviderFactory;
 
-import javax.inject.Inject;
-
 public class OutputRateCalculatorFactory {
 
     private final ConfigFactory configFactory;
     private final MaxRateProviderFactory maxRateProviderFactory;
 
-    @Inject
     public OutputRateCalculatorFactory(ConfigFactory configFactory,
                                        MaxRateProviderFactory maxRateProviderFactory) {
         this.configFactory = configFactory;

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/rate/maxrate/MaxRateProviderFactory.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/rate/maxrate/MaxRateProviderFactory.java
@@ -6,8 +6,6 @@ import pl.allegro.tech.hermes.common.config.ConfigFactory;
 import pl.allegro.tech.hermes.common.metric.HermesMetrics;
 import pl.allegro.tech.hermes.consumers.consumer.rate.SendCounters;
 
-import javax.inject.Inject;
-
 import static pl.allegro.tech.hermes.common.config.Configs.CONSUMER_MAXRATE_BUSY_TOLERANCE;
 import static pl.allegro.tech.hermes.common.config.Configs.CONSUMER_MAXRATE_HISTORY_SIZE;
 import static pl.allegro.tech.hermes.common.config.Configs.CONSUMER_MAXRATE_MIN_MAX_RATE;
@@ -18,7 +16,6 @@ public class MaxRateProviderFactory {
 
     private final Creator providerCreator;
 
-    @Inject
     public MaxRateProviderFactory(ConfigFactory configFactory,
                                   MaxRateRegistry maxRateRegistry,
                                   MaxRateSupervisor maxRateSupervisor,

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/rate/maxrate/MaxRateSupervisor.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/rate/maxrate/MaxRateSupervisor.java
@@ -9,7 +9,6 @@ import pl.allegro.tech.hermes.consumers.subscription.cache.SubscriptionsCache;
 import pl.allegro.tech.hermes.consumers.supervisor.workload.ClusterAssignmentCache;
 import pl.allegro.tech.hermes.infrastructure.zookeeper.ZookeeperPaths;
 
-import javax.inject.Inject;
 import java.time.Clock;
 import java.util.Collections;
 import java.util.Set;
@@ -28,7 +27,6 @@ public class MaxRateSupervisor implements Runnable {
     private final MaxRateRegistry maxRateRegistry;
     private ScheduledFuture<?> updateJob;
 
-    @Inject
     public MaxRateSupervisor(ConfigFactory configFactory,
                              ClusterAssignmentCache clusterAssignmentCache,
                              MaxRateRegistry maxRateRegistry,

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/receiver/kafka/BasicMessageContentReaderFactory.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/receiver/kafka/BasicMessageContentReaderFactory.java
@@ -3,14 +3,11 @@ package pl.allegro.tech.hermes.consumers.consumer.receiver.kafka;
 import pl.allegro.tech.hermes.api.Topic;
 import pl.allegro.tech.hermes.common.message.wrapper.MessageContentWrapper;
 
-import javax.inject.Inject;
-
 public class BasicMessageContentReaderFactory implements MessageContentReaderFactory {
 
     private final MessageContentWrapper messageContentWrapper;
     private final KafkaHeaderExtractor kafkaHeaderExtractor;
 
-    @Inject
     public BasicMessageContentReaderFactory(MessageContentWrapper messageContentWrapper, KafkaHeaderExtractor kafkaHeaderExtractor) {
         this.messageContentWrapper = messageContentWrapper;
         this.kafkaHeaderExtractor = kafkaHeaderExtractor;

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/receiver/kafka/KafkaHeaderExtractor.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/receiver/kafka/KafkaHeaderExtractor.java
@@ -6,15 +6,11 @@ import org.apache.kafka.common.header.Headers;
 import pl.allegro.tech.hermes.common.config.ConfigFactory;
 import pl.allegro.tech.hermes.common.config.Configs;
 
-import javax.inject.Inject;
-import java.util.Optional;
-
 public class KafkaHeaderExtractor {
 
     private final String schemaVersionHeaderName;
     private final String schemaIdHeaderName;
 
-    @Inject
     public KafkaHeaderExtractor(ConfigFactory configFactory) {
         this.schemaVersionHeaderName = configFactory.getStringProperty(Configs.KAFKA_HEADER_NAME_SCHEMA_VERSION);
         this.schemaIdHeaderName = configFactory.getStringProperty(Configs.KAFKA_HEADER_NAME_SCHEMA_ID);

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/receiver/kafka/KafkaMessageReceiverFactory.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/receiver/kafka/KafkaMessageReceiverFactory.java
@@ -9,7 +9,6 @@ import pl.allegro.tech.hermes.common.kafka.ConsumerGroupId;
 import pl.allegro.tech.hermes.common.kafka.KafkaNamesMapper;
 import pl.allegro.tech.hermes.common.metric.HermesMetrics;
 import pl.allegro.tech.hermes.consumers.consumer.filtering.FilteredMessageHandler;
-import pl.allegro.tech.hermes.domain.filtering.chain.FilterChainFactory;
 import pl.allegro.tech.hermes.consumers.consumer.idleTime.ExponentiallyGrowingIdleTimeCalculator;
 import pl.allegro.tech.hermes.consumers.consumer.idleTime.IdleTimeCalculator;
 import pl.allegro.tech.hermes.consumers.consumer.offset.ConsumerPartitionAssignmentState;
@@ -18,9 +17,9 @@ import pl.allegro.tech.hermes.consumers.consumer.rate.ConsumerRateLimiter;
 import pl.allegro.tech.hermes.consumers.consumer.receiver.MessageReceiver;
 import pl.allegro.tech.hermes.consumers.consumer.receiver.ReceiverFactory;
 import pl.allegro.tech.hermes.consumers.consumer.receiver.ThrottlingMessageReceiver;
+import pl.allegro.tech.hermes.domain.filtering.chain.FilterChainFactory;
 import pl.allegro.tech.hermes.tracker.consumers.Trackers;
 
-import javax.inject.Inject;
 import java.time.Clock;
 import java.util.Properties;
 
@@ -62,14 +61,13 @@ public class KafkaMessageReceiverFactory implements ReceiverFactory {
     private final ConfigFactory configs;
     private final MessageContentReaderFactory messageContentReaderFactory;
     private final HermesMetrics hermesMetrics;
-    private OffsetQueue offsetQueue;
+    private final OffsetQueue offsetQueue;
     private final Clock clock;
     private final KafkaNamesMapper kafkaNamesMapper;
     private final FilterChainFactory filterChainFactory;
     private final Trackers trackers;
     private final ConsumerPartitionAssignmentState consumerPartitionAssignmentState;
 
-    @Inject
     public KafkaMessageReceiverFactory(ConfigFactory configs,
                                        MessageContentReaderFactory messageContentReaderFactory,
                                        HermesMetrics hermesMetrics,

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/sender/HttpMessageBatchSenderFactory.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/sender/HttpMessageBatchSenderFactory.java
@@ -8,15 +8,12 @@ import pl.allegro.tech.hermes.consumers.consumer.sender.http.SendingResultHandle
 import pl.allegro.tech.hermes.consumers.consumer.sender.http.headers.DefaultBatchHeadersProvider;
 import pl.allegro.tech.hermes.consumers.consumer.sender.resolver.SimpleEndpointAddressResolver;
 
-import javax.inject.Inject;
-
 import static com.google.common.base.Preconditions.checkState;
 
 public class HttpMessageBatchSenderFactory implements MessageBatchSenderFactory {
-    private ConfigFactory configFactory;
-    private SendingResultHandlers resultHandlers;
+    private final ConfigFactory configFactory;
+    private final SendingResultHandlers resultHandlers;
 
-    @Inject
     public HttpMessageBatchSenderFactory(ConfigFactory configFactory, SendingResultHandlers resultHandlers) {
         this.configFactory = configFactory;
         this.resultHandlers = resultHandlers;

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/sender/ProtocolMessageSenderProvider.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/sender/ProtocolMessageSenderProvider.java
@@ -2,9 +2,13 @@ package pl.allegro.tech.hermes.consumers.consumer.sender;
 
 import pl.allegro.tech.hermes.api.Subscription;
 
+import java.util.Set;
+
 public interface ProtocolMessageSenderProvider {
 
     MessageSender create(Subscription subscription);
+
+    Set<String> getSupportedProtocols();
 
     void start() throws Exception;
 

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/sender/http/HttpClientsFactory.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/sender/http/HttpClientsFactory.java
@@ -7,7 +7,6 @@ import org.eclipse.jetty.util.HttpCookieStore;
 import pl.allegro.tech.hermes.common.config.ConfigFactory;
 import pl.allegro.tech.hermes.common.metric.executor.InstrumentedExecutorServiceFactory;
 
-import javax.inject.Inject;
 import java.util.concurrent.ExecutorService;
 
 import static pl.allegro.tech.hermes.common.config.Configs.CONSUMER_HTTP2_CLIENT_IDLE_TIMEOUT;
@@ -27,7 +26,6 @@ public class HttpClientsFactory {
     private final InstrumentedExecutorServiceFactory executorFactory;
     private final SslContextFactoryProvider sslContextFactoryProvider;
 
-    @Inject
     public HttpClientsFactory(ConfigFactory configFactory,
                               InstrumentedExecutorServiceFactory executorFactory,
                               SslContextFactoryProvider sslContextFactoryProvider) {

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/sender/http/HttpClientsWorkloadReporter.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/sender/http/HttpClientsWorkloadReporter.java
@@ -10,8 +10,6 @@ import pl.allegro.tech.hermes.common.config.Configs;
 import pl.allegro.tech.hermes.common.metric.Gauges;
 import pl.allegro.tech.hermes.common.metric.HermesMetrics;
 
-import javax.inject.Inject;
-import javax.inject.Named;
 import java.util.Queue;
 import java.util.function.Function;
 import java.util.stream.Stream;
@@ -24,10 +22,9 @@ public class HttpClientsWorkloadReporter {
     private final boolean isConnectionPoolMonitoringEnabled;
     private final boolean isRequestQueueMonitoringEnabled;
 
-    @Inject
     public HttpClientsWorkloadReporter(
             HermesMetrics metrics,
-            @Named("http-1-client") HttpClient httpClient,
+            HttpClient httpClient,
             Http2ClientHolder http2ClientHolder,
             ConfigFactory configFactory
     ) {

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/sender/http/JettyHttpMessageSenderProvider.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/sender/http/JettyHttpMessageSenderProvider.java
@@ -22,8 +22,6 @@ import pl.allegro.tech.hermes.consumers.consumer.sender.resolver.EndpointAddress
 import pl.allegro.tech.hermes.consumers.consumer.sender.resolver.ResolvableEndpointAddress;
 import pl.allegro.tech.hermes.consumers.consumer.trace.MetadataAppender;
 
-import javax.inject.Inject;
-import javax.inject.Named;
 import java.util.Collection;
 import java.util.Optional;
 
@@ -43,9 +41,8 @@ public class JettyHttpMessageSenderProvider implements ProtocolMessageSenderProv
     private final SendingResultHandlers sendingResultHandlers;
     private final HttpRequestFactoryProvider requestFactoryProvider;
 
-    @Inject
     public JettyHttpMessageSenderProvider(
-            @Named("http-1-client") HttpClient httpClient,
+            HttpClient httpClient,
             Http2ClientHolder http2ClientHolder,
             EndpointAddressResolver endpointAddressResolver,
             MetadataAppender<Request> metadataAppender,

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/sender/http/JettyHttpMessageSenderProvider.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/sender/http/JettyHttpMessageSenderProvider.java
@@ -24,6 +24,7 @@ import pl.allegro.tech.hermes.consumers.consumer.trace.MetadataAppender;
 
 import java.util.Collection;
 import java.util.Optional;
+import java.util.Set;
 
 public class JettyHttpMessageSenderProvider implements ProtocolMessageSenderProvider {
 
@@ -40,6 +41,7 @@ public class JettyHttpMessageSenderProvider implements ProtocolMessageSenderProv
     private final HttpHeadersProvidersFactory httpHeadersProviderFactory;
     private final SendingResultHandlers sendingResultHandlers;
     private final HttpRequestFactoryProvider requestFactoryProvider;
+    private final Set<String> supportedProtocols;
 
     public JettyHttpMessageSenderProvider(
             HttpClient httpClient,
@@ -49,7 +51,8 @@ public class JettyHttpMessageSenderProvider implements ProtocolMessageSenderProv
             HttpAuthorizationProviderFactory authorizationProviderFactory,
             HttpHeadersProvidersFactory httpHeadersProviderFactory,
             SendingResultHandlers sendingResultHandlers,
-            HttpRequestFactoryProvider requestFactoryProvider) {
+            HttpRequestFactoryProvider requestFactoryProvider,
+            Set<String> supportedProtocols) {
         this.httpClient = httpClient;
         this.http2ClientHolder = http2ClientHolder;
         this.endpointAddressResolver = endpointAddressResolver;
@@ -58,6 +61,7 @@ public class JettyHttpMessageSenderProvider implements ProtocolMessageSenderProv
         this.httpHeadersProviderFactory = httpHeadersProviderFactory;
         this.sendingResultHandlers = sendingResultHandlers;
         this.requestFactoryProvider = requestFactoryProvider;
+        this.supportedProtocols = supportedProtocols;
     }
 
     @Override
@@ -73,6 +77,11 @@ public class JettyHttpMessageSenderProvider implements ProtocolMessageSenderProv
         } else {
             return new JettyMessageSender(requestFactory, resolvableEndpoint, getHttpRequestHeadersProvider(subscription), sendingResultHandlers);
         }
+    }
+
+    @Override
+    public Set<String> getSupportedProtocols() {
+        return supportedProtocols;
     }
 
     private HttpHeadersProvider getHttpRequestHeadersProvider(Subscription subscription) {

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/sender/http/auth/HttpAuthorizationProviderFactory.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/sender/http/auth/HttpAuthorizationProviderFactory.java
@@ -3,14 +3,12 @@ package pl.allegro.tech.hermes.consumers.consumer.sender.http.auth;
 import pl.allegro.tech.hermes.api.Subscription;
 import pl.allegro.tech.hermes.consumers.consumer.oauth.OAuthAccessTokens;
 
-import javax.inject.Inject;
 import java.util.Optional;
 
 public class HttpAuthorizationProviderFactory {
 
     private final OAuthAccessTokens accessTokens;
 
-    @Inject
     public HttpAuthorizationProviderFactory(OAuthAccessTokens accessTokens) {
         this.accessTokens = accessTokens;
     }

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/sender/jms/JmsHornetQMessageSenderProvider.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/sender/jms/JmsHornetQMessageSenderProvider.java
@@ -8,7 +8,6 @@ import pl.allegro.tech.hermes.common.config.ConfigFactory;
 import pl.allegro.tech.hermes.consumers.consumer.trace.MetadataAppender;
 import pl.allegro.tech.hermes.consumers.uri.UriUtils;
 
-import javax.inject.Inject;
 import javax.jms.ConnectionFactory;
 import javax.jms.Message;
 import java.net.URI;
@@ -16,7 +15,6 @@ import java.util.HashMap;
 
 public class JmsHornetQMessageSenderProvider extends AbstractJmsMessageSenderProvider {
 
-    @Inject
     public JmsHornetQMessageSenderProvider(ConfigFactory configFactory, MetadataAppender<Message> metadataAppender) {
         super(configFactory, metadataAppender);
     }

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/sender/jms/JmsHornetQMessageSenderProvider.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/sender/jms/JmsHornetQMessageSenderProvider.java
@@ -1,5 +1,6 @@
 package pl.allegro.tech.hermes.consumers.consumer.sender.jms;
 
+import com.google.common.collect.ImmutableSet;
 import org.hornetq.api.core.TransportConfiguration;
 import org.hornetq.api.jms.HornetQJMSClient;
 import org.hornetq.api.jms.JMSFactoryType;
@@ -12,8 +13,10 @@ import javax.jms.ConnectionFactory;
 import javax.jms.Message;
 import java.net.URI;
 import java.util.HashMap;
+import java.util.Set;
 
 public class JmsHornetQMessageSenderProvider extends AbstractJmsMessageSenderProvider {
+    private static final Set<String> SUPPORTED_PROTOCOLS = ImmutableSet.of("jms");
 
     public JmsHornetQMessageSenderProvider(ConfigFactory configFactory, MetadataAppender<Message> metadataAppender) {
         super(configFactory, metadataAppender);
@@ -31,4 +34,8 @@ public class JmsHornetQMessageSenderProvider extends AbstractJmsMessageSenderPro
         return HornetQJMSClient.createConnectionFactoryWithoutHA(JMSFactoryType.CF, transportConfiguration);
     }
 
+    @Override
+    public Set<String> getSupportedProtocols() {
+        return SUPPORTED_PROTOCOLS;
+    }
 }

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/sender/resolver/InterpolatingEndpointAddressResolver.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/sender/resolver/InterpolatingEndpointAddressResolver.java
@@ -2,18 +2,16 @@ package pl.allegro.tech.hermes.consumers.consumer.sender.resolver;
 
 import pl.allegro.tech.hermes.api.EndpointAddress;
 import pl.allegro.tech.hermes.api.EndpointAddressResolverMetadata;
+import pl.allegro.tech.hermes.consumers.consumer.Message;
 import pl.allegro.tech.hermes.consumers.consumer.interpolation.InterpolationException;
 import pl.allegro.tech.hermes.consumers.consumer.interpolation.UriInterpolator;
-import pl.allegro.tech.hermes.consumers.consumer.Message;
 
-import javax.inject.Inject;
 import java.net.URI;
 
 public class InterpolatingEndpointAddressResolver implements EndpointAddressResolver {
 
     private final UriInterpolator interpolator;
 
-    @Inject
     public InterpolatingEndpointAddressResolver(UriInterpolator interpolator) {
         this.interpolator = interpolator;
     }

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/health/ConsumerHttpServer.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/health/ConsumerHttpServer.java
@@ -6,7 +6,6 @@ import com.sun.net.httpserver.HttpServer;
 import pl.allegro.tech.hermes.common.config.ConfigFactory;
 import pl.allegro.tech.hermes.common.config.Configs;
 
-import javax.inject.Inject;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.InetSocketAddress;
@@ -23,7 +22,6 @@ public class ConsumerHttpServer {
 
     private static final String STATUS_UP = "{\"status\": \"UP\"}";
 
-    @Inject
     public ConsumerHttpServer(ConfigFactory configFactory, ConsumerMonitor monitor, ObjectMapper mapper) throws IOException {
         this.mapper = mapper;
         server = createServer(configFactory.getIntProperty(Configs.CONSUMER_HEALTH_CHECK_PORT));

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/message/undelivered/UndeliveredMessageLogPersister.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/message/undelivered/UndeliveredMessageLogPersister.java
@@ -5,7 +5,6 @@ import pl.allegro.tech.hermes.common.config.ConfigFactory;
 import pl.allegro.tech.hermes.common.config.Configs;
 import pl.allegro.tech.hermes.common.message.undelivered.UndeliveredMessageLog;
 
-import javax.inject.Inject;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 
@@ -15,9 +14,8 @@ public class UndeliveredMessageLogPersister {
 
     private final int periodMs;
     private final UndeliveredMessageLog undeliveredMessageLog;
-    private ScheduledExecutorService scheduledExecutorService;
+    private final ScheduledExecutorService scheduledExecutorService;
 
-    @Inject
     public UndeliveredMessageLogPersister(UndeliveredMessageLog undeliveredMessageLog, ConfigFactory configFactory) {
         this.undeliveredMessageLog = undeliveredMessageLog;
         this.periodMs = configFactory.getIntProperty(Configs.UNDELIVERED_MESSAGE_LOG_PERSIST_PERIOD_MS);

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/registry/ConsumerNodesRegistry.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/registry/ConsumerNodesRegistry.java
@@ -6,6 +6,7 @@ import org.apache.curator.framework.recipes.cache.PathChildrenCacheEvent;
 import org.apache.curator.framework.recipes.cache.PathChildrenCacheListener;
 import org.apache.curator.framework.recipes.leader.LeaderLatch;
 import org.apache.curator.framework.recipes.leader.LeaderLatchListener;
+import org.apache.zookeeper.KeeperException.NodeExistsException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import pl.allegro.tech.hermes.common.exception.InternalProcessingException;
@@ -124,10 +125,12 @@ public class ConsumerNodesRegistry extends PathChildrenCache implements PathChil
                         .withMode(EPHEMERAL).forPath(nodePath);
                 logger.info("Registered in consumer nodes registry as {}", consumerNodeId);
             }
-            refresh();
+        } catch (NodeExistsException e) {
+            // Ignore as it is a race condition between threads trying to register the consumer node.
         } catch (Exception e) {
             throw new InternalProcessingException(e);
         }
+        refresh();
     }
 
     private List<String> findDeadConsumers(long currentTime) {

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/ConsumerFactory.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/ConsumerFactory.java
@@ -21,7 +21,6 @@ import pl.allegro.tech.hermes.consumers.consumer.sender.MessageBatchSenderFactor
 import pl.allegro.tech.hermes.domain.topic.TopicRepository;
 import pl.allegro.tech.hermes.tracker.consumers.Trackers;
 
-import javax.inject.Inject;
 import java.time.Clock;
 
 public class ConsumerFactory {
@@ -42,7 +41,6 @@ public class ConsumerFactory {
     private final ConsumerAuthorizationHandler consumerAuthorizationHandler;
     private final Clock clock;
 
-    @Inject
     public ConsumerFactory(ReceiverFactory messageReceiverFactory,
                            HermesMetrics hermesMetrics,
                            ConfigFactory configFactory,

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/ConsumersExecutorService.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/ConsumersExecutorService.java
@@ -8,7 +8,6 @@ import pl.allegro.tech.hermes.common.config.Configs;
 import pl.allegro.tech.hermes.common.metric.HermesMetrics;
 import pl.allegro.tech.hermes.consumers.supervisor.process.ConsumerProcess;
 
-import javax.inject.Inject;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.ThreadFactory;
@@ -20,7 +19,6 @@ public class ConsumersExecutorService {
     private static final Logger logger = LoggerFactory.getLogger(ConsumersExecutorService.class);
     private final ThreadPoolExecutor executor;
 
-    @Inject
     public ConsumersExecutorService(ConfigFactory configFactory, HermesMetrics hermesMetrics) {
         ThreadFactory threadFactory = new ThreadFactoryBuilder()
             .setNameFormat("Consumer-%d")

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/NonblockingConsumersSupervisor.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/NonblockingConsumersSupervisor.java
@@ -20,7 +20,6 @@ import pl.allegro.tech.hermes.consumers.supervisor.process.Retransmitter;
 import pl.allegro.tech.hermes.consumers.supervisor.process.Signal;
 import pl.allegro.tech.hermes.domain.subscription.SubscriptionRepository;
 
-import javax.inject.Inject;
 import java.time.Clock;
 import java.util.Set;
 import java.util.concurrent.Executors;
@@ -45,7 +44,6 @@ public class NonblockingConsumersSupervisor implements ConsumersSupervisor {
 
     private final ScheduledExecutorService scheduledExecutor;
 
-    @Inject
     public NonblockingConsumersSupervisor(ConfigFactory configFactory,
                                           ConsumersExecutorService executor,
                                           ConsumerFactory consumerFactory,

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/process/Retransmitter.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/process/Retransmitter.java
@@ -10,18 +10,15 @@ import pl.allegro.tech.hermes.common.kafka.offset.PartitionOffsets;
 import pl.allegro.tech.hermes.common.kafka.offset.SubscriptionOffsetChangeIndicator;
 import pl.allegro.tech.hermes.consumers.consumer.Consumer;
 
-import javax.inject.Inject;
-
 import static pl.allegro.tech.hermes.common.config.Configs.KAFKA_CLUSTER_NAME;
 
 public class Retransmitter {
 
     private static final Logger logger = LoggerFactory.getLogger(Retransmitter.class);
 
-    private SubscriptionOffsetChangeIndicator subscriptionOffsetChangeIndicator;
-    private String brokersClusterName;
+    private final SubscriptionOffsetChangeIndicator subscriptionOffsetChangeIndicator;
+    private final String brokersClusterName;
 
-    @Inject
     public Retransmitter(SubscriptionOffsetChangeIndicator subscriptionOffsetChangeIndicator,
                          ConfigFactory configs) {
         this.subscriptionOffsetChangeIndicator = subscriptionOffsetChangeIndicator;

--- a/hermes-consumers/src/test/groovy/pl/allegro/tech/hermes/consumers/consumer/result/InMemoryLogRepository.groovy
+++ b/hermes-consumers/src/test/groovy/pl/allegro/tech/hermes/consumers/consumer/result/InMemoryLogRepository.groovy
@@ -36,6 +36,11 @@ class InMemoryLogRepository implements LogRepository {
         filtered.add(message)
     }
 
+    @Override
+    void close() {
+
+    }
+
     boolean hasSuccessfulLog(String kafkaTopic, int partition, long offset) {
         return logContains(successful, kafkaTopic, partition, offset)
     }

--- a/hermes-management/build.gradle
+++ b/hermes-management/build.gradle
@@ -10,7 +10,9 @@ dependencies {
     compile group: 'net.sf.jopt-simple', name: 'jopt-simple', version: '4.8'
     compile group: 'org.glassfish.jersey.ext', name: 'jersey-mvc-freemarker', version: versions.jersey
 
-    compile 'io.swagger:swagger-jersey2-jaxrs:1.6.3'
+    compile (group: 'io.swagger', name: 'swagger-jersey2-jaxrs', version: '1.6.3') {
+        exclude group: 'javax.validation', module: 'validation-api'
+    }
 
     compile group: 'org.apache.kafka', name: 'kafka-clients', version: versions.kafka
 

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/api/mappers/ConstraintViolationMapper.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/api/mappers/ConstraintViolationMapper.java
@@ -3,7 +3,7 @@ package pl.allegro.tech.hermes.management.api.mappers;
 import com.google.common.base.Function;
 import com.google.common.base.Joiner;
 import com.google.common.collect.Lists;
-import org.glassfish.jersey.server.validation.ValidationError;
+import org.glassfish.jersey.server.validation.ValidationErrorData;
 import org.glassfish.jersey.server.validation.internal.ValidationHelper;
 import pl.allegro.tech.hermes.api.ErrorCode;
 
@@ -33,15 +33,15 @@ public class ConstraintViolationMapper extends AbstractExceptionMapper<Constrain
     private String prepareMessage(ConstraintViolationException ex) {
         List<String> errors = Lists.transform(
                 ValidationHelper.constraintViolationToValidationErrors(ex),
-                new ValidationErrorConverter()
+                new ValidationErrorDataConverter()
         );
 
         return Joiner.on("; ").join(errors);
     }
 
-    private static final class ValidationErrorConverter implements Function<ValidationError, String> {
+    private static final class ValidationErrorDataConverter implements Function<ValidationErrorData, String> {
         @Override
-        public String apply(ValidationError input) {
+        public String apply(ValidationErrorData input) {
             return input.getPath() + " " + input.getMessage();
         }
     }

--- a/hermes-tracker-elasticsearch/src/main/java/pl/allegro/tech/hermes/tracker/elasticsearch/consumers/ConsumersElasticsearchLogRepository.java
+++ b/hermes-tracker-elasticsearch/src/main/java/pl/allegro/tech/hermes/tracker/elasticsearch/consumers/ConsumersElasticsearchLogRepository.java
@@ -27,6 +27,8 @@ public class ConsumersElasticsearchLogRepository extends BatchingLogRepository<E
 
     private static final int DOCUMENT_EXPECTED_SIZE = 1024;
 
+    private final Client elasticClient;
+
     private ConsumersElasticsearchLogRepository(Client elasticClient,
                                                 String clusterName,
                                                 String hostname,
@@ -37,6 +39,7 @@ public class ConsumersElasticsearchLogRepository extends BatchingLogRepository<E
                                                 MetricRegistry metricRegistry,
                                                 PathsCompiler pathsCompiler) {
         super(queueSize, clusterName, hostname, metricRegistry, pathsCompiler);
+        this.elasticClient = elasticClient;
 
         registerQueueSizeGauge(Gauges.CONSUMER_TRACKER_ELASTICSEARCH_QUEUE_SIZE);
         registerRemainingCapacityGauge(Gauges.CONSUMER_TRACKER_ELASTICSEARCH_REMAINING_CAPACITY);
@@ -75,6 +78,11 @@ public class ConsumersElasticsearchLogRepository extends BatchingLogRepository<E
     @Override
     public void logFiltered(MessageMetadata message, long timestamp, String reason) {
         queue.offer(document(message, timestamp, FILTERED, reason));
+    }
+
+    @Override
+    public void close() {
+        elasticClient.close();
     }
 
     private ElasticsearchDocument document(MessageMetadata message, long createdAt, SentMessageTraceStatus status) {

--- a/hermes-tracker-mongo/src/main/java/pl/allegro/tech/hermes/tracker/mongo/consumers/MongoLogRepository.java
+++ b/hermes-tracker-mongo/src/main/java/pl/allegro/tech/hermes/tracker/mongo/consumers/MongoLogRepository.java
@@ -59,6 +59,11 @@ public class MongoLogRepository extends BatchingLogRepository<DBObject> implemen
         queue.offer(subscriptionLog(message, timestamp, FILTERED).append(REASON, reason));
     }
 
+    @Override
+    public void close() {
+
+    }
+
     private BasicDBObject subscriptionLog(MessageMetadata message, long timestamp, SentMessageTraceStatus status) {
         return new BasicDBObject()
                 .append(MESSAGE_ID, message.getMessageId())

--- a/hermes-tracker/src/main/java/pl/allegro/tech/hermes/tracker/consumers/DiscardedSendingTracker.java
+++ b/hermes-tracker/src/main/java/pl/allegro/tech/hermes/tracker/consumers/DiscardedSendingTracker.java
@@ -38,8 +38,4 @@ public class DiscardedSendingTracker implements SendingTracker {
     public void logFiltered(MessageMetadata messageMetadata, String reason) {
 
     }
-
-    void add(LogRepository logRepository) {
-        repositories.add(logRepository);
-    }
 }

--- a/hermes-tracker/src/main/java/pl/allegro/tech/hermes/tracker/consumers/LogRepository.java
+++ b/hermes-tracker/src/main/java/pl/allegro/tech/hermes/tracker/consumers/LogRepository.java
@@ -7,4 +7,5 @@ public interface LogRepository {
     void logDiscarded(MessageMetadata message, long timestamp, String reason);
     void logInflight(MessageMetadata message, long timestamp);
     void logFiltered(MessageMetadata message, long timestamp, String reason);
+    void close();
 }

--- a/hermes-tracker/src/main/java/pl/allegro/tech/hermes/tracker/consumers/SendingMessageTracker.java
+++ b/hermes-tracker/src/main/java/pl/allegro/tech/hermes/tracker/consumers/SendingMessageTracker.java
@@ -37,8 +37,4 @@ class SendingMessageTracker implements SendingTracker {
     public void logFiltered(MessageMetadata message, String reason) {
         repositories.forEach(r -> r.logFiltered(message, clock.millis(), reason));
     }
-
-    void add(LogRepository logRepository) {
-        repositories.add(logRepository);
-    }
 }

--- a/hermes-tracker/src/main/java/pl/allegro/tech/hermes/tracker/consumers/Trackers.java
+++ b/hermes-tracker/src/main/java/pl/allegro/tech/hermes/tracker/consumers/Trackers.java
@@ -7,23 +7,16 @@ import java.util.List;
 
 public class Trackers {
 
+    private final List<LogRepository> repositories;
     private final SendingMessageTracker sendingMessageTracker;
     private final DiscardedSendingTracker discardedSendingTracker;
     private final NoOperationSendingTracker noOperationDeliveryTracker;
 
     public Trackers(List<LogRepository> repositories) {
-        this(new SendingMessageTracker(repositories, Clock.systemUTC()),
-                new DiscardedSendingTracker(repositories, Clock.systemUTC()),
-                new NoOperationSendingTracker());
-    }
-
-    Trackers(SendingMessageTracker sendingMessageTracker,
-             DiscardedSendingTracker discardedSendingTracker,
-             NoOperationSendingTracker noOperationDeliveryTracker) {
-
-        this.sendingMessageTracker = sendingMessageTracker;
-        this.discardedSendingTracker = discardedSendingTracker;
-        this.noOperationDeliveryTracker = noOperationDeliveryTracker;
+        this.repositories = repositories;
+        this.sendingMessageTracker = new SendingMessageTracker(repositories, Clock.systemUTC());
+        this.discardedSendingTracker = new DiscardedSendingTracker(repositories, Clock.systemUTC());
+        this.noOperationDeliveryTracker = new NoOperationSendingTracker();
     }
 
     public SendingTracker get(Subscription subscription) {
@@ -39,7 +32,7 @@ public class Trackers {
         return noOperationDeliveryTracker;
     }
 
-    public void add(LogRepository logRepository) {
-        sendingMessageTracker.add(logRepository);
+    public void close() {
+        repositories.forEach(LogRepository::close);
     }
 }

--- a/hermes-tracker/src/test/java/pl/allegro/tech/hermes/tracker/consumers/TrackersTest.java
+++ b/hermes-tracker/src/test/java/pl/allegro/tech/hermes/tracker/consumers/TrackersTest.java
@@ -1,40 +1,38 @@
 package pl.allegro.tech.hermes.tracker.consumers;
 
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import pl.allegro.tech.hermes.api.Subscription;
 import pl.allegro.tech.hermes.api.TrackingMode;
 
+import java.util.ArrayList;
+
 import static org.assertj.core.api.Assertions.assertThat;
+import static pl.allegro.tech.hermes.api.TrackingMode.TRACKING_OFF;
+import static pl.allegro.tech.hermes.api.TrackingMode.TRACK_ALL;
+import static pl.allegro.tech.hermes.api.TrackingMode.TRACK_DISCARDED_ONLY;
 import static pl.allegro.tech.hermes.test.helper.builder.SubscriptionBuilder.subscription;
 
-@RunWith(MockitoJUnitRunner.class)
 public class TrackersTest {
-
-    @Mock
-    SendingMessageTracker messageDeliveryTracker;
-
-    @Mock
-    NoOperationSendingTracker noOperationDeliveryTracker;
-
-    @Mock
-    DiscardedSendingTracker discardedSendingTracker;
-
-    @InjectMocks
-    Trackers trackers;
 
     @Test
     public void shouldDispatchCorrectTracker() {
-        assertThat(trackers.get(subscription("group.topic", "sub").withTrackingMode(TrackingMode.TRACKING_OFF)
-                .build())).isEqualTo(noOperationDeliveryTracker);
-        assertThat(trackers.get(subscription("group.topic", "sub")
-                .withTrackingMode(TrackingMode.TRACK_DISCARDED_ONLY).build())).isEqualTo(discardedSendingTracker);
+        // given
+        Trackers trackers = new Trackers(new ArrayList<>());
 
+        // when
+        SendingTracker trackingOffTracker = trackers.get(subscriptionWithTrackingMode(TRACKING_OFF));
+        SendingTracker trackDiscardedOnlyTracker = trackers.get(subscriptionWithTrackingMode(TRACK_DISCARDED_ONLY));
+        SendingTracker trackAllTracker = trackers.get(subscriptionWithTrackingMode(TRACK_ALL));
 
-        assertThat(trackers.get(subscription("group.topic", "sub").withTrackingMode(TrackingMode.TRACK_ALL)
-                .build())).isEqualTo(messageDeliveryTracker);
+        // then
+        assertThat(trackingOffTracker.getClass()).isEqualTo(NoOperationSendingTracker.class);
+        assertThat(trackDiscardedOnlyTracker.getClass()).isEqualTo(DiscardedSendingTracker.class);
+        assertThat(trackAllTracker.getClass()).isEqualTo(SendingMessageTracker.class);
     }
 
+    private static Subscription subscriptionWithTrackingMode(TrackingMode trackingMode) {
+        return subscription("group.topic", "sub")
+                .withTrackingMode(trackingMode)
+                .build();
+    }
 }

--- a/integration/src/integration/java/pl/allegro/tech/hermes/integration/management/OfflineRetransmissionManagementTest.java
+++ b/integration/src/integration/java/pl/allegro/tech/hermes/integration/management/OfflineRetransmissionManagementTest.java
@@ -80,8 +80,8 @@ public class OfflineRetransmissionManagementTest extends IntegrationTest {
         assertThat(response).containsMessages(
                 "sourceTopic may not be empty",
                 "targetTopic may not be empty",
-                "startTimestamp may not be null",
-                "endTimestamp may not be null");
+                "endTimestamp must not be null",
+                "endTimestamp must not be null");
     }
 
     @Test

--- a/integration/src/integration/java/pl/allegro/tech/hermes/integration/test/HttpResponseAssertion.java
+++ b/integration/src/integration/java/pl/allegro/tech/hermes/integration/test/HttpResponseAssertion.java
@@ -34,7 +34,7 @@ public class HttpResponseAssertion extends AbstractAssert<HttpResponseAssertion,
 
     public HttpResponseAssertion containsMessages(String ...messages) {
         String responseBody = actual.readEntity(String.class);
-        assertThat(Arrays.stream(messages).allMatch(responseBody::contains)).isTrue();
+        assertThat(Arrays.stream(messages).allMatch(responseBody::contains)).as("response: " + responseBody).isTrue();
         return this;
     }
 

--- a/integration/src/integration/java/pl/allegro/tech/hermes/integration/test/HttpResponseAssertion.java
+++ b/integration/src/integration/java/pl/allegro/tech/hermes/integration/test/HttpResponseAssertion.java
@@ -34,7 +34,7 @@ public class HttpResponseAssertion extends AbstractAssert<HttpResponseAssertion,
 
     public HttpResponseAssertion containsMessages(String ...messages) {
         String responseBody = actual.readEntity(String.class);
-        assertThat(Arrays.stream(messages).allMatch(responseBody::contains)).as("response: " + responseBody).isTrue();
+        assertThat(Arrays.stream(messages).allMatch(responseBody::contains)).isTrue();
         return this;
     }
 


### PR DESCRIPTION
This PR is a follow-up to #1457.

What has been done in the PR:
* updated documentation related to extending Hermes
* removed dependency on a DI framework from packages other than `config`
* updated versions of `hibernate-validator` and `jersey` to match those that Spring brings 
* fixed race condition on registering a consumer node in zookeeper
* added closing the tracker module on the application shutdown - in the hk2 world it was possible to register a shutdown hook for this purpose 