### PR TITLE
Fix handling of interrupts

### DIFF
--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/BatchConsumer.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/BatchConsumer.java
@@ -219,7 +219,7 @@ public class BatchConsumer implements Consumer {
                 .retryIfRuntimeException()
                 .retryIfResult(result -> consuming && !result.succeeded() && shouldRetryOnClientError(retryClientErrors, result))
                 .withWaitStrategy(fixedWait(messageBackoff, MILLISECONDS))
-                .withStopStrategy(attempt -> attempt.getDelaySinceFirstAttempt() > messageTtlMillis)
+                .withStopStrategy(attempt -> attempt.getDelaySinceFirstAttempt() > messageTtlMillis || Thread.currentThread().isInterrupted())
                 .withRetryListener(getRetryListener(result -> {
                     batch.incrementRetryCounter();
                     markSendingResult(batch, result);

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/BatchConsumer.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/BatchConsumer.java
@@ -219,7 +219,8 @@ public class BatchConsumer implements Consumer {
                 .retryIfRuntimeException()
                 .retryIfResult(result -> consuming && !result.succeeded() && shouldRetryOnClientError(retryClientErrors, result))
                 .withWaitStrategy(fixedWait(messageBackoff, MILLISECONDS))
-                .withStopStrategy(attempt -> attempt.getDelaySinceFirstAttempt() > messageTtlMillis || Thread.currentThread().isInterrupted())
+                .withStopStrategy(attempt -> attempt.getDelaySinceFirstAttempt() > messageTtlMillis
+                        || Thread.currentThread().isInterrupted())
                 .withRetryListener(getRetryListener(result -> {
                     batch.incrementRetryCounter();
                     markSendingResult(batch, result);

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/Consumer.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/Consumer.java
@@ -9,6 +9,11 @@ import java.util.Set;
 
 public interface Consumer {
 
+    /**
+     * Consume **must** make sure that interrupted status is restored as it is needed for stopping unhealthy consumers.
+     * Swallowing the interrupt by consume or any of its dependencies will result in consumer being marked
+     * as unhealthy and will prevent commits despite messages being sent to subscribers.
+     */
     void consume(Runnable signalsInterrupt);
 
     void initialize();

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/SerialConsumer.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/SerialConsumer.java
@@ -118,6 +118,9 @@ public class SerialConsumer implements Consumer {
             } else {
                 inflightSemaphore.release();
             }
+        } catch (InterruptedException e) {
+            logger.info("Restoring interrupted status {}", subscription.getQualifiedName(), e);
+            Thread.currentThread().interrupt();
         } catch (Exception e) {
             logger.error("Consumer loop failed for {}", subscription.getQualifiedName(), e);
         }

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/sender/http/JettyMessageBatchSender.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/sender/http/JettyMessageBatchSender.java
@@ -4,6 +4,8 @@ import org.apache.http.entity.ContentType;
 import org.apache.http.protocol.HTTP;
 import org.eclipse.jetty.client.api.ContentResponse;
 import org.eclipse.jetty.client.api.Request;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import pl.allegro.tech.hermes.api.EndpointAddress;
 import pl.allegro.tech.hermes.api.EndpointAddressResolverMetadata;
 import pl.allegro.tech.hermes.consumers.consumer.batch.MessageBatch;
@@ -28,6 +30,8 @@ import static pl.allegro.tech.hermes.common.http.MessageMetadataHeaders.SUBSCRIP
 import static pl.allegro.tech.hermes.common.http.MessageMetadataHeaders.TOPIC_NAME;
 
 public class JettyMessageBatchSender implements MessageBatchSender {
+
+    private static final Logger logger = LoggerFactory.getLogger(JettyMessageBatchSender.class);
 
     private final BatchHttpRequestFactory requestFactory;
     private final EndpointAddressResolver resolver;
@@ -64,6 +68,10 @@ public class JettyMessageBatchSender implements MessageBatchSender {
             ContentResponse response = request.send();
             return resultHandlers.handleSendingResultForBatch(response);
         } catch (TimeoutException | ExecutionException | InterruptedException e) {
+            if (e instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+                logger.info("Restoring interrupted status", e);
+            }
             throw new HttpBatchSenderException("Failed to send message batch", e);
         }
     }


### PR DESCRIPTION
When consumer process is deemed unhealthy it is interrupted. There were places in code when `InterruptedException` was catched but interrupted status was not restored. Because of that `ConsumerProcess#run` was unable to detect that the thread was interrupted:

```java
while (running && !Thread.currentThread().isInterrupted()) {
```

consumer process was still sending messages to subscribers but was marked as unhealthy and its messages were not commited. This situation would last until consumer was restarted. 

In this PR `interrupted` statuses are restored, enabling unhealthy consumer process to exit.