### PR TITLE
Fix java 17 and spring-boot 2.7.7 migration bugs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,7 +50,7 @@ allprojects {
     project.ext.versions = [
             kafka             : '2.8.2',
             guava             : '23.0',
-            jackson           : '2.11.4',
+            jackson           : '2.13.4',
             jersey            : '2.35',
             jetty             : '9.4.19.v20190610',
             curator           : '5.4.0',

--- a/docker/latest/consumers/Dockerfile
+++ b/docker/latest/consumers/Dockerfile
@@ -1,10 +1,10 @@
-FROM gradle:6.9.3-jdk11 AS builder
+FROM gradle:7.6-jdk17 AS builder
 
 COPY --chown=gradle:gradle . /home/gradle/src/
 WORKDIR /home/gradle/src/
 RUN gradle clean distZip -Pdistribution
 
-FROM adoptopenjdk/openjdk11:jre
+FROM eclipse-temurin:17.0.7_7-jre
 
 RUN apt-get update \
   && apt-get -y install unzip wget bash \

--- a/docker/latest/frontend/Dockerfile
+++ b/docker/latest/frontend/Dockerfile
@@ -1,10 +1,10 @@
-FROM gradle:6.9.3-jdk11 AS builder
+FROM gradle:7.6-jdk17 AS builder
 
 COPY --chown=gradle:gradle . /home/gradle/src/
 WORKDIR /home/gradle/src/
 RUN gradle clean distZip -Pdistribution
 
-FROM adoptopenjdk/openjdk11:jre
+FROM eclipse-temurin:17.0.7_7-jre
 
 RUN apt-get update \
   && apt-get -y install unzip wget bash \

--- a/docker/latest/management/Dockerfile
+++ b/docker/latest/management/Dockerfile
@@ -1,10 +1,10 @@
-FROM gradle:6.9.3-jdk11 AS builder
+FROM gradle:7.6-jdk17 AS builder
 
 COPY --chown=gradle:gradle . /home/gradle/src/
 WORKDIR /home/gradle/src/
 RUN gradle clean distZip -Pdistribution
 
-FROM adoptopenjdk/openjdk11:jre
+FROM eclipse-temurin:17.0.7_7-jre
 
 RUN apt-get update \
   && apt-get -y install unzip wget bash \

--- a/hermes-client/build.gradle
+++ b/hermes-client/build.gradle
@@ -1,16 +1,20 @@
-dependencies {
-    compileOnly group: 'io.dropwizard.metrics', name: 'metrics-core', version: versions.dropwizard_metrics
-    compileOnly group: 'io.micrometer', name: 'micrometer-core', version: versions.micrometer_metrics
-    compileOnly group: 'org.glassfish.jersey.core', name: 'jersey-client', version: versions.jersey
-    compileOnly group: 'org.glassfish.jersey.inject', name: 'jersey-hk2', version: versions.jersey
-    compileOnly group: 'org.springframework', name: 'spring-web', version: versions.spring_web
-    compileOnly group: 'org.springframework', name: 'spring-webflux', version: versions.spring_web
+plugins {
+    id 'java-library'
+}
 
-    compileOnly group: 'com.squareup.okhttp3', name: 'okhttp', version: versions.okhttp
+dependencies {
+    api group: 'io.dropwizard.metrics', name: 'metrics-core', version: versions.dropwizard_metrics
+    api group: 'io.micrometer', name: 'micrometer-core', version: versions.micrometer_metrics
+    api group: 'org.glassfish.jersey.core', name: 'jersey-client', version: versions.jersey
+    compileOnly group: 'org.glassfish.jersey.inject', name: 'jersey-hk2', version: versions.jersey
+    api group: 'org.springframework', name: 'spring-web', version: versions.spring_web
+    api group: 'org.springframework', name: 'spring-webflux', version: versions.spring_web
+
+    api group: 'com.squareup.okhttp3', name: 'okhttp', version: versions.okhttp
     compileOnly group: 'org.eclipse.jetty.alpn', name: 'alpn-api', version: versions.alpn_api
 
     implementation group: 'net.jodah', name: 'failsafe', version: versions.failsafe
-    implementation group: 'io.projectreactor', name: 'reactor-core', version: '3.4.25'
+    api group: 'io.projectreactor', name: 'reactor-core', version: '3.4.25'
 
     testImplementation group: 'org.spockframework', name: 'spock-core', version: versions.spock
     testImplementation group: 'org.spockframework', name: 'spock-junit4', version: versions.spock

--- a/hermes-common/src/test/groovy/pl/allegro/tech/hermes/test/IntegrationTest.groovy
+++ b/hermes-common/src/test/groovy/pl/allegro/tech/hermes/test/IntegrationTest.groovy
@@ -3,6 +3,7 @@ package pl.allegro.tech.hermes.test
 import com.fasterxml.jackson.databind.ObjectMapper
 import org.apache.curator.framework.CuratorFramework
 import org.junit.ClassRule
+import pl.allegro.tech.hermes.common.di.factories.ObjectMapperFactory
 import pl.allegro.tech.hermes.common.kafka.KafkaNamesMapper
 import pl.allegro.tech.hermes.common.kafka.NamespaceKafkaNamesMapper
 import pl.allegro.tech.hermes.infrastructure.zookeeper.ZookeeperGroupRepository
@@ -30,7 +31,7 @@ abstract class IntegrationTest extends Specification {
 
     protected RepositoryWaiter wait = new RepositoryWaiter(zookeeperResource.curator(), paths)
 
-    protected ObjectMapper mapper = new ObjectMapper()
+    protected ObjectMapper mapper = new ObjectMapperFactory(true).provide()
 
     protected ZookeeperGroupRepository groupRepository = new ZookeeperGroupRepository(zookeeper(), mapper, paths)
 

--- a/hermes-mock/build.gradle
+++ b/hermes-mock/build.gradle
@@ -1,13 +1,14 @@
 plugins {
     id 'groovy'
     id 'java'
+    id 'java-library'
 }
 
 dependencies {
     implementation group: 'junit', name: 'junit', version: '4.11'
-    implementation group: 'com.github.tomakehurst', name: 'wiremock', version: versions.wiremock
+    api group: 'com.github.tomakehurst', name: 'wiremock', version: versions.wiremock
     implementation group: 'com.jayway.awaitility', name: 'awaitility', version: '1.6.1'
-    implementation group: 'org.apache.avro', name: 'avro', version: versions.avro
+    api group: 'org.apache.avro', name: 'avro', version: versions.avro
     implementation group: 'tech.allegro.schema.json2avro', name: 'converter', version: versions.json2avro
     implementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: versions.junit_jupiter
 


### PR DESCRIPTION
This PR

- fixes: https://github.com/allegro/hermes/issues/1683, by including missing transitive dependencies for hermes-mock
- fixes https://github.com/allegro/hermes/issues/1684 and https://github.com/allegro/hermes/pull/1673#issuecomment-1606271069 by fixing jackson version clash and providing hermes java 17 docker images