### PR TITLE
Check if topic group exists before topic creation

### DIFF
--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/domain/topic/TopicService.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/domain/topic/TopicService.java
@@ -109,6 +109,7 @@ public class TopicService {
     public void createTopicWithSchema(TopicWithSchema topicWithSchema, RequestUser createdBy, CreatorRights isAllowedToManage) {
         Topic topic = topicWithSchema.getTopic();
         auditor.beforeObjectCreation(createdBy.getUsername(), topic);
+        groupService.checkGroupExists(topic.getName().getGroupName());
         topicValidator.ensureCreatedTopicIsValid(topic, createdBy, isAllowedToManage);
         ensureTopicDoesNotExist(topic);
 

--- a/hermes-test-helper/src/main/java/pl/allegro/tech/hermes/test/helper/endpoint/HermesAPIOperations.java
+++ b/hermes-test-helper/src/main/java/pl/allegro/tech/hermes/test/helper/endpoint/HermesAPIOperations.java
@@ -72,10 +72,14 @@ public class HermesAPIOperations {
         if (endpoints.findTopics(topicWithSchema, topicWithSchema.isTrackingEnabled()).contains(topicWithSchema.getQualifiedName())) {
             return topicWithSchema;
         }
-        assertThat(endpoints.topic().create(topicWithSchema).getStatus()).isEqualTo(CREATED.getStatusCode());
+        assertThat(createTopicResponse(topicWithSchema).getStatus()).isEqualTo(CREATED.getStatusCode());
 
         wait.untilTopicCreated(topicWithSchema);
         return topicWithSchema;
+    }
+
+    public Response createTopicResponse(TopicWithSchema topicWithSchema) {
+        return endpoints.topic().create(topicWithSchema);
     }
 
     public void saveSchema(Topic topic, String schema) {
@@ -85,9 +89,10 @@ public class HermesAPIOperations {
         wait.untilSchemaCreated(topic);
     }
 
-    public RawSchema getSchema(Topic topic) {
+    public Response getSchemaResponse(Topic topic) {
         Response response = endpoints.schema().get(topic.getQualifiedName());
-        return response.readEntity(RawSchema.class);
+        System.out.println(response.toString());
+        return response;
     }
 
     public Subscription createSubscription(Topic topic, String subscriptionName, URI endpoint) {

--- a/hermes-test-helper/src/main/java/pl/allegro/tech/hermes/test/helper/endpoint/HermesAPIOperations.java
+++ b/hermes-test-helper/src/main/java/pl/allegro/tech/hermes/test/helper/endpoint/HermesAPIOperations.java
@@ -5,6 +5,7 @@ import pl.allegro.tech.hermes.api.ContentType;
 import pl.allegro.tech.hermes.api.Group;
 import pl.allegro.tech.hermes.api.OAuthProvider;
 import pl.allegro.tech.hermes.api.PatchData;
+import pl.allegro.tech.hermes.api.RawSchema;
 import pl.allegro.tech.hermes.api.Readiness;
 import pl.allegro.tech.hermes.api.Subscription;
 import pl.allegro.tech.hermes.api.SubscriptionMode;
@@ -82,6 +83,11 @@ public class HermesAPIOperations {
         assertThat(response.getStatus()).isEqualTo(CREATED.getStatusCode());
 
         wait.untilSchemaCreated(topic);
+    }
+
+    public RawSchema getSchema(Topic topic) {
+        Response response = endpoints.schema().get(topic.getQualifiedName());
+        return response.readEntity(RawSchema.class);
     }
 
     public Subscription createSubscription(Topic topic, String subscriptionName, URI endpoint) {

--- a/integration/src/integration/java/pl/allegro/tech/hermes/integration/management/TopicManagementTest.java
+++ b/integration/src/integration/java/pl/allegro/tech/hermes/integration/management/TopicManagementTest.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import org.assertj.core.api.Assertions;
 import org.testng.annotations.Test;
+import pl.allegro.tech.hermes.api.BlacklistStatus;
 import pl.allegro.tech.hermes.api.ContentType;
 import pl.allegro.tech.hermes.api.ErrorCode;
 import pl.allegro.tech.hermes.api.ErrorDescription;
@@ -11,7 +12,7 @@ import pl.allegro.tech.hermes.api.Group;
 import pl.allegro.tech.hermes.api.PatchData;
 import pl.allegro.tech.hermes.api.Topic;
 import pl.allegro.tech.hermes.api.TopicLabel;
-import pl.allegro.tech.hermes.api.BlacklistStatus;
+import pl.allegro.tech.hermes.api.TopicWithSchema;
 import pl.allegro.tech.hermes.integration.IntegrationTest;
 import pl.allegro.tech.hermes.integration.shame.Unreliable;
 import pl.allegro.tech.hermes.test.helper.avro.AvroUserSchemaLoader;
@@ -209,12 +210,17 @@ public class TopicManagementTest extends IntegrationTest {
         // given no group
 
         // when
-        Topic topic = topic("nonExistingGroup", "topic").build();
-        Response response = management.topic().create(topicWithSchema(topic, SCHEMA));
+        TopicWithSchema topicWithSchema = topicWithSchema(topic("nonExistingGroup", "topic")
+                .withContentType(AVRO)
+                .withTrackingEnabled(false).build(), SCHEMA);
+        Response createTopicResponse = operations.createTopicResponse(topicWithSchema);
+        Response schemaResponse = operations.getSchemaResponse(topicWithSchema);
 
         // then
-        assertThat(response).hasStatus(Response.Status.NOT_FOUND).hasErrorCode(ErrorCode.GROUP_NOT_EXISTS);
-        assertThat(operations.getSchema(topic)).isNull();
+//        assertThat(createTopicResponse).hasStatus(Response.Status.NOT_FOUND).hasErrorCode(ErrorCode.GROUP_NOT_EXISTS);
+
+        // and
+        assertThat(schemaResponse).hasStatus(Response.Status.NO_CONTENT);
     }
 
     @Test

--- a/integration/src/integration/java/pl/allegro/tech/hermes/integration/management/TopicManagementTest.java
+++ b/integration/src/integration/java/pl/allegro/tech/hermes/integration/management/TopicManagementTest.java
@@ -205,6 +205,19 @@ public class TopicManagementTest extends IntegrationTest {
     }
 
     @Test
+    public void shouldNotCreateTopicWithMissingGroup() {
+        // given no group
+
+        // when
+        Topic topic = topic("nonExistingGroup", "topic").build();
+        Response response = management.topic().create(topicWithSchema(topic, SCHEMA));
+
+        // then
+        assertThat(response).hasStatus(Response.Status.NOT_FOUND).hasErrorCode(ErrorCode.GROUP_NOT_EXISTS);
+        assertThat(operations.getSchema(topic)).isNull();
+    }
+
+    @Test
     public void shouldNotAllowOnCreatingSameTopicTwice() {
         // given
         operations.createGroup("overrideTopicGroup");

--- a/integration/src/integration/java/pl/allegro/tech/hermes/integration/management/TopicManagementTest.java
+++ b/integration/src/integration/java/pl/allegro/tech/hermes/integration/management/TopicManagementTest.java
@@ -217,7 +217,7 @@ public class TopicManagementTest extends IntegrationTest {
         Response schemaResponse = operations.getSchemaResponse(topicWithSchema);
 
         // then
-//        assertThat(createTopicResponse).hasStatus(Response.Status.NOT_FOUND).hasErrorCode(ErrorCode.GROUP_NOT_EXISTS);
+        assertThat(createTopicResponse).hasStatus(Response.Status.NOT_FOUND).hasErrorCode(ErrorCode.GROUP_NOT_EXISTS);
 
         // and
         assertThat(schemaResponse).hasStatus(Response.Status.NO_CONTENT);


### PR DESCRIPTION
**Before:**
When new topic was created, there was no validation against group existence. For new topics with non-existing group it was causing failure during creation. Unfortunately before fail itself avro schema was already registered (and its registration was not rolled back):

```java
public void createTopicWithSchema(TopicWithSchema topicWithSchema, RequestUser createdBy, CreatorRights isAllowedToManage) {
  // Create topic validations...

  registerAvroSchema(validateAndRegisterSchema, topicWithSchema, createdBy);
  createTopic(topic, createdBy, isAllowedToManage);
}
```

**After:**
There is a validation if group exists _before_ registering avro schema:

```java
public void createTopicWithSchema(TopicWithSchema topicWithSchema, RequestUser createdBy, CreatorRights isAllowedToManage) {
  // Create topic validations...
  groupService.checkGroupExists(topic.getName().getGroupName());
  // Other create topic validations...

  registerAvroSchema(validateAndRegisterSchema, topicWithSchema, createdBy);
  createTopic(topic, createdBy, isAllowedToManage);
}
```

Resolves https://github.com/allegro/hermes/issues/1470