### PR TITLE
Fixed exceptions catching while closing consumer

### DIFF
--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/receiver/kafka/KafkaSingleThreadedMessageReceiver.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/receiver/kafka/KafkaSingleThreadedMessageReceiver.java
@@ -153,9 +153,9 @@ public class KafkaSingleThreadedMessageReceiver implements MessageReceiver {
         } catch (IllegalStateException ex) {
             // means it was already closed
         } catch (InterruptException ex) {
-            logger.warn("InterruptException occurred during closing consumer: " + ex);
+            // means that the thread was interrupted
         } catch (KafkaException ex) {
-            logger.warn("KafkaException occurred during closing consumer: " + ex);
+            logger.warn("KafkaException occurred during closing consumer.", ex);
         } finally {
             partitionAssignmentState.revokeAll(subscription.getQualifiedName());
         }

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/receiver/kafka/KafkaSingleThreadedMessageReceiver.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/receiver/kafka/KafkaSingleThreadedMessageReceiver.java
@@ -152,6 +152,10 @@ public class KafkaSingleThreadedMessageReceiver implements MessageReceiver {
             consumer.close();
         } catch (IllegalStateException ex) {
             // means it was already closed
+        } catch (InterruptException ex) {
+            logger.warn("InterruptException occurred during closing consumer: " + ex);
+        } catch (KafkaException ex) {
+            logger.warn("KafkaException occurred during closing consumer: " + ex);
         } finally {
             partitionAssignmentState.revokeAll(subscription.getQualifiedName());
         }


### PR DESCRIPTION
This PR is a bug fix. Regarding to the documentation `close()` method can also throw `InterruptException` and `KafkaException`. Prior to this fix, throwing these exceptions could interfere with code execution and for example shutdown of the ConsumerSupervisor 
<img width="478" alt="image" src="https://user-images.githubusercontent.com/76775507/187156084-85508271-3d1c-4166-bb6d-a7c7e94ff701.png">
