### PR TITLE
Test living audit events endpoint

### DIFF
--- a/integration/src/integration/java/pl/allegro/tech/hermes/integration/env/AuditEventMockStarter.java
+++ b/integration/src/integration/java/pl/allegro/tech/hermes/integration/env/AuditEventMockStarter.java
@@ -1,0 +1,10 @@
+package pl.allegro.tech.hermes.integration.env;
+
+import pl.allegro.tech.hermes.test.helper.environment.WireMockStarter;
+
+public class AuditEventMockStarter extends WireMockStarter implements EnvironmentAware {
+
+    public AuditEventMockStarter() {
+        super(AUDIT_EVENT_PORT);
+    }
+}

--- a/integration/src/integration/java/pl/allegro/tech/hermes/integration/env/EnvironmentAware.java
+++ b/integration/src/integration/java/pl/allegro/tech/hermes/integration/env/EnvironmentAware.java
@@ -30,6 +30,8 @@ public interface EnvironmentAware {
 
     int OAUTH_SERVER_PORT = 19999;
 
+    int AUDIT_EVENT_PORT = 19998;
+
     String PRIMARY_KAFKA_CLUSTER_NAME = CONFIG_FACTORY.getStringProperty(Configs.KAFKA_CLUSTER_NAME);
 
     String SECONDARY_KAFKA_CLUSTER_NAME = "secondary";

--- a/integration/src/integration/java/pl/allegro/tech/hermes/integration/env/HermesIntegrationEnvironment.java
+++ b/integration/src/integration/java/pl/allegro/tech/hermes/integration/env/HermesIntegrationEnvironment.java
@@ -26,12 +26,9 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 
-import static com.jayway.awaitility.Awaitility.waitAtMost;
 import static pl.allegro.tech.hermes.management.infrastructure.dc.DefaultDatacenterNameProvider.DEFAULT_DC_NAME;
-import static pl.allegro.tech.hermes.test.helper.endpoint.TimeoutAdjuster.adjust;
 
 @Listeners({RetryListener.class})
 public class HermesIntegrationEnvironment implements EnvironmentAware {
@@ -64,6 +61,7 @@ public class HermesIntegrationEnvironment implements EnvironmentAware {
         STARTERS.put(WireMockStarter.class, new WireMockStarter(HTTP_ENDPOINT_PORT));
         STARTERS.put(GraphiteHttpMockStarter.class, new GraphiteHttpMockStarter());
         STARTERS.put(OAuthServerMockStarter.class, new OAuthServerMockStarter());
+        STARTERS.put(AuditEventMockStarter.class, new AuditEventMockStarter());
         STARTERS.put(JmsStarter.class, new JmsStarter());
     }
 

--- a/integration/src/integration/java/pl/allegro/tech/hermes/integration/env/SharedServices.java
+++ b/integration/src/integration/java/pl/allegro/tech/hermes/integration/env/SharedServices.java
@@ -44,6 +44,10 @@ public final class SharedServices {
         return ((WireMockStarter) starters.get(OAuthServerMockStarter.class)).instance();
     }
 
+    public WireMockServer auditEventMock() {
+        return ((WireMockStarter) starters.get(AuditEventMockStarter.class)).instance();
+    }
+
     public CuratorFramework zookeeper() {
         return zookeeper;
     }

--- a/integration/src/integration/java/pl/allegro/tech/hermes/integration/helper/AuditEventEndpoint.java
+++ b/integration/src/integration/java/pl/allegro/tech/hermes/integration/helper/AuditEventEndpoint.java
@@ -4,28 +4,22 @@ import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
 import com.google.common.collect.Iterables;
-import com.jayway.awaitility.Duration;
 import pl.allegro.tech.hermes.integration.env.EnvironmentAware;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
-import static com.jayway.awaitility.Awaitility.await;
-import static org.assertj.core.api.Assertions.assertThat;
-import static pl.allegro.tech.hermes.test.helper.endpoint.TimeoutAdjuster.adjust;
 
 public class AuditEventEndpoint implements EnvironmentAware {
 
     private static final String AUDIT_EVENT_URL = "/audit-events";
-    private final WireMock auditEventListener;
 
     private final List<LoggedRequest> receivedRequests = Collections.synchronizedList(new ArrayList<>());
-
+    private final WireMock auditEventListener;
     private final WireMockServer service;
 
     public AuditEventEndpoint(WireMockServer wireMockServer) {
@@ -42,26 +36,14 @@ public class AuditEventEndpoint implements EnvironmentAware {
             }
         });
 
-        auditEventListener
-                .register(
-                        post(urlEqualTo(AUDIT_EVENT_URL))
-                                .willReturn(aResponse().withStatus(201)));
+        auditEventListener.register(post(urlEqualTo(AUDIT_EVENT_URL))
+                .willReturn(aResponse().withStatus(201)));
     }
 
-    public void waitUntilReceived(long seconds) {
-        await().atMost(adjust(new Duration(seconds, TimeUnit.SECONDS))).until(() ->
-                assertThat(receivedRequests.size()).isGreaterThanOrEqualTo(1));
-    }
-
-    private LoggedRequest getLastReceivedRequest() {
+    public LoggedRequest getLastRequest() {
         synchronized (receivedRequests) {
             return Iterables.getLast(receivedRequests);
         }
-    }
-
-    public LoggedRequest waitAndGetLastRequest() {
-        waitUntilReceived(60);
-        return getLastReceivedRequest();
     }
 
     public void reset() {
@@ -72,4 +54,5 @@ public class AuditEventEndpoint implements EnvironmentAware {
         auditEventListener.shutdown();
         service.shutdown();
     }
+
 }

--- a/integration/src/integration/java/pl/allegro/tech/hermes/integration/helper/AuditEventEndpoint.java
+++ b/integration/src/integration/java/pl/allegro/tech/hermes/integration/helper/AuditEventEndpoint.java
@@ -1,0 +1,75 @@
+package pl.allegro.tech.hermes.integration.helper;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.verification.LoggedRequest;
+import com.google.common.collect.Iterables;
+import com.jayway.awaitility.Duration;
+import pl.allegro.tech.hermes.integration.env.EnvironmentAware;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.jayway.awaitility.Awaitility.await;
+import static org.assertj.core.api.Assertions.assertThat;
+import static pl.allegro.tech.hermes.test.helper.endpoint.TimeoutAdjuster.adjust;
+
+public class AuditEventEndpoint implements EnvironmentAware {
+
+    private static final String AUDIT_EVENT_URL = "/audit-events";
+    private final WireMock auditEventListener;
+
+    private final List<LoggedRequest> receivedRequests = Collections.synchronizedList(new ArrayList<>());
+
+    private final WireMockServer service;
+
+    public AuditEventEndpoint(WireMockServer wireMockServer) {
+        this.auditEventListener = new WireMock("localhost", wireMockServer.port());
+        this.service = wireMockServer;
+
+        service.resetMappings();
+        service.resetRequests();
+        service.resetScenarios();
+
+        service.addMockServiceRequestListener((request, response) -> {
+            if (AUDIT_EVENT_URL.equals(request.getUrl())) {
+                receivedRequests.add(LoggedRequest.createFrom(request));
+            }
+        });
+
+        auditEventListener
+                .register(
+                        post(urlEqualTo(AUDIT_EVENT_URL))
+                                .willReturn(aResponse().withStatus(201)));
+    }
+
+    public void waitUntilReceived(long seconds) {
+        await().atMost(adjust(new Duration(seconds, TimeUnit.SECONDS))).until(() ->
+                assertThat(receivedRequests.size()).isGreaterThanOrEqualTo(1));
+    }
+
+    private LoggedRequest getLastReceivedRequest() {
+        synchronized (receivedRequests) {
+            return Iterables.getLast(receivedRequests);
+        }
+    }
+
+    public LoggedRequest waitAndGetLastRequest() {
+        waitUntilReceived(60);
+        return getLastReceivedRequest();
+    }
+
+    public void reset() {
+        receivedRequests.clear();
+    }
+
+    public void stop() {
+        auditEventListener.shutdown();
+        service.shutdown();
+    }
+}

--- a/integration/src/integration/java/pl/allegro/tech/hermes/integration/management/GroupManagementTest.java
+++ b/integration/src/integration/java/pl/allegro/tech/hermes/integration/management/GroupManagementTest.java
@@ -20,22 +20,18 @@ public class GroupManagementTest extends IntegrationTest {
 
     @Test
     public void shouldEmmitAuditEventWhenGroupCreated() {
-        //given
-        RemoteServiceEndpoint remoteService = new RemoteServiceEndpoint(SharedServices.services().serviceMock(), "/audit-events");
-
         //when
         management.group().create(group("exampleGroup").build());
 
         //then
         assertThat(
-                remoteService.waitAndGetLastRequest().getBodyAsString()
+                auditEvents.waitAndGetLastRequest().getBodyAsString()
         ).contains("CREATED", "exampleGroup");
     }
 
     @Test
     public void shouldEmmitAuditEventWhenGroupRemoved() {
         //given
-        RemoteServiceEndpoint remoteService = new RemoteServiceEndpoint(SharedServices.services().serviceMock(), "/audit-events");
         operations.createGroup("anotherExampleGroup");
 
         //when
@@ -43,14 +39,13 @@ public class GroupManagementTest extends IntegrationTest {
 
         //then
         assertThat(
-                remoteService.waitAndGetLastRequest().getBodyAsString()
+                auditEvents.waitAndGetLastRequest().getBodyAsString()
         ).contains("REMOVED", "anotherExampleGroup");
     }
 
     @Test
     public void shouldEmmitAuditEventWhenGroupUpdated() {
         //given
-        RemoteServiceEndpoint remoteService = new RemoteServiceEndpoint(SharedServices.services().serviceMock(), "/audit-events");
         operations.createGroup("anotherOneExampleGroup");
 
         //when
@@ -58,7 +53,7 @@ public class GroupManagementTest extends IntegrationTest {
 
         //then
         assertThat(
-                remoteService.waitAndGetLastRequest().getBodyAsString()
+                auditEvents.waitAndGetLastRequest().getBodyAsString()
         ).contains("UPDATED", "anotherOneExampleGroup");
     }
 

--- a/integration/src/integration/java/pl/allegro/tech/hermes/integration/management/GroupManagementTest.java
+++ b/integration/src/integration/java/pl/allegro/tech/hermes/integration/management/GroupManagementTest.java
@@ -5,8 +5,6 @@ import org.testng.annotations.Test;
 import pl.allegro.tech.hermes.api.ErrorCode;
 import pl.allegro.tech.hermes.api.Group;
 import pl.allegro.tech.hermes.integration.IntegrationTest;
-import pl.allegro.tech.hermes.integration.env.SharedServices;
-import pl.allegro.tech.hermes.test.helper.endpoint.RemoteServiceEndpoint;
 
 import javax.ws.rs.core.Response;
 import java.util.stream.Stream;
@@ -25,7 +23,7 @@ public class GroupManagementTest extends IntegrationTest {
 
         //then
         assertThat(
-                auditEvents.waitAndGetLastRequest().getBodyAsString()
+                auditEvents.getLastRequest().getBodyAsString()
         ).contains("CREATED", "exampleGroup");
     }
 
@@ -39,7 +37,7 @@ public class GroupManagementTest extends IntegrationTest {
 
         //then
         assertThat(
-                auditEvents.waitAndGetLastRequest().getBodyAsString()
+                auditEvents.getLastRequest().getBodyAsString()
         ).contains("REMOVED", "anotherExampleGroup");
     }
 
@@ -53,7 +51,7 @@ public class GroupManagementTest extends IntegrationTest {
 
         //then
         assertThat(
-                auditEvents.waitAndGetLastRequest().getBodyAsString()
+                auditEvents.getLastRequest().getBodyAsString()
         ).contains("UPDATED", "anotherOneExampleGroup");
     }
 

--- a/integration/src/integration/java/pl/allegro/tech/hermes/integration/management/SubscriptionManagementTest.java
+++ b/integration/src/integration/java/pl/allegro/tech/hermes/integration/management/SubscriptionManagementTest.java
@@ -73,7 +73,7 @@ public class SubscriptionManagementTest extends IntegrationTest {
 
         //then
         assertThat(
-                auditEvents.waitAndGetLastRequest().getBodyAsString()
+                auditEvents.getLastRequest().getBodyAsString()
         ).contains("CREATED", "someSubscription");
     }
 
@@ -88,7 +88,7 @@ public class SubscriptionManagementTest extends IntegrationTest {
 
         //then
         assertThat(
-                auditEvents.waitAndGetLastRequest().getBodyAsString()
+                auditEvents.getLastRequest().getBodyAsString()
         ).contains("REMOVED", "anotherSubscription");
     }
 
@@ -104,7 +104,7 @@ public class SubscriptionManagementTest extends IntegrationTest {
 
         //then
         assertThat(
-                auditEvents.waitAndGetLastRequest().getBodyAsString()
+                auditEvents.getLastRequest().getBodyAsString()
         ).contains("UPDATED", "anotherOneSubscription");
     }
 
@@ -194,7 +194,7 @@ public class SubscriptionManagementTest extends IntegrationTest {
         wait.untilSubscriptionEndpointAddressChanged(topic, "subscription", EndpointAddress.of(HTTP_ENDPOINT_URL));
 
         publishMessage(topic.getQualifiedName(), MESSAGE.body());
-        auditEvents.waitAndGetLastRequest();
+        auditEvents.getLastRequest();
     }
 
     @Test
@@ -266,7 +266,7 @@ public class SubscriptionManagementTest extends IntegrationTest {
 
         // when
         String messageId = publishMessage(topic.getQualifiedName(), MESSAGE.body());
-        auditEvents.waitAndGetLastRequest();
+        auditEvents.getLastRequest();
 
         // then
         await().atMost(30, TimeUnit.SECONDS).until(() -> getMessageTrace(topic.getQualifiedName(), "subscription", messageId).size() == 3);

--- a/integration/src/integration/java/pl/allegro/tech/hermes/integration/management/SubscriptionManagementTest.java
+++ b/integration/src/integration/java/pl/allegro/tech/hermes/integration/management/SubscriptionManagementTest.java
@@ -66,7 +66,6 @@ public class SubscriptionManagementTest extends IntegrationTest {
     @Test
     public void shouldEmmitAuditEventWhenSubscriptionCreated() {
         //given
-        RemoteServiceEndpoint auditEventRemoteService = new RemoteServiceEndpoint(SharedServices.services().serviceMock(), "/audit-events");
         Topic topic = operations.buildTopic(randomTopic("subscribeGroup", "topic").build());
 
         //when
@@ -74,14 +73,13 @@ public class SubscriptionManagementTest extends IntegrationTest {
 
         //then
         assertThat(
-                auditEventRemoteService.waitAndGetLastRequest().getBodyAsString()
+                auditEvents.waitAndGetLastRequest().getBodyAsString()
         ).contains("CREATED", "someSubscription");
     }
 
     @Test
     public void shouldEmmitAuditEventWhenSubscriptionRemoved() {
         //given
-        RemoteServiceEndpoint auditEventRemoteService = new RemoteServiceEndpoint(SharedServices.services().serviceMock(), "/audit-events");
         Topic topic = operations.buildTopic(randomTopic("subscribeGroup2", "topic").build());
         operations.createSubscription(topic, subscription(topic, "anotherSubscription").build());
 
@@ -90,14 +88,13 @@ public class SubscriptionManagementTest extends IntegrationTest {
 
         //then
         assertThat(
-                auditEventRemoteService.waitAndGetLastRequest().getBodyAsString()
+                auditEvents.waitAndGetLastRequest().getBodyAsString()
         ).contains("REMOVED", "anotherSubscription");
     }
 
     @Test
     public void shouldEmmitAuditEventWhenSubscriptionEndpointUpdated() {
         //given
-        RemoteServiceEndpoint auditEventRemoteService = new RemoteServiceEndpoint(SharedServices.services().serviceMock(), "/audit-events");
         Topic topic = operations.buildTopic(randomTopic("subscribeGroup3", "topic").build());
         operations.createSubscription(topic, subscription(topic, "anotherOneSubscription").build());
 
@@ -107,7 +104,7 @@ public class SubscriptionManagementTest extends IntegrationTest {
 
         //then
         assertThat(
-                auditEventRemoteService.waitAndGetLastRequest().getBodyAsString()
+                auditEvents.waitAndGetLastRequest().getBodyAsString()
         ).contains("UPDATED", "anotherOneSubscription");
     }
 
@@ -196,9 +193,8 @@ public class SubscriptionManagementTest extends IntegrationTest {
         assertThat(response).hasStatus(Response.Status.OK);
         wait.untilSubscriptionEndpointAddressChanged(topic, "subscription", EndpointAddress.of(HTTP_ENDPOINT_URL));
 
-        remoteService.expectMessages(MESSAGE.body());
         publishMessage(topic.getQualifiedName(), MESSAGE.body());
-        remoteService.waitUntilReceived();
+        auditEvents.waitAndGetLastRequest();
     }
 
     @Test
@@ -267,11 +263,10 @@ public class SubscriptionManagementTest extends IntegrationTest {
                 .build();
 
         operations.createSubscription(topic, subscription);
-        remoteService.expectMessages(MESSAGE.body());
 
         // when
         String messageId = publishMessage(topic.getQualifiedName(), MESSAGE.body());
-        remoteService.waitUntilReceived();
+        auditEvents.waitAndGetLastRequest();
 
         // then
         await().atMost(30, TimeUnit.SECONDS).until(() -> getMessageTrace(topic.getQualifiedName(), "subscription", messageId).size() == 3);

--- a/integration/src/integration/java/pl/allegro/tech/hermes/integration/management/TopicManagementTest.java
+++ b/integration/src/integration/java/pl/allegro/tech/hermes/integration/management/TopicManagementTest.java
@@ -13,11 +13,9 @@ import pl.allegro.tech.hermes.api.Topic;
 import pl.allegro.tech.hermes.api.TopicLabel;
 import pl.allegro.tech.hermes.api.BlacklistStatus;
 import pl.allegro.tech.hermes.integration.IntegrationTest;
-import pl.allegro.tech.hermes.integration.env.SharedServices;
 import pl.allegro.tech.hermes.integration.shame.Unreliable;
 import pl.allegro.tech.hermes.test.helper.avro.AvroUserSchemaLoader;
 import pl.allegro.tech.hermes.test.helper.builder.TopicBuilder;
-import pl.allegro.tech.hermes.test.helper.endpoint.RemoteServiceEndpoint;
 
 import javax.ws.rs.core.Response;
 import java.util.Collections;
@@ -50,7 +48,7 @@ public class TopicManagementTest extends IntegrationTest {
 
         //then
         assertThat(
-                auditEvents.waitAndGetLastRequest().getBodyAsString()
+                auditEvents.getLastRequest().getBodyAsString()
         ).contains("CREATED", "Topic", topic.getQualifiedName());
     }
 
@@ -66,7 +64,7 @@ public class TopicManagementTest extends IntegrationTest {
 
         //then
         assertThat(
-                auditEvents.waitAndGetLastRequest().getBodyAsString()
+                auditEvents.getLastRequest().getBodyAsString()
         ).contains("REMOVED", topic.getQualifiedName());
     }
 
@@ -83,7 +81,7 @@ public class TopicManagementTest extends IntegrationTest {
 
         //then
         assertThat(
-                auditEvents.waitAndGetLastRequest().getBodyAsString()
+                auditEvents.getLastRequest().getBodyAsString()
         ).contains("UPDATED", "someTestTopicName");
     }
 
@@ -100,7 +98,7 @@ public class TopicManagementTest extends IntegrationTest {
 
         //then
         assertThat(
-                auditEvents.waitAndGetLastRequest().getBodyAsString()
+                auditEvents.getLastRequest().getBodyAsString()
         ).contains("BEFORE_UPDATE", "testGroupName.testTopicName", "someValue", "2048");
     }
 

--- a/integration/src/integration/java/pl/allegro/tech/hermes/integration/management/TopicManagementTest.java
+++ b/integration/src/integration/java/pl/allegro/tech/hermes/integration/management/TopicManagementTest.java
@@ -42,7 +42,6 @@ public class TopicManagementTest extends IntegrationTest {
     @Test
     public void shouldEmmitAuditEventWhenTopicCreated() {
         //given
-        RemoteServiceEndpoint remoteService = new RemoteServiceEndpoint(SharedServices.services().serviceMock(), "/audit-events");
         operations.createGroup("testGroupName");
         Topic topic = topic("testGroupName", "testTopicName").build();
 
@@ -51,14 +50,13 @@ public class TopicManagementTest extends IntegrationTest {
 
         //then
         assertThat(
-                remoteService.waitAndGetLastRequest().getBodyAsString()
+                auditEvents.waitAndGetLastRequest().getBodyAsString()
         ).contains("CREATED", "Topic", topic.getQualifiedName());
     }
 
     @Test
     public void shouldEmmitAuditEventWhenTopicRemoved() {
         //given
-        RemoteServiceEndpoint remoteService = new RemoteServiceEndpoint(SharedServices.services().serviceMock(), "/audit-events");
         operations.createGroup("anotherTestGroupName");
         Topic topic = topic("anotherTestGroupName", "anotherTestTopicName").build();
         operations.createTopic(topicWithSchema(topic));
@@ -68,14 +66,13 @@ public class TopicManagementTest extends IntegrationTest {
 
         //then
         assertThat(
-                remoteService.waitAndGetLastRequest().getBodyAsString()
+                auditEvents.waitAndGetLastRequest().getBodyAsString()
         ).contains("REMOVED", topic.getQualifiedName());
     }
 
     @Test
     public void shouldEmmitAuditEventWhenTopicUpdated() {
         //given
-        RemoteServiceEndpoint remoteService = new RemoteServiceEndpoint(SharedServices.services().serviceMock(), "/audit-events");
         operations.createGroup("someTestGroupName");
         Topic topic = topic("someTestGroupName", "someTestTopicName").withMaxMessageSize(1024).build();
         operations.createTopic(topicWithSchema(topic));
@@ -86,14 +83,13 @@ public class TopicManagementTest extends IntegrationTest {
 
         //then
         assertThat(
-                remoteService.waitAndGetLastRequest().getBodyAsString()
+                auditEvents.waitAndGetLastRequest().getBodyAsString()
         ).contains("UPDATED", "someTestTopicName");
     }
 
     @Test
     public void shouldEmmitAuditEventBeforeUpdateWhenWrongPatchDataKeyProvided() {
         //given
-        RemoteServiceEndpoint remoteService = new RemoteServiceEndpoint(SharedServices.services().serviceMock(), "/audit-events");
         operations.createGroup("testGroupName");
         Topic topic = topic("testGroupName", "testTopicName").withMaxMessageSize(1024).build();
         operations.createTopic(topicWithSchema(topic));
@@ -104,7 +100,7 @@ public class TopicManagementTest extends IntegrationTest {
 
         //then
         assertThat(
-                remoteService.waitAndGetLastRequest().getBodyAsString()
+                auditEvents.waitAndGetLastRequest().getBodyAsString()
         ).contains("BEFORE_UPDATE", "testGroupName.testTopicName", "someValue", "2048");
     }
 

--- a/integration/src/test/resources/application.yaml
+++ b/integration/src/test/resources/application.yaml
@@ -85,7 +85,7 @@ subscription-health:
 audit:
   isLoggingAuditEnabled: false
   isEventAuditEnabled: true
-  eventUrl: "http://localhost:18081/audit-events"
+  eventUrl: "http://localhost:19998/audit-events"
 
 group:
   nonAdminCreationEnabled: true


### PR DESCRIPTION
__Before:__
During integration tests `/audit-events` endpoint was created only when we wanted to verify audit events. It was created with usage of _RemoteServiceEndpoint_. Only then, when proper stubbing was defined, WireMock used in _RemoteServiceEndpoint_ handled requests properly. Unfortunately, in every other test (where `new RemoteServiceEndpoint(SharedServices.services().serviceMock(), "/audit-events");` was not used) requests send to `/audit-events` endpoint were not handled properly, resulting ___very long___ in error message:

```
2022-02-03T12:45:03.7035227Z     2022-02-03 12:45:03.604 ERROR WireMock - Request was not matched as there were no stubs registered:
2022-02-03T12:45:03.7038417Z     {
2022-02-03T12:45:03.7039072Z       "url" : "/audit-events",
2022-02-03T12:45:03.7039834Z       "absoluteUrl" : "http://localhost:18081/audit-events",
2022-02-03T12:45:03.7042061Z       "method" : "POST",
2022-02-03T12:45:03.7054537Z       "clientIp" : "127.0.0.1",
2022-02-03T12:45:03.7054826Z       "headers" : {
2022-02-03T12:45:03.7055150Z         "Accept" : "application/json, application/*+json",
2022-02-03T12:45:03.7055649Z         "Connection" : "keep-alive",
2022-02-03T12:45:03.7056121Z         "User-Agent" : "Apache-HttpClient/4.5.13 (Java/1.8.0_292)",
2022-02-03T12:45:03.7056455Z         "Host" : "localhost:18081",
2022-02-03T12:45:03.7057014Z         "Accept-Encoding" : "gzip,deflate",
2022-02-03T12:45:03.7057373Z         "Content-Length" : "180",
2022-02-03T12:45:03.7057754Z         "Content-Type" : "application/json"
2022-02-03T12:45:03.7058024Z       },
2022-02-03T12:45:03.7058446Z       "cookies" : { },
2022-02-03T12:45:03.7060228Z       "browserProxyRequest" : false,
2022-02-03T12:45:03.7060534Z       "loggedDate" : 1643892303604,
2022-02-03T12:45:03.7062795Z       "bodyAsBase64" : "eyJldmVudFR5cGUiOiJDUkVBVEVEIiwicmVzb3VyY2VOYW1lIjoiR3JvdXAoc2Vjb25kYXJ5S2Fma2EpIiwicGF5bG9hZENsYXNzIjoiR3JvdXAiLCJwYXlsb2FkIjoie1wiZ3JvdXBOYW1lXCI6XCJzZWNvbmRhcnlLYWZrYVwiLFwic3VwcG9ydFRlYW1cIjpcInRlYW1cIn0iLCJ1c2VybmFtZSI6InRlc3QtdXNlciJ9",
2022-02-03T12:45:03.7065587Z       "body" : "{\"eventType\":\"CREATED\",\"resourceName\":\"Group(secondaryKafka)\",\"payloadClass\":\"Group\",\"payload\":\"{\\\"groupName\\\":\\\"secondaryKafka\\\",\\\"supportTeam\\\":\\\"team\\\"}\",\"username\":\"test-user\"}",
2022-02-03T12:45:03.7066213Z       "scheme" : "http",
2022-02-03T12:45:03.7066831Z       "host" : "localhost",
2022-02-03T12:45:03.7067103Z       "port" : 18081,
2022-02-03T12:45:03.7067493Z       "loggedDateString" : "2022-02-03T12:45:03Z",
2022-02-03T12:45:03.7067792Z       "queryParams" : { }
2022-02-03T12:45:03.7068044Z     }
2022-02-03T12:45:03.7068887Z     2022-02-03 12:45:03.612 INFO  p.a.t.h.m.i.audit.EventAuditor - Audit event emission failed.
2022-02-03T12:45:03.7070738Z     org.springframework.web.client.HttpClientErrorException$NotFound: 404 Not Found: [No response could be served as there are no stub mappings in this WireMock instance.]
2022-02-03T12:45:03.7071553Z     	at org.springframework.web.client.HttpClientErrorException.create(HttpClientErrorException.java:113)
2022-02-03T12:45:03.7072375Z     	at org.springframework.web.client.DefaultResponseErrorHandler.handleError(DefaultResponseErrorHandler.java:186)
2022-02-03T12:45:03.7073218Z     	at org.springframework.web.client.DefaultResponseErrorHandler.handleError(DefaultResponseErrorHandler.java:125)
2022-02-03T12:45:03.7074334Z     	at org.springframework.web.client.ResponseErrorHandler.handleError(ResponseErrorHandler.java:63)
2022-02-03T12:45:03.7075061Z     	at org.springframework.web.client.RestTemplate.handleResponse(RestTemplate.java:818)
2022-02-03T12:45:03.7075700Z     	at org.springframework.web.client.RestTemplate.doExecute(RestTemplate.java:776)
2022-02-03T12:45:03.7076285Z     	at org.springframework.web.client.RestTemplate.execute(RestTemplate.java:710)
2022-02-03T12:45:03.7076904Z     	at org.springframework.web.client.RestTemplate.postForObject(RestTemplate.java:436)
2022-02-03T12:45:03.7077657Z     	at pl.allegro.tech.hermes.management.infrastructure.audit.EventAuditor.lambda$objectCreated$3(EventAuditor.java:81)
2022-02-03T12:45:03.7078549Z     	at pl.allegro.tech.hermes.management.infrastructure.audit.EventAuditor.ignoringExceptions(EventAuditor.java:113)
2022-02-03T12:45:03.7079438Z     	at pl.allegro.tech.hermes.management.infrastructure.audit.EventAuditor.objectCreated(EventAuditor.java:74)
2022-02-03T12:45:03.7080338Z     	at pl.allegro.tech.hermes.management.infrastructure.audit.CompositeAuditor.lambda$objectCreated$3(CompositeAuditor.java:35)
2022-02-03T12:45:03.7081030Z     	at java.util.LinkedHashMap$LinkedValues.forEach(LinkedHashMap.java:608)
2022-02-03T12:45:03.7081756Z     	at pl.allegro.tech.hermes.management.infrastructure.audit.CompositeAuditor.objectCreated(CompositeAuditor.java:35)
2022-02-03T12:45:03.7082591Z     	at pl.allegro.tech.hermes.management.domain.group.GroupService.createGroup(GroupService.java:62)
2022-02-03T12:45:03.7083301Z     	at pl.allegro.tech.hermes.management.api.GroupsEndpoint.create(GroupsEndpoint.java:74)
2022-02-03T12:45:03.7083883Z     	at sun.reflect.GeneratedMethodAccessor265.invoke(Unknown Source)
2022-02-03T12:45:03.7084462Z     	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
2022-02-03T12:45:03.7084973Z     	at java.lang.reflect.Method.invoke(Method.java:498)
2022-02-03T12:45:03.7085765Z     	at org.glassfish.jersey.server.model.internal.ResourceMethodInvocationHandlerFactory.lambda$static$0(ResourceMethodInvocationHandlerFactory.java:52)
2022-02-03T12:45:03.7086858Z     	at org.glassfish.jersey.server.model.internal.AbstractJavaResourceMethodDispatcher$1.run(AbstractJavaResourceMethodDispatcher.java:124)
2022-02-03T12:45:03.7087919Z     	at org.glassfish.jersey.server.model.internal.AbstractJavaResourceMethodDispatcher.invoke(AbstractJavaResourceMethodDispatcher.java:167)
2022-02-03T12:45:03.7089099Z     	at org.glassfish.jersey.server.model.internal.JavaResourceMethodDispatcherProvider$ResponseOutInvoker.doDispatch(JavaResourceMethodDispatcherProvider.java:176)
2022-02-03T12:45:03.7090204Z     	at org.glassfish.jersey.server.model.internal.AbstractJavaResourceMethodDispatcher.dispatch(AbstractJavaResourceMethodDispatcher.java:79)
2022-02-03T12:45:03.7091128Z     	at org.glassfish.jersey.server.model.ResourceMethodInvoker.invoke(ResourceMethodInvoker.java:469)
2022-02-03T12:45:03.7094570Z     	at org.glassfish.jersey.server.model.ResourceMethodInvoker.apply(ResourceMethodInvoker.java:391)
2022-02-03T12:45:03.7095364Z     	at org.glassfish.jersey.server.model.ResourceMethodInvoker.apply(ResourceMethodInvoker.java:80)
2022-02-03T12:45:03.7095976Z     	at org.glassfish.jersey.server.ServerRuntime$1.run(ServerRuntime.java:255)
2022-02-03T12:45:03.7096618Z     	at org.glassfish.jersey.internal.Errors$1.call(Errors.java:248)
2022-02-03T12:45:03.7097538Z     	at org.glassfish.jersey.internal.Errors$1.call(Errors.java:244)
2022-02-03T12:45:03.7098029Z     	at org.glassfish.jersey.internal.Errors.process(Errors.java:292)
2022-02-03T12:45:03.7098516Z     	at org.glassfish.jersey.internal.Errors.process(Errors.java:274)
2022-02-03T12:45:03.7099017Z     	at org.glassfish.jersey.internal.Errors.process(Errors.java:244)
2022-02-03T12:45:03.7099599Z     	at org.glassfish.jersey.process.internal.RequestScope.runInScope(RequestScope.java:265)
2022-02-03T12:45:03.7100206Z     	at org.glassfish.jersey.server.ServerRuntime.process(ServerRuntime.java:234)
2022-02-03T12:45:03.7100820Z     	at org.glassfish.jersey.server.ApplicationHandler.handle(ApplicationHandler.java:680)
2022-02-03T12:45:03.7101476Z     	at org.glassfish.jersey.servlet.WebComponent.serviceImpl(WebComponent.java:394)
2022-02-03T12:45:03.7102118Z     	at org.glassfish.jersey.servlet.ServletContainer.serviceImpl(ServletContainer.java:386)
2022-02-03T12:45:03.7102744Z     	at org.glassfish.jersey.servlet.ServletContainer.doFilter(ServletContainer.java:561)
2022-02-03T12:45:03.7103378Z     	at org.glassfish.jersey.servlet.ServletContainer.doFilter(ServletContainer.java:502)
2022-02-03T12:45:03.7104228Z     	at org.glassfish.jersey.servlet.ServletContainer.doFilter(ServletContainer.java:439)
2022-02-03T12:45:03.7106061Z     	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:193)
2022-02-03T12:45:03.7106795Z     	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166)
2022-02-03T12:45:03.7108418Z     	at org.springframework.web.filter.RequestContextFilter.doFilterInternal(RequestContextFilter.java:100)
2022-02-03T12:45:03.7109362Z     	at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:119)
2022-02-03T12:45:03.7110466Z     	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:193)
2022-02-03T12:45:03.7111203Z     	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166)
2022-02-03T12:45:03.7111920Z     	at org.springframework.web.filter.FormContentFilter.doFilterInternal(FormContentFilter.java:93)
2022-02-03T12:45:03.7112650Z     	at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:119)
2022-02-03T12:45:03.7113396Z     	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:193)
2022-02-03T12:45:03.7114105Z     	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166)
2022-02-03T12:45:03.7114956Z     	at org.springframework.boot.actuate.metrics.web.servlet.WebMvcMetricsFilter.doFilterInternal(WebMvcMetricsFilter.java:93)
2022-02-03T12:45:03.7122385Z     	at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:119)
2022-02-03T12:45:03.7123161Z     	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:193)
2022-02-03T12:45:03.7123879Z     	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166)
2022-02-03T12:45:03.7124652Z     	at org.springframework.web.filter.CharacterEncodingFilter.doFilterInternal(CharacterEncodingFilter.java:201)
2022-02-03T12:45:03.7125435Z     	at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:119)
2022-02-03T12:45:03.7126178Z     	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:193)
2022-02-03T12:45:03.7144574Z     	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166)
2022-02-03T12:45:03.7145482Z     	at org.apache.catalina.core.StandardWrapperValve.invoke(StandardWrapperValve.java:202)
2022-02-03T12:45:03.7146146Z     	at org.apache.catalina.core.StandardContextValve.invoke(StandardContextValve.java:97)
2022-02-03T12:45:03.7146950Z     	at org.apache.catalina.authenticator.AuthenticatorBase.invoke(AuthenticatorBase.java:542)
2022-02-03T12:45:03.7147576Z     	at org.apache.catalina.core.StandardHostValve.invoke(StandardHostValve.java:143)
2022-02-03T12:45:03.7149007Z     	at org.apache.catalina.valves.ErrorReportValve.invoke(ErrorReportValve.java:92)
2022-02-03T12:45:03.7151623Z     	at org.apache.catalina.core.StandardEngineValve.invoke(StandardEngineValve.java:78)
2022-02-03T12:45:03.7152243Z     	at org.apache.catalina.connector.CoyoteAdapter.service(CoyoteAdapter.java:343)
2022-02-03T12:45:03.7152815Z     	at org.apache.coyote.http11.Http11Processor.service(Http11Processor.java:374)
2022-02-03T12:45:03.7153429Z     	at org.apache.coyote.AbstractProcessorLight.process(AbstractProcessorLight.java:65)
2022-02-03T12:45:03.7154049Z     	at org.apache.coyote.AbstractProtocol$ConnectionHandler.process(AbstractProtocol.java:888)
2022-02-03T12:45:03.7154633Z     	at org.apache.tomcat.util.net.NioEndpoint$SocketProcessor.doRun(NioEndpoint.java:1597)
2022-02-03T12:45:03.7155210Z     	at org.apache.tomcat.util.net.SocketProcessorBase.run(SocketProcessorBase.java:49)
2022-02-03T12:45:03.7155822Z     	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
2022-02-03T12:45:03.7156406Z     	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
2022-02-03T12:45:03.7156956Z     	at org.apache.tomcat.util.threads.TaskThread$WrappingRunnable.run(TaskThread.java:61)
2022-02-03T12:45:03.7157409Z     	at java.lang.Thread.run(Thread.java:748)
```

Such long error logs were making it difficult to debug application behaviour during integration tests.

__PR changes:__
In this PR I've created separate WireMock server handling `/audit-events` on port `19998`. WireMock in `AuditEventEndpoint` is stubbed to handle POST requests on `/audit-events` endpoint and return 201 HTTP response code with no body. It starts at the beginning of integration tests, all received requests are cleared after every test, and server stops at the end of integration tests.

__After:__

When we want to test if some event was sent to `/audit-events` you can use `getLastRequest()` function from publicly available `auditEvents` object. If you're not interested in verifying any audit events, then you don't have to do anything (and any error won't be logged)!