### PR TITLE
add ability to run integration tests on m1 mac

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -75,7 +75,7 @@ allprojects {
             spring_web        : '5.1.5.RELEASE',
             failsafe          : '2.3.1',
             junit_jupiter     : '5.8.2',
-            testcontainers    : '1.15.3',
+            testcontainers    : '1.17.3',
             spring            : '2.4.2',
             assertj           : '3.22.0'
     ]

--- a/docs/docs/quickstart.md
+++ b/docs/docs/quickstart.md
@@ -62,6 +62,22 @@ To start hermes frontend, management and consumers we can use the following comm
 
 or use `Run/Debug Configurations` in IntelliJ
 
+### Testing 
+
+#### Unit tests
+
+`./gradlew check`
+
+#### Integration tests
+
+`./gradlew integrationTest`
+
+Optionally `confluentImagesTag` parameter can be provided to run tests with specified versions of
+Kafka, ZooKeeper and SchemaRegistry. E.g. to run tests with images dedicated for arm64:
+
+`./gradlew integrationTest -PconfluentImagesTag=7.2.2.arm64`
+
+
 ## Creating group and topic
 
 Now you're ready to create a **topic** for publishing messages.

--- a/hermes-test-helper/src/main/java/pl/allegro/tech/hermes/test/helper/containers/ConfluentSchemaRegistryContainer.java
+++ b/hermes-test-helper/src/main/java/pl/allegro/tech/hermes/test/helper/containers/ConfluentSchemaRegistryContainer.java
@@ -8,7 +8,7 @@ import static java.lang.String.format;
 
 public class ConfluentSchemaRegistryContainer extends GenericContainer<ConfluentSchemaRegistryContainer> {
     private static final DockerImageName DEFAULT_SCHEMA_REGISTRY_IMAGE_NAME = DockerImageName.parse("confluentinc/cp-schema-registry")
-            .withTag("6.1.0");
+            .withTag(ImageTags.confluentImagesTag());
     private static final int SCHEMA_REGISTRY_PORT = 8081;
 
     public ConfluentSchemaRegistryContainer() {

--- a/hermes-test-helper/src/main/java/pl/allegro/tech/hermes/test/helper/containers/ImageTags.java
+++ b/hermes-test-helper/src/main/java/pl/allegro/tech/hermes/test/helper/containers/ImageTags.java
@@ -1,0 +1,7 @@
+package pl.allegro.tech.hermes.test.helper.containers;
+
+public class ImageTags {
+    static String confluentImagesTag() {
+        return System.getProperty("confluentImagesTag", "6.1.0");
+    }
+}

--- a/hermes-test-helper/src/main/java/pl/allegro/tech/hermes/test/helper/containers/KafkaContainerCluster.java
+++ b/hermes-test-helper/src/main/java/pl/allegro/tech/hermes/test/helper/containers/KafkaContainerCluster.java
@@ -26,13 +26,12 @@ import static pl.allegro.tech.hermes.test.helper.containers.TestcontainersUtils.
 import static pl.allegro.tech.hermes.test.helper.containers.TestcontainersUtils.readFileFromClasspath;
 
 public class KafkaContainerCluster implements Startable {
-    private static final String CONFLUENT_PLATFORM_VERSION = "6.1.0";
     private static final DockerImageName ZOOKEEPER_IMAGE_NAME = DockerImageName.parse("confluentinc/cp-zookeeper")
-            .withTag(CONFLUENT_PLATFORM_VERSION);
+            .withTag(ImageTags.confluentImagesTag());
     private static final DockerImageName KAFKA_IMAGE_NAME = DockerImageName.parse("confluentinc/cp-kafka")
-            .withTag(CONFLUENT_PLATFORM_VERSION);
-    private static final DockerImageName TOXIPROXY_IMAGE_NAME = DockerImageName.parse("shopify/toxiproxy")
-            .withTag("2.1.0");
+            .withTag(ImageTags.confluentImagesTag());
+    private static final DockerImageName TOXIPROXY_IMAGE_NAME = DockerImageName.parse("ghcr.io/shopify/toxiproxy")
+            .withTag("2.4.0");
 
     private static final Duration CLUSTER_START_TIMEOUT = Duration.ofMinutes(360);
     private static final String ZOOKEEPER_NETWORK_ALIAS = "zookeeper";

--- a/hermes-test-helper/src/main/java/pl/allegro/tech/hermes/test/helper/containers/ZookeeperContainer.java
+++ b/hermes-test-helper/src/main/java/pl/allegro/tech/hermes/test/helper/containers/ZookeeperContainer.java
@@ -6,7 +6,7 @@ import org.testcontainers.utility.DockerImageName;
 
 public class ZookeeperContainer extends GenericContainer<ZookeeperContainer> {
     private static final DockerImageName DEFAULT_ZOOKEEPER_IMAGE_NAME = DockerImageName.parse("confluentinc/cp-zookeeper")
-            .withTag("6.1.0");
+            .withTag(ImageTags.confluentImagesTag());
     private static final int DEFAULT_ZOOKEEPER_PORT = 2181;
 
     private final int clientPort;
@@ -17,6 +17,7 @@ public class ZookeeperContainer extends GenericContainer<ZookeeperContainer> {
 
     public ZookeeperContainer(DockerImageName zooKeeperImage, int clientPort) {
         super(zooKeeperImage);
+        withExposedPorts(clientPort);
         withEnv("ZOOKEEPER_CLIENT_PORT", String.valueOf(clientPort));
         this.clientPort = clientPort;
     }

--- a/integration/build.gradle
+++ b/integration/build.gradle
@@ -74,6 +74,11 @@ task integrationTest(type: Test) {
     if (project.hasProperty('tests.timeout.multiplier')) {
         args += "-Dtests.timeout.multiplier=${project.property('tests.timeout.multiplier')}"
     }
+
+    if (project.hasProperty("confluentImagesTag")) {
+        args += "-DconfluentImagesTag=${project.property("confluentImagesTag")}"
+    }
+
     jvmArgs = args
     minHeapSize "2000m"
     maxHeapSize "3500m"


### PR DESCRIPTION
This PR enables developers to run integration tests on M1 macs, specifically:
- `testcontainers` and `toxiproxy` image were updated to allow running `toxiproxy` native arm64 image
- ability to specify confluent image tag via gradle task property was added, so developers can run tests with arm images:

```bash
 ./gradlew clean integrationTest -PconfluentImagesTag=7.2.2.arm64
```