### PR TITLE
support for editing boolean endpoint address resolver metadata properties

### DIFF
--- a/hermes-console-vue/json-server/db.json
+++ b/hermes-console-vue/json-server/db.json
@@ -400,7 +400,7 @@
         }
       ],
       "endpointAddressResolverMetadata": {
-        "additionalMetadata": false,
+        "additionalMetadata": true,
         "nonSupportedProperty": 2
       },
       "http2Enabled": false,

--- a/hermes-console-vue/json-server/subscriptions.json
+++ b/hermes-console-vue/json-server/subscriptions.json
@@ -56,7 +56,7 @@
       }
     ],
     "endpointAddressResolverMetadata": {
-      "additionalMetadata": false,
+      "additionalMetadata": true,
       "nonSupportedProperty": 2
     },
     "http2Enabled": false,

--- a/hermes-console-vue/src/composables/subscription/use-create-subscription/useCreateSubscription.ts
+++ b/hermes-console-vue/src/composables/subscription/use-create-subscription/useCreateSubscription.ts
@@ -148,5 +148,6 @@ function initializeForm(
     deleteSubscriptionAutomatically: false,
     pathFilters: [],
     headerFilters: [],
+    endpointAddressResolverMetadata: form.value.endpointAddressResolverMetadata,
   };
 }

--- a/hermes-console-vue/src/composables/subscription/use-form-subscription/form-mapper.ts
+++ b/hermes-console-vue/src/composables/subscription/use-form-subscription/form-mapper.ts
@@ -41,7 +41,7 @@ export function parseFormToRequestBody(
     },
     subscriptionPolicy: mapSubscriptionPolicy(form),
     trackingMode: form.messageDeliveryTrackingMode,
-    endpointAddressResolverMetadata: {},
+    endpointAddressResolverMetadata: form.endpointAddressResolverMetadata,
     subscriptionIdentityHeadersEnabled: form.attachSubscriptionIdentityHeaders,
     autoDeleteWithTopicEnabled: form.deleteSubscriptionAutomatically,
   };

--- a/hermes-console-vue/src/composables/subscription/use-form-subscription/types.ts
+++ b/hermes-console-vue/src/composables/subscription/use-form-subscription/types.ts
@@ -1,4 +1,5 @@
 import type { ComputedRef } from 'vue';
+import type { EndpointAddressResolverMetadata } from '@/api/subscription';
 import type { FieldValidator } from '@/utils/validators';
 import type { HeaderFilter } from '@/views/subscription/subscription-form/subscription-header-filters/types';
 import type { OwnerSource } from '@/api/owner';
