### PR TITLE
Moved away from jcenter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ import java.time.Duration
 
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
     }
 }
 

--- a/integration/build.gradle
+++ b/integration/build.gradle
@@ -1,5 +1,5 @@
 repositories {
-    jcenter()
+    mavenCentral()
     maven { url 'https://repository.jboss.org/nexus/content/groups/public' }
 }
 


### PR DESCRIPTION
[JCenter has been deprecated](https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/) for some time and [seems to be completely down today](https://stackoverflow.com/questions/74258160/is-jcenter-down-permanently-31-oct). 