### PR TITLE
Hermes frontend prometheus support

### DIFF
--- a/hermes-benchmark/src/jmh/java/pl/allegro/tech/hermes/benchmark/environment/HermesServerFactory.java
+++ b/hermes-benchmark/src/jmh/java/pl/allegro/tech/hermes/benchmark/environment/HermesServerFactory.java
@@ -53,7 +53,7 @@ class HermesServerFactory {
         ThroughputLimiter throughputLimiter = (exampleTopic, throughput) -> quotaConfirmed();
         HermesMetrics hermesMetrics = new HermesMetrics(new MetricRegistry(), new PathsCompiler(""));
         MetricsFacade metricsFacade = new MetricsFacade(new SimpleMeterRegistry(), hermesMetrics);
-        TopicsCache topicsCache = new InMemoryTopicsCache(hermesMetrics, metricsFacade, topic);
+        TopicsCache topicsCache = new InMemoryTopicsCache(metricsFacade, topic);
         BrokerMessageProducer brokerMessageProducer = new InMemoryBrokerMessageProducer();
         RawSchemaClient rawSchemaClient = new InMemorySchemaClient(topic.getName(), loadMessageResource("schema"), 1, 1);
         Trackers trackers = new Trackers(Collections.emptyList());
@@ -67,7 +67,7 @@ class HermesServerFactory {
         return new HermesServer(
                 sslProperties,
                 hermesServerProperties,
-                hermesMetrics,
+                metricsFacade,
                 httpHandler,
                 new DisabledReadinessChecker(false),
                 new NoOpMessagePreviewPersister(),

--- a/hermes-benchmark/src/jmh/java/pl/allegro/tech/hermes/benchmark/environment/InMemoryTopicsCache.java
+++ b/hermes-benchmark/src/jmh/java/pl/allegro/tech/hermes/benchmark/environment/InMemoryTopicsCache.java
@@ -14,14 +14,12 @@ import java.util.Optional;
 
 class InMemoryTopicsCache implements TopicsCache {
 
-    private final HermesMetrics oldMetrics;
     private final MetricsFacade metricsFacade;
     private final KafkaTopics kafkaTopics;
     private final Topic topic;
 
 
-    InMemoryTopicsCache(HermesMetrics oldMetrics, MetricsFacade metricsFacade, Topic topic) {
-        this.oldMetrics = oldMetrics;
+    InMemoryTopicsCache(MetricsFacade metricsFacade, Topic topic) {
         this.metricsFacade = metricsFacade;
         this.topic = topic;
         this.kafkaTopics = new KafkaTopics(new KafkaTopic(KafkaTopicName.valueOf(topic.getQualifiedName()), topic.getContentType()));
@@ -33,7 +31,6 @@ class InMemoryTopicsCache implements TopicsCache {
             return Optional.of(
                     new CachedTopic(
                             topic,
-                            oldMetrics,
                             metricsFacade,
                             kafkaTopics
                     )

--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/common/metric/BufferMetrics.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/common/metric/BufferMetrics.java
@@ -1,0 +1,21 @@
+package pl.allegro.tech.hermes.common.metric;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tags;
+
+import java.util.concurrent.ConcurrentMap;
+
+public class BufferMetrics {
+    private final MeterRegistry meterRegistry;
+    private final HermesMetrics hermesMetrics;
+
+    public BufferMetrics(HermesMetrics hermesMetrics, MeterRegistry meterRegistry) {
+        this.meterRegistry = meterRegistry;
+        this.hermesMetrics = hermesMetrics;
+    }
+
+    public void registerBackupStorageSizeGauge(ConcurrentMap<?, ?> map) {
+        this.hermesMetrics.registerMessageRepositorySizeGauge(map::size);
+        this.meterRegistry.gaugeMapSize("backup-storage.size", Tags.empty(), map);
+    }
+}

--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/common/metric/Gauges.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/common/metric/Gauges.java
@@ -13,7 +13,7 @@ public class Gauges {
 
     public static final String ACK_ALL_BUFFER_TOTAL_BYTES = KAFKA_PRODUCER + ACK_ALL + "buffer-total-bytes";
     public static final String ACK_ALL_BUFFER_AVAILABLE_BYTES = KAFKA_PRODUCER + ACK_ALL + "buffer-available-bytes";
-    public static final String ACK_ALL_CONFIRMS_METADATA_AGE = KAFKA_PRODUCER + ACK_ALL + "metadata-age";
+    public static final String ACK_ALL_METADATA_AGE = KAFKA_PRODUCER + ACK_ALL + "metadata-age";
     public static final String ACK_ALL_RECORD_QUEUE_TIME_MAX = KAFKA_PRODUCER + ACK_ALL + "record-queue-time-max";
     public static final String ACK_ALL_COMPRESSION_RATE = KAFKA_PRODUCER + ACK_ALL + "compression-rate-avg";
     public static final String ACK_ALL_FAILED_BATCHES_TOTAL = KAFKA_PRODUCER + ACK_ALL + "failed-batches-total";

--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/common/metric/MetricsFacade.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/common/metric/MetricsFacade.java
@@ -7,7 +7,7 @@ public class MetricsFacade {
     private final TopicMetrics topicMetrics;
     private final SubscriptionMetrics subscriptionMetrics;
     private final ConsumerMetrics consumerMetrics;
-    private final BufferMetrics bufferMetrics;
+    private final PersistentBufferMetrics persistentBufferMetrics;
     private final ProducerMetrics producerMetrics;
 
     public MetricsFacade(MeterRegistry meterRegistry,
@@ -15,7 +15,7 @@ public class MetricsFacade {
         this.topicMetrics = new TopicMetrics(hermesMetrics, meterRegistry);
         this.subscriptionMetrics = new SubscriptionMetrics(hermesMetrics, meterRegistry);
         this.consumerMetrics = new ConsumerMetrics(hermesMetrics, meterRegistry);
-        this.bufferMetrics = new BufferMetrics(hermesMetrics, meterRegistry);
+        this.persistentBufferMetrics = new PersistentBufferMetrics(hermesMetrics, meterRegistry);
         this.producerMetrics = new ProducerMetrics(hermesMetrics, meterRegistry);
     }
 
@@ -31,8 +31,8 @@ public class MetricsFacade {
         return consumerMetrics;
     }
 
-    public BufferMetrics bufferMetrics() {
-        return bufferMetrics;
+    public PersistentBufferMetrics persistentBufferMetrics() {
+        return persistentBufferMetrics;
     }
 
     public ProducerMetrics producerMetrics() {

--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/common/metric/MetricsFacade.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/common/metric/MetricsFacade.java
@@ -7,12 +7,16 @@ public class MetricsFacade {
     private final TopicMetrics topicMetrics;
     private final SubscriptionMetrics subscriptionMetrics;
     private final ConsumerMetrics consumerMetrics;
+    private final BufferMetrics bufferMetrics;
+    private final ProducerMetrics producerMetrics;
 
     public MetricsFacade(MeterRegistry meterRegistry,
                          HermesMetrics hermesMetrics) {
         this.topicMetrics = new TopicMetrics(hermesMetrics, meterRegistry);
         this.subscriptionMetrics = new SubscriptionMetrics(hermesMetrics, meterRegistry);
         this.consumerMetrics = new ConsumerMetrics(hermesMetrics, meterRegistry);
+        this.bufferMetrics = new BufferMetrics(hermesMetrics, meterRegistry);
+        this.producerMetrics = new ProducerMetrics(hermesMetrics, meterRegistry);
     }
 
     public TopicMetrics topics() {
@@ -25,6 +29,14 @@ public class MetricsFacade {
 
     public ConsumerMetrics consumers() {
         return consumerMetrics;
+    }
+
+    public BufferMetrics bufferMetrics() {
+        return bufferMetrics;
+    }
+
+    public ProducerMetrics producerMetrics() {
+        return producerMetrics;
     }
 }
 

--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/common/metric/PersistentBufferMetrics.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/common/metric/PersistentBufferMetrics.java
@@ -3,18 +3,18 @@ package pl.allegro.tech.hermes.common.metric;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tags;
 
-import java.util.concurrent.ConcurrentMap;
+import java.util.Map;
 
-public class BufferMetrics {
+public class PersistentBufferMetrics {
     private final MeterRegistry meterRegistry;
     private final HermesMetrics hermesMetrics;
 
-    public BufferMetrics(HermesMetrics hermesMetrics, MeterRegistry meterRegistry) {
+    public PersistentBufferMetrics(HermesMetrics hermesMetrics, MeterRegistry meterRegistry) {
         this.meterRegistry = meterRegistry;
         this.hermesMetrics = hermesMetrics;
     }
 
-    public void registerBackupStorageSizeGauge(ConcurrentMap<?, ?> map) {
+    public void registerBackupStorageSizeGauge(Map<?, ?> map) {
         this.hermesMetrics.registerMessageRepositorySizeGauge(map::size);
         this.meterRegistry.gaugeMapSize("backup-storage.size", Tags.empty(), map);
     }

--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/common/metric/ProducerMetrics.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/common/metric/ProducerMetrics.java
@@ -1,0 +1,207 @@
+package pl.allegro.tech.hermes.common.metric;
+
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tags;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.common.Metric;
+import org.apache.kafka.common.MetricName;
+import org.apache.kafka.common.Node;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Predicate;
+
+import static pl.allegro.tech.hermes.common.metric.Gauges.ACK_ALL;
+import static pl.allegro.tech.hermes.common.metric.Gauges.ACK_ALL_BUFFER_AVAILABLE_BYTES;
+import static pl.allegro.tech.hermes.common.metric.Gauges.ACK_ALL_BUFFER_TOTAL_BYTES;
+import static pl.allegro.tech.hermes.common.metric.Gauges.ACK_ALL_COMPRESSION_RATE;
+import static pl.allegro.tech.hermes.common.metric.Gauges.ACK_ALL_FAILED_BATCHES_TOTAL;
+import static pl.allegro.tech.hermes.common.metric.Gauges.ACK_ALL_METADATA_AGE;
+import static pl.allegro.tech.hermes.common.metric.Gauges.ACK_ALL_RECORD_QUEUE_TIME_MAX;
+import static pl.allegro.tech.hermes.common.metric.Gauges.ACK_LEADER;
+import static pl.allegro.tech.hermes.common.metric.Gauges.ACK_LEADER_BUFFER_AVAILABLE_BYTES;
+import static pl.allegro.tech.hermes.common.metric.Gauges.ACK_LEADER_BUFFER_TOTAL_BYTES;
+import static pl.allegro.tech.hermes.common.metric.Gauges.ACK_LEADER_COMPRESSION_RATE;
+import static pl.allegro.tech.hermes.common.metric.Gauges.ACK_LEADER_FAILED_BATCHES_TOTAL;
+import static pl.allegro.tech.hermes.common.metric.Gauges.ACK_LEADER_METADATA_AGE;
+import static pl.allegro.tech.hermes.common.metric.Gauges.ACK_LEADER_RECORD_QUEUE_TIME_MAX;
+import static pl.allegro.tech.hermes.common.metric.HermesMetrics.escapeDots;
+
+// exposes producer metrics, see: https://docs.confluent.io/platform/current/kafka/monitoring.html#producer-metrics
+public class ProducerMetrics {
+    private final HermesMetrics hermesMetrics;
+    private final MeterRegistry meterRegistry;
+
+    public ProducerMetrics(HermesMetrics hermesMetrics, MeterRegistry meterRegistry) {
+        this.hermesMetrics = hermesMetrics;
+        this.meterRegistry = meterRegistry;
+    }
+
+    public void registerAckAllTotalBytesGauge(Producer<byte[], byte[]> producer) {
+        registerTotalBytesGauge(producer, ACK_ALL_BUFFER_TOTAL_BYTES);
+    }
+
+    public void registerAckLeaderTotalBytesGauge(Producer<byte[], byte[]> producer) {
+        registerTotalBytesGauge(producer, ACK_LEADER_BUFFER_TOTAL_BYTES);
+    }
+
+    public void registerAckAllAvailableBytesGauge(Producer<byte[], byte[]> producer) {
+        registerAvailableBytesGauge(producer, ACK_ALL_BUFFER_AVAILABLE_BYTES);
+    }
+
+    public void registerAckLeaderAvailableBytesGauge(Producer<byte[], byte[]> producer) {
+        registerAvailableBytesGauge(producer, ACK_LEADER_BUFFER_AVAILABLE_BYTES);
+    }
+
+    public void registerAckAllCompressionRateGauge(Producer<byte[], byte[]> producer) {
+        registerCompressionRateGauge(producer, ACK_ALL_COMPRESSION_RATE);
+    }
+
+    public void registerAckLeaderCompressionRateGauge(Producer<byte[], byte[]> producer) {
+        registerCompressionRateGauge(producer, ACK_LEADER_COMPRESSION_RATE);
+    }
+
+    public void registerAckAllFailedBatchesGauge(Producer<byte[], byte[]> producer) {
+        registerFailedBatchesGauge(producer, ACK_ALL_FAILED_BATCHES_TOTAL);
+    }
+
+    public void registerAckLeaderFailedBatchesGauge(Producer<byte[], byte[]> producer) {
+        registerFailedBatchesGauge(producer, ACK_LEADER_FAILED_BATCHES_TOTAL);
+    }
+
+    public void registerAckAllMetadataAgeGauge(Producer<byte[], byte[]> producer) {
+        registerMetadataAgeGauge(producer, ACK_ALL_METADATA_AGE);
+    }
+
+    public void registerAckLeaderMetadataAgeGauge(Producer<byte[], byte[]> producer) {
+        registerMetadataAgeGauge(producer, ACK_LEADER_METADATA_AGE);
+    }
+
+    public void registerAckAllRecordQueueTimeMaxGauge(Producer<byte[], byte[]> producer) {
+        registerRecordQueueTimeMaxGauge(producer, ACK_ALL_RECORD_QUEUE_TIME_MAX);
+    }
+
+    public void registerAckLeaderRecordQueueTimeMaxGauge(Producer<byte[], byte[]> producer) {
+        registerRecordQueueTimeMaxGauge(producer, ACK_LEADER_RECORD_QUEUE_TIME_MAX);
+    }
+
+    public void registerAckAllMaxLatencyPerBrokerGauge(Producer<byte[], byte[]> producer, List<Node> brokers) {
+        registerLatencyPerBrokerGauge(producer, "request-latency-max", ACK_ALL, brokers);
+    }
+
+    public void registerAckLeaderMaxLatencyPerBrokerGauge(Producer<byte[], byte[]> producer, List<Node> brokers) {
+        registerLatencyPerBrokerGauge(producer, "request-latency-max", ACK_LEADER, brokers);
+    }
+
+    public void registerAckAllAvgLatencyPerBrokerGauge(Producer<byte[], byte[]> producer, List<Node> brokers) {
+        registerLatencyPerBrokerGauge(producer, "request-latency-avg", ACK_ALL, brokers);
+    }
+
+    public void registerAckLeaderAvgLatencyPerBrokerGauge(Producer<byte[], byte[]> producer, List<Node> brokers) {
+        registerLatencyPerBrokerGauge(producer, "request-latency-avg", ACK_LEADER, brokers);
+    }
+
+    private void registerTotalBytesGauge(Producer<byte[], byte[]> producer, String gauge) {
+        registerProducerGauge(
+                producer,
+                new MetricName("buffer-total-bytes", "producer-metrics", "buffer total bytes", Collections.emptyMap()),
+                gauge
+        );
+    }
+
+    private void registerAvailableBytesGauge(Producer<byte[], byte[]> producer, String gauge) {
+        registerProducerGauge(
+                producer,
+                new MetricName("buffer-available-bytes", "producer-metrics", "buffer available bytes", Collections.emptyMap()),
+                gauge
+        );
+    }
+
+    private void registerCompressionRateGauge(Producer<byte[], byte[]> producer, String gauge) {
+        registerProducerGauge(
+                producer,
+                new MetricName("compression-rate-avg", "producer-metrics", "average compression rate", Collections.emptyMap()),
+                gauge
+        );
+    }
+
+    private void registerFailedBatchesGauge(Producer<byte[], byte[]> producer, String gauge) {
+        registerProducerGauge(
+                producer,
+                new MetricName("record-error-total", "producer-metrics", "failed publishing batches", Collections.emptyMap()),
+                gauge
+        );
+    }
+
+    private void registerMetadataAgeGauge(Producer<byte[], byte[]> producer, String gauge) {
+        registerProducerGauge(
+                producer,
+                new MetricName("metadata-age", "producer-metrics", "age [s] of metadata", Collections.emptyMap()),
+                gauge
+        );
+    }
+
+    public void registerRecordQueueTimeMaxGauge(Producer<byte[], byte[]> producer, String gauge) {
+        registerProducerGauge(
+                producer,
+                new MetricName(
+                        "record-queue-time-max",
+                        "producer-metrics",
+                        "maximum time [ms] that batch spent in the send buffer",
+                        Collections.emptyMap()),
+                gauge
+        );
+    }
+
+    private void registerLatencyPerBrokerGauge(Producer<byte[], byte[]> producer,
+                                               String metricName,
+                                               String producerName,
+                                               List<Node> brokers) {
+        for (Node broker : brokers) {
+            registerLatencyPerBrokerGauge(producer, metricName, producerName, broker);
+        }
+    }
+
+    private void registerLatencyPerBrokerGauge(Producer<byte[], byte[]> producer,
+                                               String metricName,
+                                               String producerName,
+                                               Node node) {
+        String gauge = Gauges.KAFKA_PRODUCER + producerName + "." + metricName + "." + escapeDots(node.host());
+        Predicate<Map.Entry<MetricName, ? extends Metric>> predicate = entry -> entry.getKey().group().equals("producer-node-metrics")
+                && entry.getKey().name().equals(metricName)
+                && entry.getKey().tags().containsValue("node-" + node.id());
+        registerProducerGaugeGraphite(producer, gauge, predicate);
+        registerProducerGaugePrometheus(producer, gauge, predicate, Tags.of("broker", node.host()));
+    }
+
+
+    private void registerProducerGauge(final Producer<byte[], byte[]> producer,
+                                       final MetricName producerMetricName,
+                                       final String gauge) {
+        Predicate<Map.Entry<MetricName, ? extends Metric>> predicate = entry -> entry.getKey().group().equals(producerMetricName.group()) && entry.getKey().name().equals(producerMetricName.name());
+        registerProducerGaugeGraphite(producer, gauge, predicate);
+        registerProducerGaugePrometheus(producer, gauge, predicate, Tags.empty());
+    }
+
+    private double findProducerMetricByName(Producer<byte[], byte[]> producer, Predicate<Map.Entry<MetricName, ? extends Metric>> predicate) {
+        Optional<? extends Map.Entry<MetricName, ? extends Metric>> first =
+                producer.metrics().entrySet().stream().filter(predicate).findFirst();
+        double value = first.map(metricNameEntry -> metricNameEntry.getValue().value()).orElse(0.0);
+        return value < 0 ? 0.0 : value;
+    }
+
+    private void registerProducerGaugePrometheus(Producer<byte[], byte[]> producer, String gauge, Predicate<Map.Entry<MetricName, ? extends Metric>> predicate, Tags tags) {
+        Gauge.builder(gauge, producer, p -> findProducerMetricByName(p, predicate))
+                .tags(tags)
+                .register(meterRegistry);
+    }
+
+    private void registerProducerGaugeGraphite(Producer<byte[], byte[]> producer, String gauge, Predicate<Map.Entry<MetricName, ? extends Metric>> predicate) {
+        hermesMetrics.registerGauge(gauge, () -> findProducerMetricByName(producer, predicate));
+    }
+
+
+}

--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/common/metric/ProducerMetrics.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/common/metric/ProducerMetrics.java
@@ -32,7 +32,7 @@ import static pl.allegro.tech.hermes.common.metric.Gauges.ACK_LEADER_RECORD_QUEU
 import static pl.allegro.tech.hermes.common.metric.Gauges.INFLIGHT_REQUESTS;
 import static pl.allegro.tech.hermes.common.metric.HermesMetrics.escapeDots;
 
-// exposes producer metrics, see: https://docs.confluent.io/platform/current/kafka/monitoring.html#producer-metrics
+// exposes kafka producer metrics, see: https://docs.confluent.io/platform/current/kafka/monitoring.html#producer-metrics
 public class ProducerMetrics {
     private final HermesMetrics hermesMetrics;
     private final MeterRegistry meterRegistry;

--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/common/metric/SubscriptionHermesCounter.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/common/metric/SubscriptionHermesCounter.java
@@ -3,9 +3,9 @@ package pl.allegro.tech.hermes.common.metric;
 import com.codahale.metrics.Meter;
 import io.micrometer.core.instrument.Counter;
 import pl.allegro.tech.hermes.api.SubscriptionName;
-import pl.allegro.tech.hermes.metrics.HermesCounter;
+import pl.allegro.tech.hermes.metrics.counters.DefaultHermesCounterWithRate;
 
-public class SubscriptionHermesCounter extends HermesCounter {
+public class SubscriptionHermesCounter extends DefaultHermesCounterWithRate {
 
     private final String graphiteName;
     private final SubscriptionName subscription;

--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/common/metric/TopicMetrics.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/common/metric/TopicMetrics.java
@@ -73,6 +73,13 @@ public class TopicMetrics {
         );
     }
 
+    public HermesCounter topicPublished(TopicName topicName) {
+        return HermesCounter.from(
+                micrometerCounter("published", topicName),
+                hermesMetrics.meter(Counters.PUBLISHED, topicName)
+        );
+    }
+
     private Timer micrometerTimer(String metricName, TopicName topicName) {
         return meterRegistry.timer(metricName, topicTags(topicName));
     }

--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/common/metric/TopicMetrics.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/common/metric/TopicMetrics.java
@@ -10,6 +10,8 @@ import pl.allegro.tech.hermes.api.TopicName;
 import pl.allegro.tech.hermes.metrics.HermesCounter;
 import pl.allegro.tech.hermes.metrics.HermesHistogram;
 import pl.allegro.tech.hermes.metrics.HermesTimer;
+import pl.allegro.tech.hermes.metrics.HermesCounterWithRate;
+import pl.allegro.tech.hermes.metrics.counters.HermesCounters;
 
 import static pl.allegro.tech.hermes.common.metric.Meters.DELAYED_PROCESSING;
 import static pl.allegro.tech.hermes.common.metric.Meters.METER;
@@ -64,64 +66,64 @@ public class TopicMetrics {
                 hermesMetrics.timer(Timers.ACK_LEADER_BROKER_LATENCY));
     }
 
-    public HermesCounter topicThroughputBytes(TopicName topicName) {
-        return HermesCounter.from(
+    public HermesCounterWithRate topicThroughputBytes(TopicName topicName) {
+        return HermesCounters.from(
                 micrometerCounter("topic-throughput", topicName),
                 hermesMetrics.meter(TOPIC_THROUGHPUT_BYTES, topicName)
         );
     }
 
-    public HermesCounter topicGlobalThroughputBytes() {
-        return HermesCounter.from(
+    public HermesCounterWithRate topicGlobalThroughputBytes() {
+        return HermesCounters.from(
                 meterRegistry.counter("topic-global-throughput"),
                 hermesMetrics.meter(THROUGHPUT_BYTES)
         );
     }
 
     public HermesCounter topicPublished(TopicName topicName) {
-        return HermesCounter.from(
+        return HermesCounters.from(
                 micrometerCounter("published", topicName),
-                hermesMetrics.meter(Counters.PUBLISHED, topicName)
+                hermesMetrics.counter(Counters.PUBLISHED, topicName)
         );
     }
 
     public HermesCounter topicGlobalRequestCounter() {
-        return HermesCounter.from(
+        return HermesCounters.from(
                 meterRegistry.counter("topic-global-requests"),
                 hermesMetrics.meter(METER)
         );
     }
 
     public HermesCounter topicRequestCounter(TopicName topicName) {
-        return HermesCounter.from(
+        return HermesCounters.from(
                 micrometerCounter("topic-requests", topicName),
                 hermesMetrics.meter(TOPIC_METER)
         );
     }
 
     public HermesCounter topicGlobalDelayedProcessingCounter() {
-        return HermesCounter.from(
+        return HermesCounters.from(
                 meterRegistry.counter("topic-global-delayed-processing"),
                 hermesMetrics.meter(DELAYED_PROCESSING)
         );
     }
 
     public HermesCounter topicDelayedProcessingCounter(TopicName topicName) {
-        return HermesCounter.from(
+        return HermesCounters.from(
                 micrometerCounter("topic-delayed-processing", topicName),
                 hermesMetrics.meter(TOPIC_DELAYED_PROCESSING)
         );
     }
 
     public HermesCounter topicGlobalHttpStatusCodeCounter(int statusCode) {
-        return HermesCounter.from(
+        return HermesCounters.from(
                 meterRegistry.counter("topic-global-http-status-codes", Tags.of("status_code", String.valueOf(statusCode))),
                 hermesMetrics.httpStatusCodeMeter(statusCode)
         );
     }
 
     public HermesCounter topicHttpStatusCodeCounter(TopicName topicName, int statusCode) {
-        return HermesCounter.from(
+        return HermesCounters.from(
                 meterRegistry.counter("topic-http-status-codes", topicTags(topicName).and("status_code", String.valueOf(statusCode))),
                 hermesMetrics.httpStatusCodeMeter(statusCode, topicName)
         );

--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/common/metric/TopicMetrics.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/common/metric/TopicMetrics.java
@@ -8,9 +8,9 @@ import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.Timer;
 import pl.allegro.tech.hermes.api.TopicName;
 import pl.allegro.tech.hermes.metrics.HermesCounter;
+import pl.allegro.tech.hermes.metrics.HermesCounterWithRate;
 import pl.allegro.tech.hermes.metrics.HermesHistogram;
 import pl.allegro.tech.hermes.metrics.HermesTimer;
-import pl.allegro.tech.hermes.metrics.HermesCounterWithRate;
 import pl.allegro.tech.hermes.metrics.counters.HermesCounters;
 
 import static pl.allegro.tech.hermes.common.metric.Meters.DELAYED_PROCESSING;

--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/common/metric/TopicMetrics.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/common/metric/TopicMetrics.java
@@ -1,19 +1,16 @@
 package pl.allegro.tech.hermes.common.metric;
 
-import com.codahale.metrics.Meter;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.DistributionSummary;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.Timer;
-import io.micrometer.core.instrument.distribution.Histogram;
 import pl.allegro.tech.hermes.api.TopicName;
 import pl.allegro.tech.hermes.metrics.HermesCounter;
 import pl.allegro.tech.hermes.metrics.HermesHistogram;
 import pl.allegro.tech.hermes.metrics.HermesTimer;
 
-import java.util.List;
 
 import static pl.allegro.tech.hermes.common.metric.Meters.DELAYED_PROCESSING;
 import static pl.allegro.tech.hermes.common.metric.Meters.METER;
@@ -21,7 +18,6 @@ import static pl.allegro.tech.hermes.common.metric.Meters.THROUGHPUT_BYTES;
 import static pl.allegro.tech.hermes.common.metric.Meters.TOPIC_DELAYED_PROCESSING;
 import static pl.allegro.tech.hermes.common.metric.Meters.TOPIC_METER;
 import static pl.allegro.tech.hermes.common.metric.Meters.TOPIC_THROUGHPUT_BYTES;
-import static pl.allegro.tech.hermes.metrics.PathContext.pathContext;
 
 public class TopicMetrics {
     private final HermesMetrics hermesMetrics;
@@ -97,7 +93,6 @@ public class TopicMetrics {
         );
     }
 
-    // TODO: is requests appropriate
     public HermesCounter topicRequestCounter(TopicName topicName) {
         return HermesCounter.from(
                 micrometerCounter("topic-requests", topicName),
@@ -134,7 +129,6 @@ public class TopicMetrics {
     }
 
     public HermesHistogram topicGlobalMessageContentSizeHistogram() {
-        // TODO: configure properly
         return HermesHistogram.of(
                 DistributionSummary.builder("topic-global-message-size")
                         .register(meterRegistry),
@@ -143,12 +137,11 @@ public class TopicMetrics {
     }
 
     public HermesHistogram topicMessageContentSizeHistogram(TopicName topicName) {
-        // TODO: configure properly
         return HermesHistogram.of(
                 DistributionSummary.builder("topic-message-size")
                         .tags(topicTags(topicName))
                         .register(meterRegistry),
-                hermesMetrics.messageContentSizeHistogram()
+                hermesMetrics.messageContentSizeHistogram(topicName)
         );
     }
 

--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/common/metric/TopicMetrics.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/common/metric/TopicMetrics.java
@@ -11,7 +11,6 @@ import pl.allegro.tech.hermes.metrics.HermesCounter;
 import pl.allegro.tech.hermes.metrics.HermesHistogram;
 import pl.allegro.tech.hermes.metrics.HermesTimer;
 
-
 import static pl.allegro.tech.hermes.common.metric.Meters.DELAYED_PROCESSING;
 import static pl.allegro.tech.hermes.common.metric.Meters.METER;
 import static pl.allegro.tech.hermes.common.metric.Meters.THROUGHPUT_BYTES;

--- a/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/buffer/PersistentBufferExtension.java
+++ b/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/buffer/PersistentBufferExtension.java
@@ -2,7 +2,7 @@ package pl.allegro.tech.hermes.frontend.buffer;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import pl.allegro.tech.hermes.common.metric.HermesMetrics;
+import pl.allegro.tech.hermes.common.metric.MetricsFacade;
 import pl.allegro.tech.hermes.frontend.buffer.chronicle.ChronicleMapMessageRepository;
 import pl.allegro.tech.hermes.frontend.listeners.BrokerListeners;
 
@@ -23,7 +23,7 @@ public class PersistentBufferExtension {
     private final BrokerListeners listeners;
 
     private final BackupMessagesLoader backupMessagesLoader;
-    private final HermesMetrics hermesMetrics;
+    private final MetricsFacade metricsFacade;
 
     private int entries;
     private int avgMessageSize;
@@ -32,12 +32,12 @@ public class PersistentBufferExtension {
                                      Clock clock,
                                      BrokerListeners listeners,
                                      BackupMessagesLoader backupMessagesLoader,
-                                     HermesMetrics hermesMetrics) {
+                                     MetricsFacade metricsFacade) {
         this.persistentBufferExtensionParameters = persistentBufferExtensionParameters;
         this.clock = clock;
         this.listeners = listeners;
         this.backupMessagesLoader = backupMessagesLoader;
-        this.hermesMetrics = hermesMetrics;
+        this.metricsFacade = metricsFacade;
     }
 
     public void extend() {
@@ -82,7 +82,7 @@ public class PersistentBufferExtension {
 
     private void enableLocalStorage(BackupFilesManager backupFilesManager) {
         MessageRepository repository = persistentBufferExtensionParameters.isSizeReportingEnabled()
-                ? new ChronicleMapMessageRepository(backupFilesManager.getCurrentBackupFile(), entries, avgMessageSize, hermesMetrics)
+                ? new ChronicleMapMessageRepository(backupFilesManager.getCurrentBackupFile(), entries, avgMessageSize, metricsFacade)
                 : new ChronicleMapMessageRepository(backupFilesManager.getCurrentBackupFile(), entries, avgMessageSize);
 
         BrokerListener brokerListener = new BrokerListener(repository);

--- a/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/buffer/chronicle/ChronicleMapMessageRepository.java
+++ b/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/buffer/chronicle/ChronicleMapMessageRepository.java
@@ -52,7 +52,7 @@ public class ChronicleMapMessageRepository implements MessageRepository {
 
     public ChronicleMapMessageRepository(File file, int entries, int averageMessageSize, MetricsFacade metricsFacade) {
         this(file, entries, averageMessageSize);
-        metricsFacade.bufferMetrics().registerBackupStorageSizeGauge(map);
+        metricsFacade.persistentBufferMetrics().registerBackupStorageSizeGauge(map);
     }
 
     @Override

--- a/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/buffer/chronicle/ChronicleMapMessageRepository.java
+++ b/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/buffer/chronicle/ChronicleMapMessageRepository.java
@@ -5,7 +5,7 @@ import net.openhft.chronicle.map.ChronicleMapBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import pl.allegro.tech.hermes.api.Topic;
-import pl.allegro.tech.hermes.common.metric.HermesMetrics;
+import pl.allegro.tech.hermes.common.metric.MetricsFacade;
 import pl.allegro.tech.hermes.frontend.buffer.BackupMessage;
 import pl.allegro.tech.hermes.frontend.buffer.MessageRepository;
 import pl.allegro.tech.hermes.frontend.publishing.message.Message;
@@ -50,9 +50,9 @@ public class ChronicleMapMessageRepository implements MessageRepository {
         }
     }
 
-    public ChronicleMapMessageRepository(File file, int entries, int averageMessageSize, HermesMetrics hermesMetrics) {
+    public ChronicleMapMessageRepository(File file, int entries, int averageMessageSize, MetricsFacade metricsFacade) {
         this(file, entries, averageMessageSize);
-        hermesMetrics.registerMessageRepositorySizeGauge(map::size);
+        metricsFacade.bufferMetrics().registerBackupStorageSizeGauge(map);
     }
 
     @Override

--- a/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/cache/topic/NotificationBasedTopicsCache.java
+++ b/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/cache/topic/NotificationBasedTopicsCache.java
@@ -6,7 +6,6 @@ import org.slf4j.LoggerFactory;
 import pl.allegro.tech.hermes.api.Topic;
 import pl.allegro.tech.hermes.api.TopicName;
 import pl.allegro.tech.hermes.common.kafka.KafkaNamesMapper;
-import pl.allegro.tech.hermes.common.metric.HermesMetrics;
 import pl.allegro.tech.hermes.common.metric.MetricsFacade;
 import pl.allegro.tech.hermes.domain.group.GroupRepository;
 import pl.allegro.tech.hermes.domain.notifications.InternalNotificationsBus;
@@ -29,7 +28,6 @@ public class NotificationBasedTopicsCache implements TopicCallback, TopicsCache,
 
     private final GroupRepository groupRepository;
     private final TopicRepository topicRepository;
-    private final HermesMetrics oldHermesMetrics;
     private final MetricsFacade metricsFacade;
     private final KafkaNamesMapper kafkaNamesMapper;
 
@@ -37,12 +35,10 @@ public class NotificationBasedTopicsCache implements TopicCallback, TopicsCache,
                                         BlacklistZookeeperNotifyingCache blacklistZookeeperNotifyingCache,
                                         GroupRepository groupRepository,
                                         TopicRepository topicRepository,
-                                        HermesMetrics oldHermesMetrics,
                                         MetricsFacade metricsFacade,
                                         KafkaNamesMapper kafkaNamesMapper) {
         this.groupRepository = groupRepository;
         this.topicRepository = topicRepository;
-        this.oldHermesMetrics = oldHermesMetrics;
         this.metricsFacade = metricsFacade;
         this.kafkaNamesMapper = kafkaNamesMapper;
         notificationsBus.registerTopicCallback(this);
@@ -112,10 +108,10 @@ public class NotificationBasedTopicsCache implements TopicCallback, TopicsCache,
     }
 
     private CachedTopic cachedTopic(Topic topic) {
-        return new CachedTopic(topic, oldHermesMetrics, metricsFacade, kafkaNamesMapper.toKafkaTopics(topic));
+        return new CachedTopic(topic, metricsFacade, kafkaNamesMapper.toKafkaTopics(topic));
     }
 
     private CachedTopic bannedTopic(Topic topic) {
-        return new CachedTopic(topic, oldHermesMetrics, metricsFacade, kafkaNamesMapper.toKafkaTopics(topic), true);
+        return new CachedTopic(topic, metricsFacade, kafkaNamesMapper.toKafkaTopics(topic), true);
     }
 }

--- a/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/config/FrontendConfiguration.java
+++ b/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/config/FrontendConfiguration.java
@@ -5,7 +5,6 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import pl.allegro.tech.hermes.common.kafka.KafkaNamesMapper;
-import pl.allegro.tech.hermes.common.metric.HermesMetrics;
 import pl.allegro.tech.hermes.common.metric.MetricsFacade;
 import pl.allegro.tech.hermes.domain.group.GroupRepository;
 import pl.allegro.tech.hermes.domain.notifications.InternalNotificationsBus;
@@ -41,13 +40,12 @@ public class FrontendConfiguration {
     public TopicsCache notificationBasedTopicsCache(InternalNotificationsBus internalNotificationsBus,
                                                     GroupRepository groupRepository,
                                                     TopicRepository topicRepository,
-                                                    HermesMetrics hermesMetrics,
                                                     MetricsFacade metricsFacade,
                                                     KafkaNamesMapper kafkaNamesMapper,
                                                     BlacklistZookeeperNotifyingCache blacklistZookeeperNotifyingCache) {
 
         return new NotificationBasedTopicsCache(internalNotificationsBus, blacklistZookeeperNotifyingCache,
-                groupRepository, topicRepository, hermesMetrics, metricsFacade, kafkaNamesMapper);
+                groupRepository, topicRepository, metricsFacade, kafkaNamesMapper);
     }
 
     @Bean
@@ -66,9 +64,9 @@ public class FrontendConfiguration {
                                                                Clock clock,
                                                                BrokerListeners listeners,
                                                                BackupMessagesLoader backupMessagesLoader,
-                                                               HermesMetrics hermesMetrics) {
+                                                               MetricsFacade metricsFacade) {
         return new PersistentBufferExtension(localMessageStorageProperties, clock, listeners, backupMessagesLoader,
-                hermesMetrics);
+                metricsFacade);
     }
 
     @Bean(initMethod = "startup")

--- a/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/config/FrontendProducerConfiguration.java
+++ b/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/config/FrontendProducerConfiguration.java
@@ -4,6 +4,7 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import pl.allegro.tech.hermes.common.metric.HermesMetrics;
+import pl.allegro.tech.hermes.common.metric.MetricsFacade;
 import pl.allegro.tech.hermes.frontend.producer.BrokerMessageProducer;
 import pl.allegro.tech.hermes.frontend.producer.kafka.KafkaBrokerMessageProducer;
 import pl.allegro.tech.hermes.frontend.producer.kafka.KafkaHeaderFactory;
@@ -27,9 +28,9 @@ public class FrontendProducerConfiguration {
     @Bean
     public BrokerMessageProducer kafkaBrokerMessageProducer(Producers producers,
                                                             KafkaTopicMetadataFetcher kafkaTopicMetadataFetcher,
-                                                            HermesMetrics hermesMetrics,
+                                                            MetricsFacade metricsFacade,
                                                             MessageToKafkaProducerRecordConverter messageConverter) {
-        return new KafkaBrokerMessageProducer(producers, kafkaTopicMetadataFetcher, hermesMetrics, messageConverter);
+        return new KafkaBrokerMessageProducer(producers, kafkaTopicMetadataFetcher, metricsFacade, messageConverter);
     }
 
     @Bean

--- a/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/config/FrontendProducerConfiguration.java
+++ b/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/config/FrontendProducerConfiguration.java
@@ -3,7 +3,6 @@ package pl.allegro.tech.hermes.frontend.config;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import pl.allegro.tech.hermes.common.metric.HermesMetrics;
 import pl.allegro.tech.hermes.common.metric.MetricsFacade;
 import pl.allegro.tech.hermes.frontend.producer.BrokerMessageProducer;
 import pl.allegro.tech.hermes.frontend.producer.kafka.KafkaBrokerMessageProducer;

--- a/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/config/FrontendServerConfiguration.java
+++ b/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/config/FrontendServerConfiguration.java
@@ -7,7 +7,7 @@ import org.apache.curator.framework.CuratorFramework;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import pl.allegro.tech.hermes.common.metric.HermesMetrics;
+import pl.allegro.tech.hermes.common.metric.MetricsFacade;
 import pl.allegro.tech.hermes.common.ssl.SslContextFactory;
 import pl.allegro.tech.hermes.frontend.cache.topic.TopicsCache;
 import pl.allegro.tech.hermes.frontend.producer.BrokerMessageProducer;
@@ -37,7 +37,7 @@ public class FrontendServerConfiguration {
     @Bean(initMethod = "start", destroyMethod = "stop")
     public HermesServer hermesServer(HermesServerProperties hermesServerProperties,
                                      SslProperties sslProperties,
-                                     HermesMetrics hermesMetrics,
+                                     MetricsFacade metricsFacade,
                                      HttpHandler publishingHandler,
                                      DefaultReadinessChecker defaultReadinessChecker,
                                      DefaultMessagePreviewPersister defaultMessagePreviewPersister,
@@ -49,7 +49,7 @@ public class FrontendServerConfiguration {
         return new HermesServer(
                 sslProperties,
                 hermesServerProperties,
-                hermesMetrics,
+                metricsFacade,
                 publishingHandler,
                 defaultReadinessChecker,
                 defaultMessagePreviewPersister,

--- a/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/metric/CachedTopic.java
+++ b/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/metric/CachedTopic.java
@@ -10,6 +10,7 @@ import pl.allegro.tech.hermes.metrics.HermesHistogram;
 import pl.allegro.tech.hermes.metrics.HermesRateMeter;
 import pl.allegro.tech.hermes.metrics.HermesTimer;
 import pl.allegro.tech.hermes.metrics.HermesTimerContext;
+import pl.allegro.tech.hermes.metrics.HermesCounterWithRate;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -35,8 +36,8 @@ public class CachedTopic {
     private final HermesHistogram topicMessageContentSize;
     private final HermesHistogram globalMessageContentSize;
 
-    private final HermesCounter topicThroughputMeter;
-    private final HermesCounter globalThroughputMeter;
+    private final HermesCounterWithRate topicThroughputMeter;
+    private final HermesCounterWithRate globalThroughputMeter;
 
     private final HermesCounter published;
 

--- a/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/metric/CachedTopic.java
+++ b/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/metric/CachedTopic.java
@@ -6,11 +6,11 @@ import pl.allegro.tech.hermes.common.kafka.KafkaTopics;
 import pl.allegro.tech.hermes.common.metric.MetricsFacade;
 import pl.allegro.tech.hermes.common.metric.timer.StartedTimersPair;
 import pl.allegro.tech.hermes.metrics.HermesCounter;
+import pl.allegro.tech.hermes.metrics.HermesCounterWithRate;
 import pl.allegro.tech.hermes.metrics.HermesHistogram;
 import pl.allegro.tech.hermes.metrics.HermesRateMeter;
 import pl.allegro.tech.hermes.metrics.HermesTimer;
 import pl.allegro.tech.hermes.metrics.HermesTimerContext;
-import pl.allegro.tech.hermes.metrics.HermesCounterWithRate;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;

--- a/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/metric/CachedTopic.java
+++ b/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/metric/CachedTopic.java
@@ -43,7 +43,7 @@ public class CachedTopic {
     private final HermesCounter topicThroughputMeter;
     private final HermesCounter globalThroughputMeter;
 
-    private final Counter published;
+    private final HermesCounter published;
 
     private final Map<Integer, MetersPair> httpStatusCodesMeters = new ConcurrentHashMap<>();
 
@@ -68,7 +68,7 @@ public class CachedTopic {
         topicMessageContentSize = oldHermesMetrics.messageContentSizeHistogram(topic.getName());
         globalMessageContentSize = oldHermesMetrics.messageContentSizeHistogram();
 
-        published = oldHermesMetrics.counter(Counters.PUBLISHED, topic.getName());
+        published = metricsFacade.topics().topicPublished(topic.getName());
 
         globalThroughputMeter = metricsFacade.topics().topicGlobalThroughputBytes();
         topicThroughputMeter = metricsFacade.topics().topicThroughputBytes(topic.getName());
@@ -127,7 +127,7 @@ public class CachedTopic {
     }
 
     public void incrementPublished() {
-        published.inc();
+        published.increment(1L);
     }
 
     public void reportMessageContentSize(int size) {

--- a/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/metric/MetersPair.java
+++ b/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/metric/MetersPair.java
@@ -1,18 +1,18 @@
 package pl.allegro.tech.hermes.frontend.metric;
 
-import com.codahale.metrics.Meter;
+import pl.allegro.tech.hermes.metrics.HermesCounter;
 
 public class MetersPair {
-    private final Meter meter1;
-    private final Meter meter2;
+    private final HermesCounter meter1;
+    private final HermesCounter meter2;
 
-    public MetersPair(Meter meter1, Meter meter2) {
+    public MetersPair(HermesCounter meter1, HermesCounter meter2) {
         this.meter1 = meter1;
         this.meter2 = meter2;
     }
 
     void mark() {
-        meter1.mark();
-        meter2.mark();
+        meter1.increment(1L);
+        meter2.increment(1L);
     }
 }

--- a/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/producer/kafka/KafkaBrokerMessageProducer.java
+++ b/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/producer/kafka/KafkaBrokerMessageProducer.java
@@ -7,7 +7,7 @@ import org.apache.kafka.common.PartitionInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import pl.allegro.tech.hermes.api.Topic;
-import pl.allegro.tech.hermes.common.metric.HermesMetrics;
+import pl.allegro.tech.hermes.common.metric.MetricsFacade;
 import pl.allegro.tech.hermes.frontend.metric.CachedTopic;
 import pl.allegro.tech.hermes.frontend.producer.BrokerMessageProducer;
 import pl.allegro.tech.hermes.frontend.publishing.PublishingCallback;
@@ -21,18 +21,18 @@ public class KafkaBrokerMessageProducer implements BrokerMessageProducer {
     private static final Logger logger = LoggerFactory.getLogger(KafkaBrokerMessageProducer.class);
     private final Producers producers;
     private final KafkaTopicMetadataFetcher kafkaTopicMetadataFetcher;
-    private final HermesMetrics metrics;
+    private final MetricsFacade metricsFacade;
     private final MessageToKafkaProducerRecordConverter messageConverter;
 
     public KafkaBrokerMessageProducer(Producers producers,
                                       KafkaTopicMetadataFetcher kafkaTopicMetadataFetcher,
-                                      HermesMetrics metrics,
+                                      MetricsFacade metricsFacade,
                                       MessageToKafkaProducerRecordConverter messageConverter) {
         this.producers = producers;
         this.kafkaTopicMetadataFetcher = kafkaTopicMetadataFetcher;
-        this.metrics = metrics;
+        this.metricsFacade = metricsFacade;
         this.messageConverter = messageConverter;
-        producers.registerGauges(metrics);
+        producers.registerGauges(metricsFacade);
     }
 
     @Override
@@ -99,7 +99,7 @@ public class KafkaBrokerMessageProducer implements BrokerMessageProducer {
         public void onCompletion(RecordMetadata recordMetadata, Exception e) {
             if (e == null) {
                 callback.onPublished(message, topic);
-                producers.maybeRegisterNodeMetricsGauges(metrics);
+                producers.maybeRegisterNodeMetricsGauges(metricsFacade);
             } else {
                 callback.onUnpublished(message, topic, e);
             }

--- a/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/producer/kafka/Producers.java
+++ b/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/producer/kafka/Producers.java
@@ -7,16 +7,14 @@ import org.apache.kafka.common.Node;
 import pl.allegro.tech.hermes.api.Topic;
 import pl.allegro.tech.hermes.common.metric.Gauges;
 import pl.allegro.tech.hermes.common.metric.HermesMetrics;
+import pl.allegro.tech.hermes.common.metric.MetricsFacade;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Predicate;
 
-import static pl.allegro.tech.hermes.common.metric.Gauges.ACK_ALL;
-import static pl.allegro.tech.hermes.common.metric.Gauges.ACK_LEADER;
 import static pl.allegro.tech.hermes.common.metric.HermesMetrics.escapeDots;
 
 public class Producers {
@@ -38,33 +36,33 @@ public class Producers {
         return topic.isReplicationConfirmRequired() ? ackAll : ackLeader;
     }
 
-    public void registerGauges(HermesMetrics metrics) {
-        registerTotalBytesGauge(ackLeader, metrics, Gauges.ACK_LEADER_BUFFER_TOTAL_BYTES);
-        registerAvailableBytesGauge(ackLeader, metrics, Gauges.ACK_LEADER_BUFFER_AVAILABLE_BYTES);
-        registerTotalBytesGauge(ackAll, metrics, Gauges.ACK_ALL_BUFFER_TOTAL_BYTES);
-        registerAvailableBytesGauge(ackAll, metrics, Gauges.ACK_ALL_BUFFER_AVAILABLE_BYTES);
-        registerCompressionRateGauge(ackLeader, metrics, Gauges.ACK_LEADER_COMPRESSION_RATE);
-        registerCompressionRateGauge(ackAll, metrics, Gauges.ACK_ALL_COMPRESSION_RATE);
-        registerFailedBatchesGauge(ackAll, metrics, Gauges.ACK_ALL_FAILED_BATCHES_TOTAL);
-        registerFailedBatchesGauge(ackLeader, metrics, Gauges.ACK_LEADER_FAILED_BATCHES_TOTAL);
-        registerMetadataAgeGauge(ackAll, metrics, Gauges.ACK_ALL_CONFIRMS_METADATA_AGE);
-        registerMetadataAgeGauge(ackLeader, metrics, Gauges.ACK_LEADER_METADATA_AGE);
-        registerRecordQueueTimeMaxGauge(ackAll, metrics, Gauges.ACK_ALL_RECORD_QUEUE_TIME_MAX);
-        registerRecordQueueTimeMaxGauge(ackLeader, metrics, Gauges.ACK_LEADER_RECORD_QUEUE_TIME_MAX);
+    public void registerGauges(MetricsFacade metricsFacade) {
+        metricsFacade.producerMetrics().registerAckAllTotalBytesGauge(ackAll);
+        metricsFacade.producerMetrics().registerAckLeaderTotalBytesGauge(ackLeader);
+        metricsFacade.producerMetrics().registerAckAllAvailableBytesGauge(ackAll);
+        metricsFacade.producerMetrics().registerAckLeaderAvailableBytesGauge(ackLeader);
+        metricsFacade.producerMetrics().registerAckAllCompressionRateGauge(ackAll);
+        metricsFacade.producerMetrics().registerAckLeaderCompressionRateGauge(ackLeader);
+        metricsFacade.producerMetrics().registerAckAllFailedBatchesGauge(ackAll);
+        metricsFacade.producerMetrics().registerAckLeaderFailedBatchesGauge(ackLeader);
+        metricsFacade.producerMetrics().registerAckAllMetadataAgeGauge(ackAll);
+        metricsFacade.producerMetrics().registerAckLeaderMetadataAgeGauge(ackLeader);
+        metricsFacade.producerMetrics().registerAckAllRecordQueueTimeMaxGauge(ackAll);
+        metricsFacade.producerMetrics().registerAckLeaderRecordQueueTimeMaxGauge(ackAll);
     }
 
-    public void maybeRegisterNodeMetricsGauges(HermesMetrics metrics) {
+    public void maybeRegisterNodeMetricsGauges(MetricsFacade metricsFacade) {
         if (reportNodeMetrics && nodeMetricsRegistered.compareAndSet(false, true)) {
-            registerLatencyPerBrokerGauge(metrics);
+            registerLatencyPerBrokerGauge(metricsFacade);
         }
     }
 
-    private void registerLatencyPerBrokerGauge(HermesMetrics metrics) {
+    private void registerLatencyPerBrokerGauge(MetricsFacade metricsFacade) {
         List<Node> brokers = ProducerBrokerNodeReader.read(ackLeader);
-        registerLatencyPerBrokerGauge(ackAll, metrics, "request-latency-avg", ACK_ALL, brokers);
-        registerLatencyPerBrokerGauge(ackLeader, metrics, "request-latency-avg", ACK_LEADER, brokers);
-        registerLatencyPerBrokerGauge(ackAll, metrics, "request-latency-max", ACK_ALL, brokers);
-        registerLatencyPerBrokerGauge(ackLeader, metrics, "request-latency-max", ACK_LEADER, brokers);
+        metricsFacade.producerMetrics().registerAckAllAvgLatencyPerBrokerGauge(ackAll, brokers);
+        metricsFacade.producerMetrics().registerAckLeaderAvgLatencyPerBrokerGauge(ackLeader, brokers);
+        metricsFacade.producerMetrics().registerAckAllMaxLatencyPerBrokerGauge(ackAll, brokers);
+        metricsFacade.producerMetrics().registerAckLeaderMaxLatencyPerBrokerGauge(ackLeader, brokers);
     }
 
     private void registerLatencyPerBrokerGauge(Producer<byte[], byte[]> producer,
@@ -91,72 +89,6 @@ public class Producers {
 
     }
 
-    private void registerCompressionRateGauge(Producer<byte[], byte[]> producer, HermesMetrics metrics, String gauge) {
-        registerProducerGauge(
-                producer,
-                metrics,
-                new MetricName("compression-rate-avg", "producer-metrics", "average compression rate", Collections.emptyMap()),
-                gauge
-        );
-    }
-
-    private void registerTotalBytesGauge(Producer<byte[], byte[]> producer, HermesMetrics metrics, String gauge) {
-        registerProducerGauge(
-                producer,
-                metrics,
-                new MetricName("buffer-total-bytes", "producer-metrics", "buffer total bytes", Collections.emptyMap()),
-                gauge
-        );
-    }
-
-    private void registerAvailableBytesGauge(Producer<byte[], byte[]> producer, HermesMetrics metrics, String gauge) {
-        registerProducerGauge(
-                producer,
-                metrics,
-                new MetricName("buffer-available-bytes", "producer-metrics", "buffer available bytes", Collections.emptyMap()),
-                gauge
-        );
-    }
-
-    private void registerFailedBatchesGauge(Producer<byte[], byte[]> producer, HermesMetrics metrics, String gauge) {
-        registerProducerGauge(
-                producer,
-                metrics,
-                new MetricName("record-error-total", "producer-metrics", "failed publishing batches", Collections.emptyMap()),
-                gauge
-        );
-    }
-
-    private void registerRecordQueueTimeMaxGauge(Producer<byte[], byte[]> producer, HermesMetrics metrics, String gauge) {
-        registerProducerGauge(
-                producer,
-                metrics,
-                new MetricName(
-                        "record-queue-time-max",
-                        "producer-metrics",
-                        "maximum time [ms] that batch spent in the send buffer",
-                        Collections.emptyMap()),
-                gauge
-        );
-    }
-
-    private void registerMetadataAgeGauge(Producer<byte[], byte[]> producer, HermesMetrics metrics, String gauge) {
-        registerProducerGauge(
-                producer,
-                metrics,
-                new MetricName("metadata-age", "producer-metrics", "age [s] of metadata", Collections.emptyMap()),
-                gauge
-        );
-    }
-
-    private void registerProducerGauge(final Producer<byte[], byte[]> producer,
-                                       final HermesMetrics metrics,
-                                       final MetricName name,
-                                       final String gauge) {
-
-        registerGauge(producer, metrics, gauge,
-                entry -> entry.getKey().group().equals(name.group()) && entry.getKey().name().equals(name.name()));
-    }
 
     private void registerGauge(Producer<byte[], byte[]> producer, HermesMetrics metrics, String gauge,
                                Predicate<Map.Entry<MetricName, ? extends Metric>> predicate) {

--- a/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/server/HermesServer.java
+++ b/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/server/HermesServer.java
@@ -6,7 +6,7 @@ import io.undertow.server.HttpHandler;
 import io.undertow.server.RoutingHandler;
 import io.undertow.server.handlers.RequestDumpingHandler;
 import org.xnio.SslClientAuthMode;
-import pl.allegro.tech.hermes.common.metric.HermesMetrics;
+import pl.allegro.tech.hermes.common.metric.MetricsFacade;
 import pl.allegro.tech.hermes.frontend.publishing.handlers.ThroughputLimiter;
 import pl.allegro.tech.hermes.frontend.publishing.preview.MessagePreviewPersister;
 import pl.allegro.tech.hermes.frontend.services.HealthCheckService;
@@ -24,7 +24,7 @@ import static org.xnio.Options.SSL_CLIENT_AUTH_MODE;
 
 public class HermesServer {
 
-    private final HermesMetrics hermesMetrics;
+    private final MetricsFacade metricsFacade;
     private final HermesServerParameters hermesServerParameters;
     private final SslParameters sslParameters;
     private final HttpHandler publishingHandler;
@@ -42,7 +42,7 @@ public class HermesServer {
     public HermesServer(
             SslParameters sslParameters,
             HermesServerParameters hermesServerParameters,
-            HermesMetrics hermesMetrics,
+            MetricsFacade metricsFacade,
             HttpHandler publishingHandler,
             ReadinessChecker readinessChecker,
             MessagePreviewPersister messagePreviewPersister,
@@ -54,7 +54,7 @@ public class HermesServer {
 
         this.sslParameters = sslParameters;
         this.hermesServerParameters = hermesServerParameters;
-        this.hermesMetrics = hermesMetrics;
+        this.metricsFacade = metricsFacade;
         this.publishingHandler = publishingHandler;
         this.prometheusMeterRegistry = prometheusMeterRegistry;
         this.healthCheckService = new HealthCheckService();
@@ -105,7 +105,7 @@ public class HermesServer {
     }
 
     private Undertow configureServer() {
-        gracefulShutdown = new HermesShutdownHandler(handlers(), hermesMetrics);
+        gracefulShutdown = new HermesShutdownHandler(handlers(), metricsFacade);
         Undertow.Builder builder = Undertow.builder()
                 .addHttpListener(hermesServerParameters.getPort(), hermesServerParameters.getHost())
                 .setServerOption(REQUEST_PARSE_TIMEOUT, (int) hermesServerParameters.getRequestParseTimeout().toMillis())

--- a/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/server/HermesShutdownHandler.java
+++ b/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/server/HermesShutdownHandler.java
@@ -68,7 +68,8 @@ public class HermesShutdownHandler implements HttpHandler {
     }
 
     private boolean isBufferEmpty() {
-        long bufferUsedBytes = (long) (metrics.producerMetrics().getBufferTotalBytes() - metrics.producerMetrics().getBufferAvailableBytes());
+        long bufferUsedBytes = (long) (metrics.producerMetrics().getBufferTotalBytes()
+                - metrics.producerMetrics().getBufferAvailableBytes());
         logger.info("Buffer flush: {} bytes still in use", bufferUsedBytes);
         return  bufferUsedBytes < TOLERANCE_BYTES;
     }

--- a/hermes-frontend/src/test/groovy/pl/allegro/tech/hermes/frontend/producer/kafka/KafkaBrokerMessageProducerIntegrationTest.groovy
+++ b/hermes-frontend/src/test/groovy/pl/allegro/tech/hermes/frontend/producer/kafka/KafkaBrokerMessageProducerIntegrationTest.groovy
@@ -2,6 +2,7 @@ package pl.allegro.tech.hermes.frontend.producer.kafka
 
 import com.codahale.metrics.MetricRegistry
 import com.jayway.awaitility.Awaitility
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import org.apache.commons.lang3.tuple.ImmutablePair
 import org.apache.kafka.clients.admin.AdminClient
 import org.apache.kafka.clients.admin.NewTopic
@@ -21,6 +22,7 @@ import pl.allegro.tech.hermes.common.kafka.ConsumerGroupId
 import pl.allegro.tech.hermes.common.kafka.JsonToAvroMigrationKafkaNamesMapper
 import pl.allegro.tech.hermes.common.kafka.KafkaNamesMapper
 import pl.allegro.tech.hermes.common.metric.HermesMetrics
+import pl.allegro.tech.hermes.common.metric.MetricsFacade
 import pl.allegro.tech.hermes.frontend.config.SchemaProperties
 import pl.allegro.tech.hermes.frontend.config.KafkaHeaderNameProperties
 import pl.allegro.tech.hermes.frontend.config.KafkaProducerProperties
@@ -100,7 +102,7 @@ class KafkaBrokerMessageProducerIntegrationTest extends Specification {
         producers = new Producers(leaderConfirms, everyoneConfirms, kafkaProducerProperties.isReportNodeMetricsEnabled())
         brokerMessageProducer = new KafkaBrokerMessageProducer(producers,
                 new KafkaTopicMetadataFetcher(adminClient, kafkaProducerProperties.getMetadataMaxAge()),
-                new HermesMetrics(new MetricRegistry(), new PathsCompiler("localhost")),
+                new MetricsFacade(new SimpleMeterRegistry(), new HermesMetrics(new MetricRegistry(), new PathsCompiler("localhost"))),
                 new MessageToKafkaProducerRecordConverter(new KafkaHeaderFactory(kafkaHeaderNameProperties),
                         schemaProperties.isIdHeaderEnabled()
                 )

--- a/hermes-frontend/src/test/groovy/pl/allegro/tech/hermes/frontend/server/CachedTopicsTestHelper.groovy
+++ b/hermes-frontend/src/test/groovy/pl/allegro/tech/hermes/frontend/server/CachedTopicsTestHelper.groovy
@@ -22,11 +22,11 @@ class CachedTopicsTestHelper {
 
     static CachedTopic cachedTopic(String name) {
         def kafkaTopics = new KafkaTopics(new KafkaTopic(KafkaTopicName.valueOf(name), ContentType.JSON))
-        return new CachedTopic(TopicBuilder.topic(name).build(), hermesMetrics, micrometerHermesMetrics, kafkaTopics)
+        return new CachedTopic(TopicBuilder.topic(name).build(), micrometerHermesMetrics, kafkaTopics)
     }
 
     static CachedTopic cachedTopic(Topic topic) {
         def kafkaTopics = new KafkaTopics(new KafkaTopic(KafkaTopicName.valueOf(topic.qualifiedName), ContentType.JSON))
-        return new CachedTopic(topic, hermesMetrics, micrometerHermesMetrics, kafkaTopics)
+        return new CachedTopic(topic, micrometerHermesMetrics, kafkaTopics)
     }
 }

--- a/hermes-frontend/src/test/java/pl/allegro/tech/hermes/frontend/producer/kafka/KafkaBrokerMessageProducerTest.java
+++ b/hermes-frontend/src/test/java/pl/allegro/tech/hermes/frontend/producer/kafka/KafkaBrokerMessageProducerTest.java
@@ -69,10 +69,10 @@ public class KafkaBrokerMessageProducerTest {
 
     @Before
     public void before() {
-        cachedTopic = new CachedTopic(TOPIC, hermesMetrics, metricsFacade, kafkaNamesMapper.toKafkaTopics(TOPIC));
+        cachedTopic = new CachedTopic(TOPIC, metricsFacade, kafkaNamesMapper.toKafkaTopics(TOPIC));
         MessageToKafkaProducerRecordConverter messageConverter =
             new MessageToKafkaProducerRecordConverter(kafkaHeaderFactory, schemaProperties.isIdHeaderEnabled());
-        producer = new KafkaBrokerMessageProducer(producers, kafkaTopicMetadataFetcher, hermesMetrics, messageConverter);
+        producer = new KafkaBrokerMessageProducer(producers, kafkaTopicMetadataFetcher, metricsFacade, messageConverter);
     }
 
     @After
@@ -131,7 +131,7 @@ public class KafkaBrokerMessageProducerTest {
     public void shouldUseEveryoneConfirmProducerForTopicWithAckAll() {
         //given
         Topic topic = topic("group.all").withAck(Topic.Ack.ALL).build();
-        CachedTopic cachedTopic = new CachedTopic(topic, hermesMetrics, metricsFacade,
+        CachedTopic cachedTopic = new CachedTopic(topic, metricsFacade,
                 kafkaNamesMapper.toKafkaTopics(topic));
 
         //when

--- a/hermes-metrics/src/main/java/pl/allegro/tech/hermes/metrics/HermesCounter.java
+++ b/hermes-metrics/src/main/java/pl/allegro/tech/hermes/metrics/HermesCounter.java
@@ -1,28 +1,6 @@
 package pl.allegro.tech.hermes.metrics;
 
 
-public class HermesCounter implements HermesRateMeter {
-    protected final io.micrometer.core.instrument.Counter micrometerCounter;
-    protected final com.codahale.metrics.Meter graphiteMeter;
-
-    protected HermesCounter(io.micrometer.core.instrument.Counter micrometerCounter,
-                          com.codahale.metrics.Meter graphiteMeter) {
-        this.micrometerCounter = micrometerCounter;
-        this.graphiteMeter = graphiteMeter;
-    }
-
-    public static HermesCounter from(io.micrometer.core.instrument.Counter micrometerCounter,
-                                     com.codahale.metrics.Meter graphiteMeter) {
-        return new HermesCounter(micrometerCounter, graphiteMeter);
-    }
-
-    public void increment(long size) {
-        this.micrometerCounter.increment((double) size);
-        this.graphiteMeter.mark(size);
-    }
-
-    @Override
-    public double getOneMinuteRate() {
-        return this.graphiteMeter.getOneMinuteRate();
-    }
+public interface HermesCounter {
+    void increment(long size);
 }

--- a/hermes-metrics/src/main/java/pl/allegro/tech/hermes/metrics/HermesCounterWithRate.java
+++ b/hermes-metrics/src/main/java/pl/allegro/tech/hermes/metrics/HermesCounterWithRate.java
@@ -1,0 +1,4 @@
+package pl.allegro.tech.hermes.metrics;
+
+public interface HermesCounterWithRate extends HermesCounter, HermesRateMeter {
+}

--- a/hermes-metrics/src/main/java/pl/allegro/tech/hermes/metrics/HermesHistogram.java
+++ b/hermes-metrics/src/main/java/pl/allegro/tech/hermes/metrics/HermesHistogram.java
@@ -1,13 +1,11 @@
 package pl.allegro.tech.hermes.metrics;
 
-
-import io.micrometer.core.instrument.distribution.Histogram;
-
 public class HermesHistogram {
     private final io.micrometer.core.instrument.DistributionSummary micrometerHistogram;
     private final com.codahale.metrics.Histogram graphiteHistogram;
 
-    private HermesHistogram(io.micrometer.core.instrument.DistributionSummary micrometerHistogram, com.codahale.metrics.Histogram graphiteHistogram) {
+    private HermesHistogram(io.micrometer.core.instrument.DistributionSummary micrometerHistogram,
+                            com.codahale.metrics.Histogram graphiteHistogram) {
         this.micrometerHistogram = micrometerHistogram;
         this.graphiteHistogram = graphiteHistogram;
     }

--- a/hermes-metrics/src/main/java/pl/allegro/tech/hermes/metrics/HermesHistogram.java
+++ b/hermes-metrics/src/main/java/pl/allegro/tech/hermes/metrics/HermesHistogram.java
@@ -1,0 +1,24 @@
+package pl.allegro.tech.hermes.metrics;
+
+
+import io.micrometer.core.instrument.distribution.Histogram;
+
+public class HermesHistogram {
+    private final io.micrometer.core.instrument.DistributionSummary micrometerHistogram;
+    private final com.codahale.metrics.Histogram graphiteHistogram;
+
+    private HermesHistogram(io.micrometer.core.instrument.DistributionSummary micrometerHistogram, com.codahale.metrics.Histogram graphiteHistogram) {
+        this.micrometerHistogram = micrometerHistogram;
+        this.graphiteHistogram = graphiteHistogram;
+    }
+
+    public static HermesHistogram of(io.micrometer.core.instrument.DistributionSummary micrometerHistogram,
+                                   com.codahale.metrics.Histogram graphiteHistogram) {
+        return new HermesHistogram(micrometerHistogram, graphiteHistogram);
+    }
+
+    public void record(int value) {
+        micrometerHistogram.record(value);
+        graphiteHistogram.update(value);
+    }
+}

--- a/hermes-metrics/src/main/java/pl/allegro/tech/hermes/metrics/counters/DefaultHermesCounter.java
+++ b/hermes-metrics/src/main/java/pl/allegro/tech/hermes/metrics/counters/DefaultHermesCounter.java
@@ -1,0 +1,25 @@
+package pl.allegro.tech.hermes.metrics.counters;
+
+
+import pl.allegro.tech.hermes.metrics.HermesCounter;
+
+public class DefaultHermesCounter implements HermesCounter {
+    protected final io.micrometer.core.instrument.Counter micrometerCounter;
+    protected final com.codahale.metrics.Counter graphiteCounter;
+
+    protected DefaultHermesCounter(io.micrometer.core.instrument.Counter micrometerCounter,
+                                   com.codahale.metrics.Counter graphiteCounter) {
+        this.micrometerCounter = micrometerCounter;
+        this.graphiteCounter = graphiteCounter;
+    }
+
+    public static DefaultHermesCounter from(io.micrometer.core.instrument.Counter micrometerCounter,
+                                            com.codahale.metrics.Counter graphiteCounter) {
+        return new DefaultHermesCounter(micrometerCounter, graphiteCounter);
+    }
+
+    public void increment(long size) {
+        this.micrometerCounter.increment((double) size);
+        this.graphiteCounter.inc(size);
+    }
+}

--- a/hermes-metrics/src/main/java/pl/allegro/tech/hermes/metrics/counters/DefaultHermesCounterWithRate.java
+++ b/hermes-metrics/src/main/java/pl/allegro/tech/hermes/metrics/counters/DefaultHermesCounterWithRate.java
@@ -1,0 +1,30 @@
+package pl.allegro.tech.hermes.metrics.counters;
+
+
+import pl.allegro.tech.hermes.metrics.HermesCounterWithRate;
+
+public class DefaultHermesCounterWithRate implements HermesCounterWithRate {
+    protected final io.micrometer.core.instrument.Counter micrometerCounter;
+    protected final com.codahale.metrics.Meter graphiteMeter;
+
+    protected DefaultHermesCounterWithRate(io.micrometer.core.instrument.Counter micrometerCounter,
+                                    com.codahale.metrics.Meter graphiteMeter) {
+        this.micrometerCounter = micrometerCounter;
+        this.graphiteMeter = graphiteMeter;
+    }
+
+    public static DefaultHermesCounterWithRate from(io.micrometer.core.instrument.Counter micrometerCounter,
+                                             com.codahale.metrics.Meter graphiteMeter) {
+        return new DefaultHermesCounterWithRate(micrometerCounter, graphiteMeter);
+    }
+
+    public void increment(long size) {
+        this.micrometerCounter.increment((double) size);
+        this.graphiteMeter.mark(size);
+    }
+
+    @Override
+    public double getOneMinuteRate() {
+        return graphiteMeter.getOneMinuteRate();
+    }
+}

--- a/hermes-metrics/src/main/java/pl/allegro/tech/hermes/metrics/counters/HermesCounters.java
+++ b/hermes-metrics/src/main/java/pl/allegro/tech/hermes/metrics/counters/HermesCounters.java
@@ -1,0 +1,16 @@
+package pl.allegro.tech.hermes.metrics.counters;
+
+import pl.allegro.tech.hermes.metrics.HermesCounter;
+import pl.allegro.tech.hermes.metrics.HermesCounterWithRate;
+
+public class HermesCounters {
+    public static HermesCounter from(io.micrometer.core.instrument.Counter micrometerCounter,
+                                     com.codahale.metrics.Counter graphiteCounter) {
+        return new DefaultHermesCounter(micrometerCounter, graphiteCounter);
+    }
+
+    public static HermesCounterWithRate from(io.micrometer.core.instrument.Counter micrometerCounter,
+                                             com.codahale.metrics.Meter graphiteMeter) {
+        return new DefaultHermesCounterWithRate(micrometerCounter, graphiteMeter);
+    }
+}


### PR DESCRIPTION
This PR adds support for prometheus metrics in 
- `hermes-frontend`

### Prometheus support status
- [x] hermes-api (no metrics)
- [x] hermes-benchmark (no metrics)
- [x] hermes-client (already supported)
- [ ] hermes-common 
- [ ] hermes-consumers
- [x] hermes-frontend (this PR)
- [ ] hermes-management
- [ ] hermers-metrics
- [x] hermes-mock (no metrics)
- [x] hermes-schema (no metrics)
- [x] hermes-test-helper (no metrics)
- [ ]  hermes-tracker 
- [ ] hermes-tracker-elasticsearch 


The downside of defining all metrics in one module is visible in this PR. If we want to register a gauge in `hermes-frontend` it has to be defined in `hermes-commons`. If it is defined there then `hermes-commons` needs to have a knowledge about what is being metered (which state object). 

In case of this PR `hermes-commons` now contains `ProducerMetrics` which needs to be `kafka-producer` aware - because it is responsible for creating metrics for it. 

The other example is `PersistentBufferMetrics` which is responsible for measuring `ChronicleMap` size. It must have a knowledge of `ChronicleMap` (which is not it's dependency) or any of the interfaces which it implements (`ConcurrentMap`, `Map`):

```java
 public void registerBackupStorageSizeGauge(Map<?, ?> map) {
        this.hermesMetrics.registerMessageRepositorySizeGauge(map::size);
        this.meterRegistry.gaugeMapSize("backup-storage.size", Tags.empty(), map);
    }
```

But this raises a question: should every map be accepted? 


Perhaps the gauge should be defined flexibly as

```java
public <T> void registerGauge(T obj, ToDoubleFunction<T> f) {
        this.hermesMetrics.registerMessageRepositorySizeGauge(() -> f.applyAsDouble(obj));
        Gauge.builder("backup-storage.size", obj, f)
                .register(meterRegistry);
    }
```

then `hermes-commons` does not need to have the knowledge about state objects and it is responsbility of the caller to supply correct arguments
