### PR TITLE
Fix release notes generation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,8 @@ jobs:
   release:
 
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     environment: ci
 
     steps:


### PR DESCRIPTION
**Problem:**
Running `release.yml` GitHub Action resulted with error `"message": "Bad credentials"` when calling `POST https://api.github.com/repos/allegro/hermes/releases`.

I've added required permissions for GITHUB_TOKEN to create new release, as described in:
- [contents permission documentation](https://docs.github.com/en/rest/overview/permissions-required-for-github-apps#permission-on-contents),
-  [example call GitHub REST API with permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#example-2-calling-the-rest-api)