### PR TITLE
switch back to regular wiremock but with jetty12 support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,7 +56,7 @@ allprojects {
             curator           : '5.4.0',
             dropwizard_metrics: '4.1.0',
             micrometer_metrics: '1.11.1',
-            wiremock          : '3.3.1',
+            wiremock          : '3.5.2',
             spock             : '2.4-M1-groovy-4.0',
             groovy            : '4.0.12',
             avro              : '1.9.1',

--- a/hermes-mock/build.gradle
+++ b/hermes-mock/build.gradle
@@ -6,7 +6,7 @@ plugins {
 
 dependencies {
     implementation group: 'junit', name: 'junit', version: '4.11'
-    api group: 'org.wiremock', name: 'wiremock-standalone', version: versions.wiremock
+    api group: 'org.wiremock', name: 'wiremock-jetty12', version: versions.wiremock
     implementation group: 'com.jayway.awaitility', name: 'awaitility', version: '1.6.1'
     api group: 'org.apache.avro', name: 'avro', version: versions.avro
     implementation group: 'tech.allegro.schema.json2avro', name: 'converter', version: versions.json2avro

--- a/hermes-mock/src/main/java/pl/allegro/tech/hermes/mock/HermesMockDefine.java
+++ b/hermes-mock/src/main/java/pl/allegro/tech/hermes/mock/HermesMockDefine.java
@@ -4,9 +4,9 @@ import com.github.tomakehurst.wiremock.http.Request;
 import com.github.tomakehurst.wiremock.matching.ValueMatcher;
 import com.github.tomakehurst.wiremock.stubbing.StubMapping;
 import org.apache.avro.Schema;
+import org.apache.hc.core5.http.HttpStatus;
 import pl.allegro.tech.hermes.mock.exchange.Response;
 import pl.allegro.tech.hermes.mock.matching.ContentMatchers;
-import wiremock.org.apache.hc.core5.http.HttpStatus;
 
 import java.util.function.Predicate;
 

--- a/hermes-mock/src/main/java/pl/allegro/tech/hermes/mock/HermesMockQuery.java
+++ b/hermes-mock/src/main/java/pl/allegro/tech/hermes/mock/HermesMockQuery.java
@@ -1,9 +1,9 @@
 package pl.allegro.tech.hermes.mock;
 
 import com.github.tomakehurst.wiremock.matching.RequestPatternBuilder;
+import com.google.common.collect.Lists;
 import org.apache.avro.Schema;
 import pl.allegro.tech.hermes.mock.exchange.Request;
-import wiremock.com.google.common.collect.Lists;
 
 import java.util.List;
 import java.util.Optional;

--- a/hermes-mock/src/main/java/pl/allegro/tech/hermes/mock/exchange/Response.java
+++ b/hermes-mock/src/main/java/pl/allegro/tech/hermes/mock/exchange/Response.java
@@ -1,6 +1,6 @@
 package pl.allegro.tech.hermes.mock.exchange;
 
-import wiremock.org.apache.hc.core5.http.HttpStatus;
+import org.apache.hc.core5.http.HttpStatus;
 
 import java.time.Duration;
 

--- a/hermes-mock/src/main/java/pl/allegro/tech/hermes/mock/matching/StartsWithPattern.java
+++ b/hermes-mock/src/main/java/pl/allegro/tech/hermes/mock/matching/StartsWithPattern.java
@@ -1,8 +1,8 @@
 package pl.allegro.tech.hermes.mock.matching;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.github.tomakehurst.wiremock.matching.MatchResult;
 import com.github.tomakehurst.wiremock.matching.StringValuePattern;
-import wiremock.com.fasterxml.jackson.annotation.JsonProperty;
 
 public class StartsWithPattern extends StringValuePattern {
 

--- a/hermes-mock/src/test/groovy/pl/allegro/tech/hermes/mock/HermesMockAvroTest.groovy
+++ b/hermes-mock/src/test/groovy/pl/allegro/tech/hermes/mock/HermesMockAvroTest.groovy
@@ -6,7 +6,7 @@ import org.apache.avro.reflect.ReflectData
 import org.springframework.util.MultiValueMap
 import org.springframework.util.MultiValueMapAdapter
 import pl.allegro.tech.hermes.test.helper.client.integration.FrontendTestClient
-import wiremock.org.apache.hc.core5.http.HttpStatus
+import org.apache.hc.core5.http.HttpStatus
 import org.junit.ClassRule
 import pl.allegro.tech.hermes.test.helper.avro.AvroUserSchemaLoader
 import pl.allegro.tech.hermes.test.helper.util.Ports

--- a/hermes-mock/src/test/groovy/pl/allegro/tech/hermes/mock/HermesMockJsonTest.groovy
+++ b/hermes-mock/src/test/groovy/pl/allegro/tech/hermes/mock/HermesMockJsonTest.groovy
@@ -3,7 +3,7 @@ package pl.allegro.tech.hermes.mock
 import org.springframework.util.MultiValueMap
 import org.springframework.util.MultiValueMapAdapter
 import pl.allegro.tech.hermes.test.helper.client.integration.FrontendTestClient
-import wiremock.org.apache.hc.core5.http.HttpStatus
+import org.apache.hc.core5.http.HttpStatus
 import org.junit.ClassRule
 import pl.allegro.tech.hermes.test.helper.util.Ports
 import spock.lang.Shared

--- a/hermes-mock/src/test/groovy/pl/allegro/tech/hermes/mock/ResponseTest.groovy
+++ b/hermes-mock/src/test/groovy/pl/allegro/tech/hermes/mock/ResponseTest.groovy
@@ -2,7 +2,7 @@ package pl.allegro.tech.hermes.mock
 
 import pl.allegro.tech.hermes.mock.exchange.Response
 import spock.lang.Specification
-import wiremock.org.apache.hc.core5.http.HttpStatus;
+import org.apache.hc.core5.http.HttpStatus
 
 import static pl.allegro.tech.hermes.mock.exchange.Response.Builder.aResponse
 


### PR DESCRIPTION
When using `hermes-mock` with `wiremock-jetty12` tests in such project will have problem choosing property wiremock version (since wiremock-standalone will be on their classpath).

This should make builds faster and more accessible for people to use :)
