### PR TITLE
Fix wrong HTTP method in documentation

### DIFF
--- a/docs/docs/user/subscribing.md
+++ b/docs/docs/user/subscribing.md
@@ -116,7 +116,7 @@ Request that specifies all available options:
 It is possible to suspend any subscription. This means, that no messages will be sent, but the information about last
 consumed message is preserved. After reactivating subscription, sending starts from the point where it stopped.
 
-To change subscription status send POST request with `application/json` content type:
+To change subscription status send PUT request with `application/json` content type:
 
 ```
 /topics/{topicName}/subscriptions/{subscriptionName}/state


### PR DESCRIPTION
## What's changed?

Earlier documentation mentioned that user can change state of subscription using `POST` HTTP method. In reality it always has been `PUT` HTTP method:

<img width="918" alt="image" src="https://github.com/allegro/hermes/assets/16356036/7fe0d68a-6ea9-4e8d-bd6e-e9fe332fbdb2">
