### PR TITLE
Choosing owner from autocomplete source prevents manual entries

### DIFF
--- a/hermes-console/static/partials/ownerSelector.html
+++ b/hermes-console/static/partials/ownerSelector.html
@@ -12,7 +12,7 @@
     <div class="col-md-9">
         <input required ng-if="sourceSelectModel.autocomplete" class="form-control" id="ownerWithAutocomplete" name="owner"
                uib-typeahead="owner as owner.name for owner in owners($viewValue)" typeahead-min-length="1" typeahead-wait-ms="500"
-               placeholder="{{placeholder()}}" ng-model="$parent.ownerInputModel" autocomplete="off" />
+               placeholder="{{placeholder()}}" ng-model="$parent.ownerInputModel" autocomplete="off" editable="false" typeahead-editable="false" />
         <input required ng-if="!sourceSelectModel.autocomplete" class="form-control" id="ownerWithoutAutocomplete" name="owner"
                placeholder="{{placeholder()}}" ng-model="$parent.ownerInputModel" />
     </div>


### PR DESCRIPTION
**Until now:**

User could either choose owner from dropdown, or type it manually. Typed in owners did not contained all required data.

**Solution:**

When owner source has _autocompletion_, hermes-console user has to choose one of proposed owners from dropdown list. User can type in owner manually, but without accepting concrete owner from dropdown, form will remain invalid.

![out](https://user-images.githubusercontent.com/16356036/155163372-e1596cc6-1e8b-47d4-8eb8-521a28d02b51.gif)