### PR TITLE
Any logged-in user can remove group

### DIFF
--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/api/GroupsEndpoint.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/api/GroupsEndpoint.java
@@ -95,7 +95,7 @@ public class GroupsEndpoint {
     @DELETE
     @Path("/{groupName}")
     @ApiOperation(value = "Remove group", response = String.class, httpMethod = HttpMethod.DELETE)
-    @RolesAllowed(Roles.ADMIN)
+    @RolesAllowed(Roles.ANY)
     public Response delete(@PathParam("groupName") String groupName, @Context ContainerRequestContext requestContext) {
         groupService.removeGroup(groupName, new HermesSecurityAwareRequestUser(requestContext));
         return responseStatus(Response.Status.OK);

--- a/integration/src/integration/java/pl/allegro/tech/hermes/integration/management/GroupManagementTest.java
+++ b/integration/src/integration/java/pl/allegro/tech/hermes/integration/management/GroupManagementTest.java
@@ -5,6 +5,7 @@ import org.testng.annotations.Test;
 import pl.allegro.tech.hermes.api.ErrorCode;
 import pl.allegro.tech.hermes.api.Group;
 import pl.allegro.tech.hermes.integration.IntegrationTest;
+import pl.allegro.tech.hermes.management.TestSecurityProvider;
 
 import javax.ws.rs.core.Response;
 import java.util.stream.Stream;
@@ -111,6 +112,23 @@ public class GroupManagementTest extends IntegrationTest {
         // then
         assertThat(response).hasStatus(Response.Status.OK);
         assertThat(management.group().list()).doesNotContain("removeGroup");
+    }
+
+    @Test
+    public void shouldAllowNonAdminUserToRemoveGroup() {
+        // given
+        TestSecurityProvider.setUserIsAdmin(false);
+        operations.createGroup("removeGroup");
+
+        // when
+        Response response = management.group().delete("removeGroup");
+
+        // then
+        assertThat(response).hasStatus(Response.Status.OK);
+        assertThat(management.group().list()).doesNotContain("removeGroup");
+
+        // cleanup
+        TestSecurityProvider.reset();
     }
 
     @Test


### PR DESCRIPTION
**Until now:**
Only admins were able to remove empty groups.

**After this PR:**
Any logged-in user is able to remove empty groups.