@@ -31,6 +32,7 @@ export interface SubscriptionForm {
   deleteSubscriptionAutomatically: boolean;
   pathFilters: PathFilter[];
   headerFilters: HeaderFilter[];
+  endpointAddressResolverMetadata: EndpointAddressResolverMetadata;
 }
 
 export interface FormSubscriptionPolicy {

--- a/hermes-console-vue/src/composables/subscription/use-form-subscription/useFormSubscription.ts
+++ b/hermes-console-vue/src/composables/subscription/use-form-subscription/useFormSubscription.ts
@@ -12,6 +12,7 @@ import type {
   SubscriptionForm,
   UseFormSubscription,
 } from '@/composables/subscription/use-form-subscription/types';
+import type { EndpointAddressResolverMetadata } from '@/api/subscription';
 import type { HeaderFilter } from '@/views/subscription/subscription-form/subscription-header-filters/types';
 import type {
   MessageFilterSpecification,
@@ -133,6 +134,35 @@ function getRawDataSources(): RawDataSources {
   };
 }
 
+function getEndpointAddressResolverDefaultValues(): Record<string, any> {
+  const configStore = useAppConfigStore();
+  const defaults: Record<string, any> = {};
+  for (const [propertyName, value] of Object.entries(
+    configStore.appConfig!.subscription.endpointAddressResolverMetadata,
+  )) {
+    if (value.type == 'boolean') {
+      defaults[propertyName] = false;
+    }
+  }
+  return defaults;
+}
+
+function getEndpointAddressResolverValues(
+  metadata: EndpointAddressResolverMetadata,
+): Record<string, any> {
+  const mergedMetadata: Record<string, any> = {};
+  for (const [propertyName, defaultValue] of Object.entries(
+    getEndpointAddressResolverDefaultValues(),
+  )) {
+    if (metadata[propertyName] !== undefined) {
+      mergedMetadata[propertyName] = metadata[propertyName];
+    } else {
+      mergedMetadata[propertyName] = defaultValue;
+    }
+  }
+  return mergedMetadata;
+}
+
 function createEmptyForm(): Ref<SubscriptionForm> {
   return ref({
     name: '',
@@ -166,6 +196,7 @@ function createEmptyForm(): Ref<SubscriptionForm> {
     deleteSubscriptionAutomatically: false,
     pathFilters: [],
     headerFilters: [],
+    endpointAddressResolverMetadata: getEndpointAddressResolverDefaultValues(),
   });
 }
 
@@ -224,6 +255,9 @@ export function initializeFullyFilledForm(
     deleteSubscriptionAutomatically: subscription.autoDeleteWithTopicEnabled,
     pathFilters: mapToPathFilter(subscription.filters),
     headerFilters: mapToHeaderFilter(subscription.filters),
+    endpointAddressResolverMetadata: getEndpointAddressResolverValues(
+      subscription.endpointAddressResolverMetadata,
+    ),
   };
 }
 

--- a/hermes-console-vue/src/dummy/subscription-form.ts
+++ b/hermes-console-vue/src/dummy/subscription-form.ts
@@ -37,6 +37,9 @@ export const dummySubscriptionForm = {
   deleteSubscriptionAutomatically: false,
   pathFilters: [],
   headerFilters: [],
+  endpointAddressResolverMetadata: {
+    supportedMetadata: false,
+  },
 };
 
 export const dummySubscriptionFormValidator = {
@@ -159,6 +162,9 @@ export const dummyInitializedSubscriptionForm = {
   deleteSubscriptionAutomatically: false,
   pathFilters: [],
   headerFilters: [],
+  endpointAddressResolverMetadata: {
+    supportedMetadata: false,
+  },
 };
 
 export const dummyInitializedEditSubscriptionForm = {
@@ -192,4 +198,7 @@ export const dummyInitializedEditSubscriptionForm = {
   deleteSubscriptionAutomatically: dummySubscription.autoDeleteWithTopicEnabled,
   pathFilters: [],
   headerFilters: [],
+  endpointAddressResolverMetadata: {
+    supportedMetadata: true,
+  },
 };

--- a/hermes-console-vue/src/dummy/subscription.ts
+++ b/hermes-console-vue/src/dummy/subscription.ts
@@ -62,7 +62,7 @@ export const dummySubscription: Subscription = {
     { name: 'X-Another-Header', value: 'foobar' },
   ],
   endpointAddressResolverMetadata: {
-    supportedMetadata: false,
+    supportedMetadata: true,
     unsupportedMetadata: 2,
   },
   http2Enabled: false,

--- a/hermes-console-vue/src/views/subscription/properties-card/PropertiesCard.spec.ts
+++ b/hermes-console-vue/src/views/subscription/properties-card/PropertiesCard.spec.ts
@@ -591,7 +591,7 @@ describe('PropertiesCard', () => {
     // then
     const row = getByText('Supported metadata').closest('tr')!;
     expect(row).toBeVisible();
-    expect(within(row).getByText('false')).toBeVisible();
+    expect(within(row).getByText('true')).toBeVisible();
   });
 
   it('should render additional unsupported properties', () => {

--- a/hermes-console-vue/src/views/subscription/properties-card/PropertiesCard.vue
+++ b/hermes-console-vue/src/views/subscription/properties-card/PropertiesCard.vue
@@ -190,6 +190,7 @@
       :key="property.key"
       :name="property.title"
       :value="property.value"
+      :tooltip="property.hint"
     />
 
     <key-value-card-item

--- a/hermes-console-vue/src/views/subscription/subscription-form/SubscriptionForm.vue
+++ b/hermes-console-vue/src/views/subscription/subscription-form/SubscriptionForm.vue
@@ -12,6 +12,7 @@
   import SubscriptionPathFilters from '@/views/subscription/subscription-form/subscription-basic-filters/SubscriptionPathFilters.vue';
   import SubscriptionPathFiltersDebug from '@/views/subscription/subscription-form/subscription-basic-filters/SubscriptionPathFiltersDebug.vue';
   import TextField from '@/components/text-field/TextField.vue';
+  import TooltipIcon from '@/components/tooltip-icon/TooltipIcon.vue';
   import type { Subscription } from '@/api/subscription';
 
   const props = defineProps<{
@@ -371,6 +372,23 @@
       density="comfortable"
       hide-details
     />
+
+    <div
+      v-for="([propertyName, propertyValue]) in Object.entries(configStore.appConfig!.subscription.endpointAddressResolverMetadata)"
+      :key="propertyName"
+      class="d-flex flex-row"
+    >
+      <v-switch
+        v-model="form.endpointAddressResolverMetadata[propertyName]"
+        inset
+        :label="propertyValue.title"
+        v-if="propertyValue.type == 'boolean'"
+        color="success"
+        density="comfortable"
+        hide-details
+      />
+      <tooltip-icon :content="propertyValue.hint" />
+    </div>
 
     <div class="d-flex justify-end column-gap-2 mt-4">
       <v-btn

--- a/hermes-console-vue/src/views/subscription/subscription-form/SubscriptionForm.vue
+++ b/hermes-console-vue/src/views/subscription/subscription-form/SubscriptionForm.vue
@@ -387,7 +387,7 @@
         density="comfortable"
         hide-details
       />
-      <tooltip-icon :content="propertyValue.hint" />
+      <tooltip-icon :content="propertyValue.hint" class="align-self-center" />
     </div>
 
     <div class="d-flex justify-end column-gap-2 mt-4">


### PR DESCRIPTION
This PR re-introduces editing `endpointAddressResolverMetadata`. In old hermes-console there was support for `boolean`, `text`, `number` and `select` properties. For now only `boolean` support is re-introduced. Please submit issues if you need support for other property types.

In old hermes console `boolean` values had 3 possible values: `null`, `true`, `false`. When editing subscription for the first time after introducing new property it would appear on form but it would remain `null` until its value was explicitly changed. In this PR default value of `false` is introduced for `boolean` properties meaning that a first update to subscription after creating a new metadata property in config will result in implicitly setting this value to `false`.

