### PR TITLE
hermes-frontend configuration fixes

### DIFF
--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/config/KafkaHeaderNameProperties.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/config/KafkaHeaderNameProperties.java
@@ -2,7 +2,7 @@ package pl.allegro.tech.hermes.consumers.config;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
-@ConfigurationProperties(prefix = "frontend.kafka.header.name")
+@ConfigurationProperties(prefix = "consumer.kafka.header.name")
 public class KafkaHeaderNameProperties {
 
     private String schemaVersion = "sv";

--- a/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/config/TopicLoadingProperties.java
+++ b/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/config/TopicLoadingProperties.java
@@ -91,7 +91,7 @@ public class TopicLoadingProperties {
 
     public static class MetadataRefreshJobProperties {
 
-        private boolean enabled = false;
+        private boolean enabled = true;
 
         private Duration interval = Duration.ofSeconds(60);
 

--- a/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/producer/kafka/KafkaHeaderFactory.java
+++ b/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/producer/kafka/KafkaHeaderFactory.java
@@ -26,6 +26,6 @@ public class KafkaHeaderFactory {
     }
 
     Header schemaId(int schemaId) {
-        return new RecordHeader(kafkaHeaderNameParameters.getSchemaVersion(), Ints.toByteArray(schemaId));
+        return new RecordHeader(kafkaHeaderNameParameters.getSchemaId(), Ints.toByteArray(schemaId));
     }
 }


### PR DESCRIPTION
* restored the default value of `frontend.startup.topic.loading.metadataRefreshJob.enabled`
* fixed the name of the parameter `consumer.kafka.header.name`
* fixed setting the value of the header containing `schemaId`