### PR TITLE
fix groovy version collision

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,7 +67,7 @@ allprojects {
             spring_web        : '5.1.5.RELEASE',
             failsafe          : '2.3.1',
             junit_jupiter     : '5.8.2',
-            testcontainers    : '1.17.3',
+            testcontainers    : '1.15.3', // versions above require groovy 3.0
             spring            : '2.4.2',
             assertj           : '3.22.0'
     ]

--- a/hermes-management/src/test/groovy/pl/allegro/tech/hermes/management/domain/workload/constraints/WorkloadConstraintsServiceTest.groovy
+++ b/hermes-management/src/test/groovy/pl/allegro/tech/hermes/management/domain/workload/constraints/WorkloadConstraintsServiceTest.groovy
@@ -45,7 +45,7 @@ class WorkloadConstraintsServiceTest extends MultiZookeeperIntegrationTest {
         repository = new ZookeeperWorkloadConstraintsRepository(manager.localClient.curatorFramework, objectMapper, paths)
         repositoryManager = new ZookeeperRepositoryManager(
                 manager, new TestDatacenterNameProvider(DC_1_NAME), objectMapper,
-                paths, new DefaultZookeeperGroupRepositoryFactory(), 180000)
+                paths, new DefaultZookeeperGroupRepositoryFactory())
         repositoryManager.start()
         modeService = new ModeService()
         executor = new MultiDatacenterRepositoryCommandExecutor(repositoryManager, true, modeService)

--- a/hermes-test-helper/src/main/java/pl/allegro/tech/hermes/test/helper/containers/KafkaContainerCluster.java
+++ b/hermes-test-helper/src/main/java/pl/allegro/tech/hermes/test/helper/containers/KafkaContainerCluster.java
@@ -31,7 +31,7 @@ public class KafkaContainerCluster implements Startable {
     private static final DockerImageName KAFKA_IMAGE_NAME = DockerImageName.parse("confluentinc/cp-kafka")
             .withTag(ImageTags.confluentImagesTag());
     private static final DockerImageName TOXIPROXY_IMAGE_NAME = DockerImageName.parse("ghcr.io/shopify/toxiproxy")
-            .withTag("2.4.0");
+            .withTag("2.4.0").asCompatibleSubstituteFor("shopify/toxiproxy");;
 
     private static final Duration CLUSTER_START_TIMEOUT = Duration.ofMinutes(360);
     private static final String ZOOKEEPER_NETWORK_ALIAS = "zookeeper";


### PR DESCRIPTION
This revolves the problem introduced in: https://github.com/allegro/hermes/commit/1f990bc94282a9b6990940a85217f17d86c5dbe2, which caused groovy tests to not run in `hermes-frontend` and `hermes-management`. 

The problem was that testcontainers above version `1.15.3` depend on `spock>=2 groovy>=3`(https://github.com/testcontainers/testcontainers-java/blob/main/modules/spock/build.gradle#L9), and we are using spock version: `1.3-groovy-2.5`. One solution would be to bump spock but version 2 changed the test execution engine which breaks tests using wiremock with `ClassRule`. I have created separate issue for this: https://github.com/allegro/hermes/issues/1647