### PR TITLE
Added possibility to configure partition assignment strategy

### DIFF
--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/config/KafkaConsumerProperties.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/config/KafkaConsumerProperties.java
@@ -3,8 +3,12 @@ package pl.allegro.tech.hermes.consumers.config;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import pl.allegro.tech.hermes.api.Topic;
 import pl.allegro.tech.hermes.consumers.consumer.receiver.kafka.KafkaConsumerParameters;
+import pl.allegro.tech.hermes.consumers.consumer.receiver.kafka.PartitionAssignmentStrategy;
 
 import java.time.Duration;
+import java.util.List;
+
+import static pl.allegro.tech.hermes.consumers.consumer.receiver.kafka.PartitionAssignmentStrategy.RANGE;
 
 @ConfigurationProperties(prefix = "consumer.kafka.consumer")
 public class KafkaConsumerProperties implements KafkaConsumerParameters {
@@ -46,6 +50,8 @@ public class KafkaConsumerProperties implements KafkaConsumerParameters {
     private int maxPartitionFetchMin = Topic.MIN_MESSAGE_SIZE;
 
     private int maxPartitionFetchMax = Topic.MAX_MESSAGE_SIZE;
+
+    private List<PartitionAssignmentStrategy> partitionAssignmentStrategies = List.of(RANGE);
 
     @Override
     public int getSendBufferBytes() {
@@ -216,5 +222,14 @@ public class KafkaConsumerProperties implements KafkaConsumerParameters {
 
     public void setMaxPartitionFetchMax(int maxPartitionFetchMax) {
         this.maxPartitionFetchMax = maxPartitionFetchMax;
+    }
+
+    @Override
+    public List<PartitionAssignmentStrategy> getPartitionAssignmentStrategies() {
+        return partitionAssignmentStrategies;
+    }
+
+    public void setPartitionAssignmentStrategies(List<PartitionAssignmentStrategy> partitionAssignmentStrategies) {
+        this.partitionAssignmentStrategies = partitionAssignmentStrategies;
     }
 }

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/receiver/kafka/KafkaConsumerParameters.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/receiver/kafka/KafkaConsumerParameters.java
@@ -1,6 +1,7 @@
 package pl.allegro.tech.hermes.consumers.consumer.receiver.kafka;
 
 import java.time.Duration;
+import java.util.List;
 
 public interface KafkaConsumerParameters {
 
@@ -41,4 +42,6 @@ public interface KafkaConsumerParameters {
     int getMaxPartitionFetchMin();
 
     int getMaxPartitionFetchMax();
+
+    List<PartitionAssignmentStrategy> getPartitionAssignmentStrategies();
 }

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/receiver/kafka/PartitionAssignmentStrategy.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/receiver/kafka/PartitionAssignmentStrategy.java
@@ -1,0 +1,22 @@
+package pl.allegro.tech.hermes.consumers.consumer.receiver.kafka;
+
+import org.apache.kafka.clients.consumer.ConsumerPartitionAssignor;
+import org.apache.kafka.clients.consumer.CooperativeStickyAssignor;
+import org.apache.kafka.clients.consumer.RangeAssignor;
+import org.apache.kafka.clients.consumer.StickyAssignor;
+
+public enum PartitionAssignmentStrategy {
+    RANGE(RangeAssignor.class),
+    STICKY(StickyAssignor.class),
+    COOPERATIVE(CooperativeStickyAssignor.class);
+
+    private final Class<? extends ConsumerPartitionAssignor> assignorClass;
+
+    PartitionAssignmentStrategy(Class<? extends ConsumerPartitionAssignor> assignorClass) {
+        this.assignorClass = assignorClass;
+    }
+
+    Class<? extends ConsumerPartitionAssignor> getAssignorClass() {
+        return assignorClass;
+    }
+}


### PR DESCRIPTION
The main advantage of the newer (sticky, cooperative) partition assignment strategies is the shorter time needed to perform rebalances. We would like to try them out and test how they will work in our environment.