### PR TITLE
Explicitly releasing direct buffers in hermes-consumers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.11.2 (28.02.2022)
+
+### Fixes
+
+#### ([1468](https://github.com/allegro/hermes/pull/1468)) Explicitly releasing direct buffers in hermes-consumers
+
 ## 1.11.1 (24.02.2022)
 
 ## Enhancements

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/batch/DirectBufferPool.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/batch/DirectBufferPool.java
@@ -188,6 +188,7 @@ public final class DirectBufferPool {
                 buffer.clear();
                 this.free.add(buffer);
             } else {
+                DirectBufferUtils.release(buffer);
                 this.availableMemory += size;
             }
             Condition moreMem = this.waiters.peekFirst();

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/batch/DirectBufferUtils.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/batch/DirectBufferUtils.java
@@ -15,13 +15,13 @@ class DirectBufferUtils {
     static {
         DirectBufferCleaner cleaner;
         try {
-            cleaner = new Java11DirectBufferCleaner();
-        } catch (ReflectiveOperationException e) {
-            try {
+            if ("1.8".equals(System.getProperty("java.specification.version"))) {
                 cleaner = new Java8DirectBufferCleaner();
-            } catch (ReflectiveOperationException ex) {
-                cleaner = null;
+            } else {
+                cleaner = new Java11DirectBufferCleaner();
             }
+        } catch (ReflectiveOperationException e) {
+            cleaner = null;
         }
         CLEANER = cleaner;
     }

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/batch/DirectBufferUtils.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/batch/DirectBufferUtils.java
@@ -1,0 +1,78 @@
+package pl.allegro.tech.hermes.consumers.consumer.batch;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.nio.ByteBuffer;
+
+class DirectBufferUtils {
+    private static final Logger logger = LoggerFactory.getLogger(DirectBufferUtils.class);
+
+    private static final DirectBufferCleaner CLEANER;
+
+    static {
+        DirectBufferCleaner cleaner;
+        try {
+            cleaner = new Java11DirectBufferCleaner();
+        } catch (ReflectiveOperationException e) {
+            try {
+                cleaner = new Java8DirectBufferCleaner();
+            } catch (ReflectiveOperationException ex) {
+                cleaner = null;
+            }
+        }
+        CLEANER = cleaner;
+    }
+
+    static void release(ByteBuffer buffer) {
+        try {
+            if (CLEANER != null && buffer.isDirect()) {
+                CLEANER.clean(buffer);
+            }
+        } catch (ReflectiveOperationException e) {
+            logger.warn("Releasing ByteBuffer failed", e);
+        }
+    }
+
+    private interface DirectBufferCleaner {
+        void clean(ByteBuffer buffer) throws ReflectiveOperationException;
+    }
+
+    static class Java8DirectBufferCleaner implements DirectBufferCleaner {
+        private final Method directBufferCleaner;
+        private final Method directBufferCleanerClean;
+
+        Java8DirectBufferCleaner() throws ReflectiveOperationException {
+            directBufferCleaner = Class.forName("sun.nio.ch.DirectBuffer").getMethod("cleaner");
+            directBufferCleaner.setAccessible(true);
+            directBufferCleanerClean = Class.forName("sun.misc.Cleaner").getMethod("clean");
+            directBufferCleanerClean.setAccessible(true);
+        }
+
+        @Override
+        public void clean(ByteBuffer buffer) throws ReflectiveOperationException {
+            Object cleaner = directBufferCleaner.invoke(buffer);
+            directBufferCleanerClean.invoke(cleaner);
+        }
+    }
+
+    static class Java11DirectBufferCleaner implements DirectBufferCleaner {
+        private final Object unsafe;
+        private final Method invokeCleaner;
+
+        Java11DirectBufferCleaner() throws ReflectiveOperationException {
+            Class<?> clazz = Class.forName("sun.misc.Unsafe");
+            Field field = clazz.getDeclaredField("theUnsafe");
+            field.setAccessible(true);
+            unsafe = field.get(null);
+            invokeCleaner = clazz.getMethod("invokeCleaner", ByteBuffer.class);
+        }
+
+        @Override
+        public void clean(ByteBuffer buffer) throws ReflectiveOperationException {
+            invokeCleaner.invoke(unsafe, buffer);
+        }
+    }
+}


### PR DESCRIPTION
By default native memory used by a given instance of `DirectByteBuffer` is released when the object is garbage collected. We don't want to wait for the GC and release the memory as soon as possible. Although the implementation may seem hacky, it seems to be the only possible way for now ([other projects approach this issue in a similar way](https://github.com/akka/akka/blob/331db9b8f8b02edb9370628d62ca53a55ed037e7/akka-actor/src/main/scala/akka/io/DirectByteBufferPool.scala#L80-L107)).