### PR TITLE
Fix checkstyle action

### DIFF
--- a/.github/workflows/checkstyle.yml
+++ b/.github/workflows/checkstyle.yml
@@ -24,10 +24,13 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
       - name: Run check style
-        run: ./gradlew clean checkstyleMain
+        run: ./gradlew --continue clean checkstyleMain -PmaxCheckstyleWarnings=0
       - name: Run reviewdog
+        if: ${{ success() || failure() }}
         env:
           REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          find . -name 'main.xml' \
-            -exec bash -c 'reviewdog -f=checkstyle -reporter=github-check -filter-mode=nofilter -level=warning < "$1"' reviewdog-report {} \;
+          for f in $(find . -regex '.*/build/reports/checkstyle/.*\.xml'); do
+            module_name=$(echo "$f" | cut -d "/" -f2)
+            reviewdog -f=checkstyle -level=warning -filter-mode=nofilter -reporter=github-check -name="checkstyle-$module_name" < $f
+          done

--- a/build.gradle
+++ b/build.gradle
@@ -187,6 +187,7 @@ subprojects {
 
     checkstyle {
         toolVersion '10.3.4'
+        maxWarnings getIntProperty('maxCheckstyleWarnings', Integer.MAX_VALUE)
     }
 }
 


### PR DESCRIPTION
Prior to this change, the check responsible for performing static code analysis would not fail if any violations were reported. Additionally, only `reviewdog` comments regarding the gradle module that happened to be the last on the list built in the step `Run reviewdog` were posted (due to a name collision - see the `-name` parameter of the `reviewdog` GH action).