### PR TITLE
preserve testng test order

### DIFF
--- a/integration/build.gradle
+++ b/integration/build.gradle
@@ -89,7 +89,9 @@ task integrationTest(type: Test) {
     testClassesDirs = project.sourceSets.integration.output.classesDirs
     classpath = project.sourceSets.integration.runtimeClasspath
 
-    useTestNG()
+    useTestNG {
+        preserveOrder true
+    }
 
     testLogging {
         exceptionFormat = 'full'


### PR DESCRIPTION
Setting preserve order to true might be beneficial for e2e test stability https://docs.gradle.org/current/userguide/java_testing.html#test_execution_order