### PR TITLE
Bring back optional dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,7 +59,6 @@ allprojects {
             wiremock          : '3.0.1',
             spock             : '2.4-M1-groovy-4.0',
             groovy            : '4.0.12',
-            alpn_api          : '1.1.2.v20150522',
             avro              : '1.9.1',
             json2avro         : '0.2.14',
             okhttp            : '3.9.1',

--- a/hermes-client/build.gradle
+++ b/hermes-client/build.gradle
@@ -9,9 +9,7 @@ dependencies {
     compileOnly group: 'org.glassfish.jersey.inject', name: 'jersey-hk2', version: versions.jersey
     compileOnly group: 'org.springframework', name: 'spring-web', version: versions.spring_web
     compileOnly group: 'org.springframework', name: 'spring-webflux', version: versions.spring_web
-
     compileOnly group: 'com.squareup.okhttp3', name: 'okhttp', version: versions.okhttp
-    compileOnly group: 'org.eclipse.jetty.alpn', name: 'alpn-api', version: versions.alpn_api
 
     implementation group: 'net.jodah', name: 'failsafe', version: versions.failsafe
     api group: 'io.projectreactor', name: 'reactor-core', version: '3.4.25'
@@ -29,7 +27,6 @@ dependencies {
     testImplementation group: 'org.springframework', name: 'spring-web', version: versions.spring_web
     testImplementation group: 'org.springframework', name: 'spring-webflux', version: versions.spring_web
     testImplementation group: 'com.squareup.okhttp3', name: 'okhttp', version: versions.okhttp
-    testImplementation group: 'org.eclipse.jetty.alpn', name: 'alpn-api', version: versions.alpn_api
     testImplementation group: 'io.projectreactor.netty', name: 'reactor-netty', version: '1.0.25'
     testImplementation group: 'io.projectreactor', name: 'reactor-test', version: '3.4.25'
 

--- a/hermes-client/build.gradle
+++ b/hermes-client/build.gradle
@@ -3,14 +3,14 @@ plugins {
 }
 
 dependencies {
-    api group: 'io.dropwizard.metrics', name: 'metrics-core', version: versions.dropwizard_metrics
-    api group: 'io.micrometer', name: 'micrometer-core', version: versions.micrometer_metrics
-    api group: 'org.glassfish.jersey.core', name: 'jersey-client', version: versions.jersey
+    compileOnly group: 'io.dropwizard.metrics', name: 'metrics-core', version: versions.dropwizard_metrics
+    compileOnly group: 'io.micrometer', name: 'micrometer-core', version: versions.micrometer_metrics
+    compileOnly group: 'org.glassfish.jersey.core', name: 'jersey-client', version: versions.jersey
     compileOnly group: 'org.glassfish.jersey.inject', name: 'jersey-hk2', version: versions.jersey
-    api group: 'org.springframework', name: 'spring-web', version: versions.spring_web
-    api group: 'org.springframework', name: 'spring-webflux', version: versions.spring_web
+    compileOnly group: 'org.springframework', name: 'spring-web', version: versions.spring_web
+    compileOnly group: 'org.springframework', name: 'spring-webflux', version: versions.spring_web
 
-    api group: 'com.squareup.okhttp3', name: 'okhttp', version: versions.okhttp
+    compileOnly group: 'com.squareup.okhttp3', name: 'okhttp', version: versions.okhttp
     compileOnly group: 'org.eclipse.jetty.alpn', name: 'alpn-api', version: versions.alpn_api
 
     implementation group: 'net.jodah', name: 'failsafe', version: versions.failsafe

--- a/hermes-frontend/build.gradle
+++ b/hermes-frontend/build.gradle
@@ -20,10 +20,6 @@ dependencies {
     implementation group: 'commons-io', name: 'commons-io', version: '2.4'
     implementation group: 'net.jodah', name: 'failsafe', version: versions.failsafe
 
-    compileOnly group: 'org.eclipse.jetty.alpn', name: 'alpn-api', version: versions.alpn_api
-
-    testImplementation group: 'org.eclipse.jetty.alpn', name: 'alpn-api', version: versions.alpn_api
-
     testImplementation group: 'org.spockframework', name: 'spock-core', version: versions.spock
     testImplementation group: 'org.apache.groovy', name: 'groovy-json', version: versions.groovy
 

--- a/integration/build.gradle
+++ b/integration/build.gradle
@@ -10,7 +10,6 @@ project.configurations {
         transitive = true
         visible = true
     }
-    alpnboot
 }
 
 dependencies {
@@ -41,8 +40,6 @@ dependencies {
     integration(group: 'org.hornetq', name: 'hornetq-jms-server', version: '2.4.1.Final') {
         exclude module: 'hornetq-native'
     }
-
-    integration group: 'org.eclipse.jetty.alpn', name: 'alpn-api', version: versions.alpn_api
 }
 
 project.sourceSets {


### PR DESCRIPTION
Make dependencies back optional. They were made required when Spring Boot 2.7 support was added. Most of those dependencies are related to specific sender implementation and the user is supposed to choose one and provide the needed client library.