### PR TITLE
Update deprecated set-output and link

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
         id: 'next-version'
         run: |
           NEW_HERMES_VERSION="`./gradlew -q cV -Prelease.quiet`"
-          echo "::set-output name=new_hermes_version::$NEW_HERMES_VERSION"
+          echo "new_hermes_version=$NEW_HERMES_VERSION" >> $GITHUB_OUTPUT
           echo "New Hermes version: ${NEW_HERMES_VERSION}"
       - name: Generate release notes and create release
         if: github.ref == 'refs/heads/master'

--- a/docs/docs/user/java-client.md
+++ b/docs/docs/user/java-client.md
@@ -174,7 +174,7 @@ HermesClient client = HermesClientBuilder.hermesClient(new OkHttpHermesSender(ne
 
 Requirements:
 
-JVM configured with [ALPN support](http://www.eclipse.org/jetty/documentation/current/alpn-chapter.html#alpn-starting):
+JVM configured with [ALPN support](https://web.archive.org/web/20200924211005/http://www.eclipse.org/jetty/documentation/current/alpn-chapter.html):
 
 ```bash
 java -Xbootclasspath/p:<path_to_alpn_boot_jar> ...


### PR DESCRIPTION
"[Starting 1st June 2023 workflows using save-state or set-output commands via stdout will fail with an error.](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/#:~:text=Starting%201st%20June%202023%20workflows%20using%20save%2Dstate%20or%20set%2Doutput%20commands%20via%20stdout%20will%20fail%20with%20an%20error.)"