### PR TITLE
Add basic HermesMock listener for kotest

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,9 @@
+[versions]
+kotest = "5.5.4"
+kotlin-logging = "6.0.3"
+
+[libraries]
+kotest-assertions = { module = "io.kotest:kotest-assertions-core", version.ref = "kotest" }
+kotest-api = { module = "io.kotest:kotest-framework-api", version.ref = "kotest" }
+kotest-runner = { module = "io.kotest:kotest-runner-junit5", version.ref = "kotest" }
+kotlin-logging = { module = "io.github.oshai:kotlin-logging-jvm", version.ref = "kotlin-logging" }

--- a/hermes-mock-kotest-extension/build.gradle.kts
+++ b/hermes-mock-kotest-extension/build.gradle.kts
@@ -1,0 +1,19 @@
+plugins {
+    kotlin("jvm") version "1.9.22"
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    api(project(":hermes-mock"))
+    implementation(libs.kotest.api)
+    implementation(libs.kotlin.logging)
+    testImplementation(libs.kotest.runner)
+    testImplementation(libs.kotest.assertions)
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/hermes-mock-kotest-extension/src/main/kotlin/pl/allegro/tech/hermes/mock/kotest/HermesMockListener.kt
+++ b/hermes-mock-kotest-extension/src/main/kotlin/pl/allegro/tech/hermes/mock/kotest/HermesMockListener.kt
@@ -1,0 +1,70 @@
+package pl.allegro.tech.hermes.mock.kotest
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+import io.kotest.core.listeners.ProjectListener
+import io.kotest.core.listeners.TestListener
+import io.kotest.core.spec.Spec
+import io.kotest.core.test.TestCase
+import io.kotest.core.test.TestResult
+import pl.allegro.tech.hermes.mock.HermesMock
+
+private val logger = KotlinLogging.logger { }
+
+class HermesMockListener(
+    private val hermesMock: HermesMock,
+    private val listenerMode: ListenerMode
+) : TestListener, ProjectListener {
+    override suspend fun beforeTest(testCase: TestCase) {
+        if (listenerMode == ListenerMode.PER_TEST) {
+            logger.debug { "Started Mock Hermes $listenerMode" }
+            hermesMock.start()
+        }
+    }
+
+    override suspend fun afterTest(testCase: TestCase, result: TestResult) {
+        if (listenerMode == ListenerMode.PER_TEST) {
+            logger.debug { "Stopped Mock Hermes $listenerMode" }
+            hermesMock.stop()
+        }
+    }
+
+    override suspend fun beforeSpec(spec: Spec) {
+        if (listenerMode == ListenerMode.PER_SPEC) {
+            logger.debug { "Started Mock Hermes $listenerMode" }
+            hermesMock.start()
+        }
+    }
+
+    override suspend fun afterSpec(spec: Spec) {
+        if (listenerMode == ListenerMode.PER_SPEC) {
+            logger.debug { "Stopped Mock Hermes $listenerMode" }
+            hermesMock.stop()
+        }
+    }
+
+    override suspend fun beforeProject() {
+        if (listenerMode == ListenerMode.PER_PROJECT) {
+            logger.debug { "Started Mock Hermes $listenerMode" }
+            hermesMock.start()
+        }
+    }
+
+    override suspend fun afterProject() {
+        if (listenerMode == ListenerMode.PER_PROJECT) {
+            logger.debug { "Stopped Mock Hermes $listenerMode" }
+            hermesMock.stop()
+        }
+    }
+
+    companion object {
+        fun perSpec(hermesMock: HermesMock) = HermesMockListener(hermesMock, ListenerMode.PER_SPEC)
+        fun perTest(hermesMock: HermesMock) = HermesMockListener(hermesMock, ListenerMode.PER_TEST)
+        fun perProject(hermesMock: HermesMock) = HermesMockListener(hermesMock, ListenerMode.PER_PROJECT)
+    }
+}
+
+enum class ListenerMode {
+    PER_TEST,
+    PER_SPEC,
+    PER_PROJECT
+}

--- a/hermes-mock-kotest-extension/src/test/kotlin/pl/allegro/tech/hermes/mock/kotest/HermesMockListenerPerProjectTest.kt
+++ b/hermes-mock-kotest-extension/src/test/kotlin/pl/allegro/tech/hermes/mock/kotest/HermesMockListenerPerProjectTest.kt
@@ -1,0 +1,15 @@
+package pl.allegro.tech.hermes.mock.kotest
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import java.net.HttpURLConnection
+import java.net.URL
+
+class HermesMockListenerPerProjectTest : FunSpec({
+
+    test("should have started HermesMock") {
+        val connection = URL("http://localhost:${ProjectConfig.HERMES_MOCK_PORT}").openConnection() as HttpURLConnection
+
+        connection.responseCode shouldBe 404
+    }
+})

--- a/hermes-mock-kotest-extension/src/test/kotlin/pl/allegro/tech/hermes/mock/kotest/ProjectConfig.kt
+++ b/hermes-mock-kotest-extension/src/test/kotlin/pl/allegro/tech/hermes/mock/kotest/ProjectConfig.kt
@@ -1,0 +1,14 @@
+package pl.allegro.tech.hermes.mock.kotest
+
+import io.kotest.core.config.AbstractProjectConfig
+import io.kotest.core.extensions.Extension
+import pl.allegro.tech.hermes.mock.HermesMock
+
+object ProjectConfig : AbstractProjectConfig() {
+    const val HERMES_MOCK_PORT = 9001
+
+    val hermesMock = HermesMock.Builder().withPort(HERMES_MOCK_PORT).build()
+    val hermesMockListener = HermesMockListener(hermesMock, ListenerMode.PER_PROJECT)
+
+    override fun extensions(): List<Extension> = listOf(hermesMockListener)
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,6 @@
+plugins {
+    id 'org.gradle.toolchains.foojay-resolver-convention' version '0.5.0'
+}
 rootProject.name='hermes'
 
 include 'hermes-common',
@@ -13,5 +16,6 @@ include 'hermes-common',
         'hermes-schema',
         'hermes-benchmark',
         'hermes-mock',
-        'integration-tests'
+        'integration-tests',
+        'hermes-mock-kotest-extension'
 


### PR DESCRIPTION
# What
Add basic implementation of a kotest extension based on the Wiremock one.

# Why
To provide a ready to go implementation for kotest users.