### PR TITLE
Add missing HermesMockExpect documentation

### DIFF
--- a/docs/docs/user/hermes-mock.md
+++ b/docs/docs/user/hermes-mock.md
@@ -64,8 +64,14 @@ of a specific type.
 - `<T> void jsonMessagesOnTopicAs(String topicName, int count, Class<T> clazz)` - expects particular number of
 JSON messages on a given topic.
 
+- `<T> void jsonMessagesOnTopicAs(String topicName, int count, Class<T> clazz, Predicate<T> predicate)` - expects particular number of
+JSON messages on a given topic and matching given predicate.
+
 - `<T> void avroMessagesOnTopic(String topicName, int count, Schema schema)` - expects particular number of
 Avro messages on a given topic.
+
+- `<T> void avroMessagesOnTopic(String topicName, int count, Schema schema, Class<T> clazz, Predicate<T> predicate)` - expects particular number of
+Avro messages on a given topic and matching given predicate.
 
 ##### HermesMockQuery
 


### PR DESCRIPTION
This PR adds missing documentation for https://github.com/allegro/hermes/blob/c817e3263ea514e1e4022e90479030a84673d19f/hermes-mock/src/main/java/pl/allegro/tech/hermes/mock/HermesMockExpect.java#L45 and for https://github.com/allegro/hermes/blob/c817e3263ea514e1e4022e90479030a84673d19f/hermes-mock/src/main/java/pl/allegro/tech/hermes/mock/HermesMockExpect.java#L53