### PR TITLE
CI jobs name independent of Java version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         tests: [ 'check', 'integrationTest', 'jmh -Pjmh.iterations=1 -Pjmh.timeOnIteration=5s -Pjmh.warmupIterations=0' ]
       fail-fast: false
-    name: ${{ matrix.tests }}
+    name: gradle ${{ matrix.tests }}
 
     steps:
       - uses: actions/checkout@v2
@@ -36,7 +36,7 @@ jobs:
         run: chmod +x gradlew
       - name: Build with Gradle
         run: ./gradlew assemble
-      - name: Run tests with Gradle
+      - name: Run task with Gradle
         run: ./gradlew ${{ matrix.tests }}
       - name: Archive test results
         uses: actions/upload-artifact@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         tests: [ 'check', 'integrationTest', 'jmh -Pjmh.iterations=1 -Pjmh.timeOnIteration=5s -Pjmh.warmupIterations=0' ]
       fail-fast: false
-    name: Java 11 ${{ matrix.tests }}
+    name: Java ${{ matrix.tests }}
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        tests: [ 'check', 'integrationTest', 'jmh -Pjmh.iterations=1 -Pjmh.timeOnIteration=5s -Pjmh.warmupIterations=0' ]
+        tasks: [
+          {alias: "unitTests", name: "check"},
+          {alias: "integrationTests", name: "integrationTest"},
+          {alias: "benchmark", name: "jmh -Pjmh.iterations=1 -Pjmh.timeOnIteration=5s -Pjmh.warmupIterations=0"}
+        ]
       fail-fast: false
-    name: gradle ${{ matrix.tests }}
-
+    name: ${{ matrix.tasks.alias }}
     steps:
       - uses: actions/checkout@v2
         with:
@@ -37,11 +40,11 @@ jobs:
       - name: Build with Gradle
         run: ./gradlew assemble
       - name: Run task with Gradle
-        run: ./gradlew ${{ matrix.tests }}
-      - name: Archive test results
+        run: ./gradlew ${{ matrix.tasks.name }}
+      - name: Archive task results
         uses: actions/upload-artifact@v3
-        if: (success() || failure()) && !contains(matrix.tests, 'jmh')
+        if: (success() || failure()) && matrix.tasks.alias != 'benchmark'
         with:
-          name: ${{ matrix.tests }}-test-report
+          name: ${{ matrix.tasks.name }}-test-report
           path: '**/build/test-results/**/TEST-*.xml'
           retention-days: 90

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         tests: [ 'check', 'integrationTest', 'jmh -Pjmh.iterations=1 -Pjmh.timeOnIteration=5s -Pjmh.warmupIterations=0' ]
       fail-fast: false
-    name: Java ${{ matrix.tests }}
+    name: ${{ matrix.tests }}
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
> Remove Java version from job name so that required PR checks are independent of java version. E.g. Required check will be renamed from `Java 11 check` to `unitTests`. This will enable build which use different java version (e.g. Java 17/21) to pass all checks. We don't plan to support multiple Java version in the foreseeable future.

