### PR TITLE
Configurable consumer inflight queue size

### DIFF
--- a/hermes-api/src/main/java/pl/allegro/tech/hermes/api/SubscriptionPolicy.java
+++ b/hermes-api/src/main/java/pl/allegro/tech/hermes/api/SubscriptionPolicy.java
@@ -2,12 +2,15 @@ package pl.allegro.tech.hermes.api;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.google.common.base.MoreObjects;
+import pl.allegro.tech.hermes.api.constraints.AdminPermitted;
 import pl.allegro.tech.hermes.api.helpers.Patch;
 
 import java.util.Map;
 import java.util.Objects;
+import javax.annotation.Nullable;
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
+import javax.validation.constraints.Null;
 
 public class SubscriptionPolicy {
 
@@ -16,7 +19,6 @@ public class SubscriptionPolicy {
     private static final int DEFAULT_MESSAGE_BACKOFF = 100;
     private static final int DEFAULT_REQUEST_TIMEOUT = 1000;
     private static final int DEFAULT_SOCKET_TIMEOUT = 0;
-    private static final int DEFAULT_INFLIGHT_SIZE = 100;
     private static final int DEFAULT_SENDING_DELAY = 0;
     private static final double DEFAULT_BACKOFF_MULTIPLIER = 1;
     private static final int DEFAULT_BACKOFF_MAX_INTERVAL = 600;
@@ -40,7 +42,8 @@ public class SubscriptionPolicy {
     private int socketTimeout = DEFAULT_SOCKET_TIMEOUT;
 
     @Min(1)
-    private int inflightSize = DEFAULT_INFLIGHT_SIZE;
+    @Null(groups = AdminPermitted.class)
+    private Integer inflightSize;
 
     @Min(0)
     @Max(5000)
@@ -90,7 +93,7 @@ public class SubscriptionPolicy {
                 (Integer) properties.getOrDefault("socketTimeout", DEFAULT_SOCKET_TIMEOUT),
                 (Boolean) properties.getOrDefault("retryClientErrors", false),
                 (Integer) properties.getOrDefault("messageBackoff", DEFAULT_MESSAGE_BACKOFF),
-                (Integer) properties.getOrDefault("inflightSize", DEFAULT_INFLIGHT_SIZE),
+                (Integer) properties.getOrDefault("inflightSize", null),
                 (Integer) properties.getOrDefault("sendingDelay", DEFAULT_SENDING_DELAY),
                 ((Number) properties.getOrDefault("backoffMultiplier", DEFAULT_BACKOFF_MULTIPLIER)).doubleValue(),
                 (Integer) properties.getOrDefault("backoffMaxIntervalInSec", DEFAULT_BACKOFF_MAX_INTERVAL)
@@ -169,6 +172,7 @@ public class SubscriptionPolicy {
         return socketTimeout;
     }
 
+    @Nullable
     public Integer getInflightSize() {
         return inflightSize;
     }

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/SerialConsumer.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/SerialConsumer.java
@@ -88,10 +88,8 @@ public class SerialConsumer implements Consumer {
     }
 
     private int calculateInflightSize(Subscription subscription) {
-        return Math.min(
-                subscription.getSerialSubscriptionPolicy().getInflightSize(),
-                defaultInflight
-        );
+        Optional<Integer> subscriptionInflight = Optional.ofNullable(subscription.getSerialSubscriptionPolicy().getInflightSize());
+        return subscriptionInflight.orElse(defaultInflight);
     }
 
     @Override

--- a/hermes-management/src/test/groovy/pl/allegro/tech/hermes/management/domain/auth/TestRequestUser.groovy
+++ b/hermes-management/src/test/groovy/pl/allegro/tech/hermes/management/domain/auth/TestRequestUser.groovy
@@ -6,10 +6,16 @@ class TestRequestUser implements RequestUser {
 
     private final String username
     private final boolean admin
+    private final boolean isOwner
 
     TestRequestUser(String username, boolean admin) {
+        this(username, admin, false)
+    }
+
+    TestRequestUser(String username, boolean admin, boolean isOwner) {
         this.username = username
         this.admin = admin
+        this.isOwner = isOwner
     }
 
     @Override
@@ -24,6 +30,6 @@ class TestRequestUser implements RequestUser {
 
     @Override
     boolean isOwner(OwnerId ownerId) {
-        return false
+        return isOwner
     }
 }

--- a/hermes-management/src/test/groovy/pl/allegro/tech/hermes/management/domain/subscription/validator/InflightSizeValidatorTest.groovy
+++ b/hermes-management/src/test/groovy/pl/allegro/tech/hermes/management/domain/subscription/validator/InflightSizeValidatorTest.groovy
@@ -1,0 +1,104 @@
+package pl.allegro.tech.hermes.management.domain.subscription.validator
+
+import pl.allegro.tech.hermes.api.Subscription
+import pl.allegro.tech.hermes.api.SubscriptionPolicy
+import pl.allegro.tech.hermes.domain.subscription.SubscriptionRepository
+import pl.allegro.tech.hermes.management.api.validator.ApiPreconditions
+import pl.allegro.tech.hermes.management.domain.auth.TestRequestUser
+import pl.allegro.tech.hermes.management.domain.owner.validator.OwnerIdValidator
+import pl.allegro.tech.hermes.management.domain.topic.TopicService
+import spock.lang.Shared
+import spock.lang.Specification
+import spock.lang.Subject
+
+import javax.validation.ConstraintViolationException
+
+import static pl.allegro.tech.hermes.test.helper.builder.SubscriptionBuilder.subscription
+
+
+class InflightSizeValidatorTest extends Specification {
+
+    @Shared
+    def ownerIdValidator = Stub(OwnerIdValidator)
+    @Shared
+    def topicService = Stub(TopicService)
+    @Shared
+    def subscriptionRepository = Stub(SubscriptionRepository)
+    @Shared
+    def endpointOwnershipValidator = Stub(EndpointOwnershipValidator)
+
+    @Shared
+    private static regularUser = new TestRequestUser("regularUser", false, true)
+    @Shared
+    private static admin = new TestRequestUser("admin", true)
+
+    @Subject
+    @Shared
+    SubscriptionValidator subscriptionValidator = new SubscriptionValidator(
+            ownerIdValidator,
+            new ApiPreconditions(),
+            topicService,
+            subscriptionRepository,
+            [],
+            endpointOwnershipValidator,
+            []
+    )
+
+    def "creating subscription with inflight size should not be allowed for regular users"() {
+        given:
+        def subscription = subscriptionWithInflight(100)
+        when:
+        subscriptionValidator.checkCreation(subscription, regularUser)
+
+        then:
+        def exception = thrown(ConstraintViolationException)
+        exception.message == "serialSubscriptionPolicy.inflightSize: must be null"
+    }
+
+    def "creating subscription with inflight size should be allowed for admin users"() {
+        given:
+        def subscription = subscriptionWithInflight(100)
+
+        when:
+        subscriptionValidator.checkCreation(subscription, admin)
+
+        then:
+        noExceptionThrown()
+    }
+
+    def "creating subscription with inflight size less than 1 should not be allowed"() {
+        given:
+        def subscription = subscriptionWithInflight(inflightSize)
+        when:
+        subscriptionValidator.checkCreation(subscription, admin)
+
+        then:
+        def exception = thrown(ConstraintViolationException)
+        exception.message == "serialSubscriptionPolicy.inflightSize: must be greater than or equal to 1"
+
+        where:
+        inflightSize << [0, -1]
+    }
+
+    def "creating subscription without inflight size should be allowed for regular and admin users"() {
+        given:
+        def subscription = subscriptionWithInflight(null)
+        when:
+        subscriptionValidator.checkCreation(subscription, user)
+
+        then:
+        noExceptionThrown()
+
+        where:
+        user << [regularUser, admin]
+    }
+
+    private static Subscription subscriptionWithInflight(Integer inflightSize) {
+        return subscription("group.topic", "subscription")
+                .withSubscriptionPolicy(
+                        SubscriptionPolicy.Builder.subscriptionPolicy()
+                                .withInflightSize(inflightSize)
+                                .build()
+                ).build()
+    }
+}

--- a/hermes-test-helper/src/main/java/pl/allegro/tech/hermes/test/helper/builder/SubscriptionBuilder.java
+++ b/hermes-test-helper/src/main/java/pl/allegro/tech/hermes/test/helper/builder/SubscriptionBuilder.java
@@ -36,7 +36,7 @@ public class SubscriptionBuilder {
 
     private String description = "description";
 
-    private SubscriptionPolicy serialSubscriptionPolicy = new SubscriptionPolicy(100, 10, 1000, 1000, false, 100, 100, 0, 1, 600);
+    private SubscriptionPolicy serialSubscriptionPolicy = new SubscriptionPolicy(100, 10, 1000, 1000, false, 100, null, 0, 1, 600);
 
     private BatchSubscriptionPolicy batchSubscriptionPolicy;
 

--- a/integration/src/integration/java/pl/allegro/tech/hermes/integration/FilteringJsonTest.java
+++ b/integration/src/integration/java/pl/allegro/tech/hermes/integration/FilteringJsonTest.java
@@ -32,7 +32,7 @@ public class FilteringJsonTest extends IntegrationTest {
     static final AvroUser ALICE_GREY = new AvroUser("Alice", 20, "grey");
     static final AvroUser BOB_GREY = new AvroUser("Bob", 50, "grey");
 
-    private static final SubscriptionPolicy SUBSCRIPTION_POLICY = new SubscriptionPolicy(100, 2000, 1000, 1000, true, 100, 100, 0, 1, 600);
+    private static final SubscriptionPolicy SUBSCRIPTION_POLICY = new SubscriptionPolicy(100, 2000, 1000, 1000, true, 100, null, 0, 1, 600);
 
     @BeforeMethod
     public void initializeAlways() {


### PR DESCRIPTION
This PR changes the way in which inflight queue size for consumers is calculated. 

Prior to this change inflight queue size was calculated based on 2 values:
- subscriptionInflightSize - set per subscription, default value: 100
- globalInflightSize - global property configured by   `consumer.serialConsumer.inflightSize`, default value: 100

Final queue inflight size was calculated as `min(subscriptionInflightSize, globalInflightSize)`.

After this PR default `subscriptionInflightSize` will be set to `null`, and final size will be calculated as:  

```java
subscriptionInflightSize != null ? subscriptionInflightSize : globalInflightSize
```
subscriptionInflightSize will be configurable only by admin users from now on.


### Migration

Deploying this version without any migration would cause inflight queue of subscriptions with `subscriptionInflightSize` greater than `globalInflightSize` to grow to `subscriptionInflightSize`. 

To prevent this the following migration is needed:
1. For subscriptions with `subscriptionInflightSize >= globalInflightSize`, set `subscriptionInflightSize=globalInflightSize`
2. Deploy hermes-management with new version
3.  Deploy hermes-consumers with new version
4. For subscriptions with `subscriptionInflightSize == globalInflightSize`, set `subscriptionInflightSize=null`

### Rollback
Changes are safe to rollback.

