### PR TITLE
Multi datacenter senders improvements

### DIFF
--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/common/metric/ProducerMetrics.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/common/metric/ProducerMetrics.java
@@ -78,6 +78,14 @@ public class ProducerMetrics {
                 + meterRegistry.get(ACK_LEADER_BUFFER_AVAILABLE_BYTES).gauge().value();
     }
 
+    public <T> void registerAckLeaderRecordSendCounter(T stateObj, ToDoubleFunction<T> f, String sender, String datacenter) {
+        registerCounter(ACK_LEADER_RECORD_SEND_TOTAL, tags(sender, datacenter), stateObj, f);
+    }
+
+    public <T> void registerAckAllRecordSendCounter(T stateObj, ToDoubleFunction<T> f, String sender, String datacenter) {
+        registerCounter(ACK_ALL_RECORD_SEND_TOTAL, tags(sender, datacenter), stateObj, f);
+    }
+
     public <T> void registerProducerInflightRequestGauge(T stateObj, ToDoubleFunction<T> f) {
         meterRegistry.gauge(INFLIGHT_REQUESTS, stateObj, f);
         hermesMetrics.registerProducerInflightRequest(() -> (int) f.applyAsDouble(stateObj));
@@ -98,6 +106,10 @@ public class ProducerMetrics {
         meterRegistry.more().timeGauge(prometheusName, tags, stateObj, timeUnit, f);
     }
 
+    private <T> void registerCounter(String name, Tags tags, T stateObj, ToDoubleFunction<T> f) {
+        meterRegistry.more().counter(name, tags, stateObj, f);
+    }
+
     private static final String KAFKA_PRODUCER = "kafka-producer.";
     private static final String ACK_LEADER = "ack-leader.";
     private static final String ACK_ALL = "ack-all.";
@@ -108,6 +120,7 @@ public class ProducerMetrics {
     private static final String ACK_ALL_RECORD_QUEUE_TIME_MAX = KAFKA_PRODUCER + ACK_ALL + "record-queue-time-max";
     private static final String ACK_ALL_COMPRESSION_RATE = KAFKA_PRODUCER + ACK_ALL + "compression-rate-avg";
     private static final String ACK_ALL_FAILED_BATCHES_TOTAL = KAFKA_PRODUCER + ACK_ALL + "failed-batches-total";
+    private static final String ACK_ALL_RECORD_SEND_TOTAL = KAFKA_PRODUCER + ACK_ALL + "record-send";
 
     private static final String ACK_LEADER_FAILED_BATCHES_TOTAL = KAFKA_PRODUCER + ACK_LEADER + "failed-batches-total";
     private static final String ACK_LEADER_BUFFER_TOTAL_BYTES = KAFKA_PRODUCER + ACK_LEADER + "buffer-total-bytes";
@@ -115,4 +128,6 @@ public class ProducerMetrics {
     private static final String ACK_LEADER_RECORD_QUEUE_TIME_MAX = KAFKA_PRODUCER + ACK_LEADER + "record-queue-time-max";
     private static final String ACK_LEADER_BUFFER_AVAILABLE_BYTES = KAFKA_PRODUCER + ACK_LEADER + "buffer-available-bytes";
     private static final String ACK_LEADER_COMPRESSION_RATE = KAFKA_PRODUCER + ACK_LEADER + "compression-rate-avg";
+    private static final String ACK_LEADER_RECORD_SEND_TOTAL = KAFKA_PRODUCER + ACK_LEADER + "record-send";
+
 }

--- a/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/config/FailFastKafkaProducerProperties.java
+++ b/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/config/FailFastKafkaProducerProperties.java
@@ -6,158 +6,17 @@ import pl.allegro.tech.hermes.frontend.producer.kafka.KafkaProducerParameters;
 import java.time.Duration;
 
 @ConfigurationProperties(prefix = "frontend.kafka.fail-fast-producer")
-public class FailFastKafkaProducerProperties implements KafkaProducerParameters {
+public class FailFastKafkaProducerProperties {
+
+    private KafkaProducerParameters local = new FailFastLocalKafkaProducerProperties();
+
+    private KafkaProducerParameters remote = new FailFastRemoteKafkaProducerProperties();
 
     private Duration speculativeSendDelay = Duration.ofMillis(250);
 
     private FallbackSchedulerProperties fallbackScheduler = new FallbackSchedulerProperties();
 
     private ChaosSchedulerProperties chaosScheduler = new ChaosSchedulerProperties();
-
-    private Duration maxBlock = Duration.ofMillis(500);
-
-    private Duration metadataMaxAge = Duration.ofMinutes(5);
-
-    private String compressionCodec = "none";
-
-    private int retries = Integer.MAX_VALUE;
-
-    private Duration retryBackoff = Duration.ofMillis(50);
-
-    private Duration requestTimeout = Duration.ofMillis(500);
-
-    private Duration deliveryTimeout = Duration.ofMillis(500);
-
-    private int batchSize = 16 * 1024;
-
-    private int tcpSendBuffer = 128 * 1024;
-
-    private int maxRequestSize = 1024 * 1024;
-
-    private Duration linger = Duration.ofMillis(0);
-
-    private Duration metricsSampleWindow = Duration.ofSeconds(30);
-
-    private int maxInflightRequestsPerConnection = 5;
-
-    private boolean reportNodeMetricsEnabled = false;
-
-    @Override
-    public Duration getMaxBlock() {
-        return maxBlock;
-    }
-
-    public void setMaxBlock(Duration maxBlock) {
-        this.maxBlock = maxBlock;
-    }
-
-    @Override
-    public Duration getMetadataMaxAge() {
-        return metadataMaxAge;
-    }
-
-    public void setMetadataMaxAge(Duration metadataMaxAge) {
-        this.metadataMaxAge = metadataMaxAge;
-    }
-
-    @Override
-    public String getCompressionCodec() {
-        return compressionCodec;
-    }
-
-    public void setCompressionCodec(String compressionCodec) {
-        this.compressionCodec = compressionCodec;
-    }
-
-    @Override
-    public int getRetries() {
-        return retries;
-    }
-
-    public void setRetries(int retries) {
-        this.retries = retries;
-    }
-
-    @Override
-    public Duration getRetryBackoff() {
-        return retryBackoff;
-    }
-
-    public void setRetryBackoff(Duration retryBackoff) {
-        this.retryBackoff = retryBackoff;
-    }
-
-    @Override
-    public Duration getRequestTimeout() {
-        return requestTimeout;
-    }
-
-    public void setRequestTimeout(Duration requestTimeout) {
-        this.requestTimeout = requestTimeout;
-    }
-
-    @Override
-    public int getBatchSize() {
-        return batchSize;
-    }
-
-    public void setBatchSize(int batchSize) {
-        this.batchSize = batchSize;
-    }
-
-    @Override
-    public int getTcpSendBuffer() {
-        return tcpSendBuffer;
-    }
-
-    public void setTcpSendBuffer(int tcpSendBuffer) {
-        this.tcpSendBuffer = tcpSendBuffer;
-    }
-
-    @Override
-    public int getMaxRequestSize() {
-        return maxRequestSize;
-    }
-
-    public void setMaxRequestSize(int maxRequestSize) {
-        this.maxRequestSize = maxRequestSize;
-    }
-
-    @Override
-    public Duration getLinger() {
-        return linger;
-    }
-
-    public void setLinger(Duration linger) {
-        this.linger = linger;
-    }
-
-    @Override
-    public Duration getMetricsSampleWindow() {
-        return metricsSampleWindow;
-    }
-
-    public void setMetricsSampleWindow(Duration metricsSampleWindow) {
-        this.metricsSampleWindow = metricsSampleWindow;
-    }
-
-    @Override
-    public int getMaxInflightRequestsPerConnection() {
-        return maxInflightRequestsPerConnection;
-    }
-
-    public void setMaxInflightRequestsPerConnection(int maxInflightRequestsPerConnection) {
-        this.maxInflightRequestsPerConnection = maxInflightRequestsPerConnection;
-    }
-
-    @Override
-    public boolean isReportNodeMetricsEnabled() {
-        return reportNodeMetricsEnabled;
-    }
-
-    public void setReportNodeMetricsEnabled(boolean reportNodeMetricsEnabled) {
-        this.reportNodeMetricsEnabled = reportNodeMetricsEnabled;
-    }
 
     public Duration getSpeculativeSendDelay() {
         return speculativeSendDelay;
@@ -167,21 +26,28 @@ public class FailFastKafkaProducerProperties implements KafkaProducerParameters 
         this.speculativeSendDelay = speculativeSendDelay;
     }
 
-    @Override
-    public Duration getDeliveryTimeout() {
-        return deliveryTimeout;
-    }
-
-    public void setDeliveryTimeout(Duration deliveryTimeout) {
-        this.deliveryTimeout = deliveryTimeout;
-    }
-
     public FallbackSchedulerProperties getFallbackScheduler() {
         return fallbackScheduler;
     }
 
     public void setFallbackScheduler(FallbackSchedulerProperties fallbackScheduler) {
         this.fallbackScheduler = fallbackScheduler;
+    }
+
+    public KafkaProducerParameters getLocal() {
+        return local;
+    }
+
+    public void setLocal(KafkaProducerParameters local) {
+        this.local = local;
+    }
+
+    public KafkaProducerParameters getRemote() {
+        return remote;
+    }
+
+    public void setRemote(KafkaProducerParameters remote) {
+        this.remote = remote;
     }
 
     public ChaosSchedulerProperties getChaosScheduler() {

--- a/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/config/FailFastLocalKafkaProducerProperties.java
+++ b/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/config/FailFastLocalKafkaProducerProperties.java
@@ -1,0 +1,161 @@
+package pl.allegro.tech.hermes.frontend.config;
+
+import pl.allegro.tech.hermes.frontend.producer.kafka.KafkaProducerParameters;
+
+import java.time.Duration;
+
+public class FailFastLocalKafkaProducerProperties implements KafkaProducerParameters {
+    private Duration maxBlock = Duration.ofMillis(500);
+
+    private Duration metadataMaxAge = Duration.ofMinutes(5);
+
+    private String compressionCodec = "none";
+
+    private int retries = Integer.MAX_VALUE;
+
+    private Duration retryBackoff = Duration.ofMillis(50);
+
+    private Duration requestTimeout = Duration.ofMillis(500);
+
+    private Duration deliveryTimeout = Duration.ofMillis(500);
+
+    private int batchSize = 16 * 1024;
+
+    private int tcpSendBuffer = 128 * 1024;
+
+    private int maxRequestSize = 1024 * 1024;
+
+    private Duration linger = Duration.ofMillis(0);
+
+    private Duration metricsSampleWindow = Duration.ofSeconds(30);
+
+    private int maxInflightRequestsPerConnection = 5;
+
+    private boolean reportNodeMetricsEnabled = false;
+
+    @Override
+    public Duration getMaxBlock() {
+        return maxBlock;
+    }
+
+    public void setMaxBlock(Duration maxBlock) {
+        this.maxBlock = maxBlock;
+    }
+
+    @Override
+    public Duration getMetadataMaxAge() {
+        return metadataMaxAge;
+    }
+
+    public void setMetadataMaxAge(Duration metadataMaxAge) {
+        this.metadataMaxAge = metadataMaxAge;
+    }
+
+    @Override
+    public String getCompressionCodec() {
+        return compressionCodec;
+    }
+
+    public void setCompressionCodec(String compressionCodec) {
+        this.compressionCodec = compressionCodec;
+    }
+
+    @Override
+    public int getRetries() {
+        return retries;
+    }
+
+    public void setRetries(int retries) {
+        this.retries = retries;
+    }
+
+    @Override
+    public Duration getRetryBackoff() {
+        return retryBackoff;
+    }
+
+    public void setRetryBackoff(Duration retryBackoff) {
+        this.retryBackoff = retryBackoff;
+    }
+
+    @Override
+    public Duration getRequestTimeout() {
+        return requestTimeout;
+    }
+
+    public void setRequestTimeout(Duration requestTimeout) {
+        this.requestTimeout = requestTimeout;
+    }
+
+    @Override
+    public int getBatchSize() {
+        return batchSize;
+    }
+
+    public void setBatchSize(int batchSize) {
+        this.batchSize = batchSize;
+    }
+
+    @Override
+    public int getTcpSendBuffer() {
+        return tcpSendBuffer;
+    }
+
+    public void setTcpSendBuffer(int tcpSendBuffer) {
+        this.tcpSendBuffer = tcpSendBuffer;
+    }
+
+    @Override
+    public int getMaxRequestSize() {
+        return maxRequestSize;
+    }
+
+    public void setMaxRequestSize(int maxRequestSize) {
+        this.maxRequestSize = maxRequestSize;
+    }
+
+    @Override
+    public Duration getLinger() {
+        return linger;
+    }
+
+    public void setLinger(Duration linger) {
+        this.linger = linger;
+    }
+
+    @Override
+    public Duration getMetricsSampleWindow() {
+        return metricsSampleWindow;
+    }
+
+    public void setMetricsSampleWindow(Duration metricsSampleWindow) {
+        this.metricsSampleWindow = metricsSampleWindow;
+    }
+
+    @Override
+    public int getMaxInflightRequestsPerConnection() {
+        return maxInflightRequestsPerConnection;
+    }
+
+    public void setMaxInflightRequestsPerConnection(int maxInflightRequestsPerConnection) {
+        this.maxInflightRequestsPerConnection = maxInflightRequestsPerConnection;
+    }
+
+    @Override
+    public boolean isReportNodeMetricsEnabled() {
+        return reportNodeMetricsEnabled;
+    }
+
+    public void setReportNodeMetricsEnabled(boolean reportNodeMetricsEnabled) {
+        this.reportNodeMetricsEnabled = reportNodeMetricsEnabled;
+    }
+
+    @Override
+    public Duration getDeliveryTimeout() {
+        return deliveryTimeout;
+    }
+
+    public void setDeliveryTimeout(Duration deliveryTimeout) {
+        this.deliveryTimeout = deliveryTimeout;
+    }
+}

--- a/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/config/FailFastRemoteKafkaProducerProperties.java
+++ b/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/config/FailFastRemoteKafkaProducerProperties.java
@@ -1,0 +1,161 @@
+package pl.allegro.tech.hermes.frontend.config;
+
+import pl.allegro.tech.hermes.frontend.producer.kafka.KafkaProducerParameters;
+
+import java.time.Duration;
+
+public class FailFastRemoteKafkaProducerProperties implements KafkaProducerParameters {
+    private Duration maxBlock = Duration.ofMillis(250);
+
+    private Duration metadataMaxAge = Duration.ofMinutes(5);
+
+    private String compressionCodec = "none";
+
+    private int retries = Integer.MAX_VALUE;
+
+    private Duration retryBackoff = Duration.ofMillis(50);
+
+    private Duration requestTimeout = Duration.ofMillis(250);
+
+    private Duration deliveryTimeout = Duration.ofMillis(250);
+
+    private int batchSize = 16 * 1024;
+
+    private int tcpSendBuffer = 128 * 1024;
+
+    private int maxRequestSize = 1024 * 1024;
+
+    private Duration linger = Duration.ofMillis(0);
+
+    private Duration metricsSampleWindow = Duration.ofSeconds(30);
+
+    private int maxInflightRequestsPerConnection = 5;
+
+    private boolean reportNodeMetricsEnabled = false;
+
+    @Override
+    public Duration getMaxBlock() {
+        return maxBlock;
+    }
+
+    public void setMaxBlock(Duration maxBlock) {
+        this.maxBlock = maxBlock;
+    }
+
+    @Override
+    public Duration getMetadataMaxAge() {
+        return metadataMaxAge;
+    }
+
+    public void setMetadataMaxAge(Duration metadataMaxAge) {
+        this.metadataMaxAge = metadataMaxAge;
+    }
+
+    @Override
+    public String getCompressionCodec() {
+        return compressionCodec;
+    }
+
+    public void setCompressionCodec(String compressionCodec) {
+        this.compressionCodec = compressionCodec;
+    }
+
+    @Override
+    public int getRetries() {
+        return retries;
+    }
+
+    public void setRetries(int retries) {
+        this.retries = retries;
+    }
+
+    @Override
+    public Duration getRetryBackoff() {
+        return retryBackoff;
+    }
+
+    public void setRetryBackoff(Duration retryBackoff) {
+        this.retryBackoff = retryBackoff;
+    }
+
+    @Override
+    public Duration getRequestTimeout() {
+        return requestTimeout;
+    }
+
+    public void setRequestTimeout(Duration requestTimeout) {
+        this.requestTimeout = requestTimeout;
+    }
+
+    @Override
+    public int getBatchSize() {
+        return batchSize;
+    }
+
+    public void setBatchSize(int batchSize) {
+        this.batchSize = batchSize;
+    }
+
+    @Override
+    public int getTcpSendBuffer() {
+        return tcpSendBuffer;
+    }
+
+    public void setTcpSendBuffer(int tcpSendBuffer) {
+        this.tcpSendBuffer = tcpSendBuffer;
+    }
+
+    @Override
+    public int getMaxRequestSize() {
+        return maxRequestSize;
+    }
+
+    public void setMaxRequestSize(int maxRequestSize) {
+        this.maxRequestSize = maxRequestSize;
+    }
+
+    @Override
+    public Duration getLinger() {
+        return linger;
+    }
+
+    public void setLinger(Duration linger) {
+        this.linger = linger;
+    }
+
+    @Override
+    public Duration getMetricsSampleWindow() {
+        return metricsSampleWindow;
+    }
+
+    public void setMetricsSampleWindow(Duration metricsSampleWindow) {
+        this.metricsSampleWindow = metricsSampleWindow;
+    }
+
+    @Override
+    public int getMaxInflightRequestsPerConnection() {
+        return maxInflightRequestsPerConnection;
+    }
+
+    public void setMaxInflightRequestsPerConnection(int maxInflightRequestsPerConnection) {
+        this.maxInflightRequestsPerConnection = maxInflightRequestsPerConnection;
+    }
+
+    @Override
+    public boolean isReportNodeMetricsEnabled() {
+        return reportNodeMetricsEnabled;
+    }
+
+    public void setReportNodeMetricsEnabled(boolean reportNodeMetricsEnabled) {
+        this.reportNodeMetricsEnabled = reportNodeMetricsEnabled;
+    }
+
+    @Override
+    public Duration getDeliveryTimeout() {
+        return deliveryTimeout;
+    }
+
+    public void setDeliveryTimeout(Duration deliveryTimeout) {
+        this.deliveryTimeout = deliveryTimeout;
+    }
+}

--- a/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/config/FrontendProducerConfiguration.java
+++ b/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/config/FrontendProducerConfiguration.java
@@ -105,7 +105,10 @@ public class FrontendProducerConfiguration {
     @Bean(destroyMethod = "close")
     public KafkaMessageSenders failFastKafkaMessageSenders(FailFastKafkaProducerProperties kafkaProducerProperties,
                                                            KafkaMessageSendersFactory kafkaMessageSendersFactory) {
-        return kafkaMessageSendersFactory.provide(kafkaProducerProperties, "failFast");
+        return kafkaMessageSendersFactory.provide(
+                kafkaProducerProperties.getLocal(),
+                kafkaProducerProperties.getRemote(),
+                "failFast");
     }
 
     @Bean(destroyMethod = "close")

--- a/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/producer/kafka/KafkaMessageSender.java
+++ b/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/producer/kafka/KafkaMessageSender.java
@@ -111,27 +111,30 @@ public class KafkaMessageSender<K, V> {
     }
 
     public void registerGauges(Topic.Ack ack, String sender) {
-        MetricName bufferTotalBytes = producerMetric("buffer-total-bytes", "producer-metrics", "buffer total bytes");
-        MetricName bufferAvailableBytes = producerMetric("buffer-available-bytes", "producer-metrics", "buffer available bytes");
-        MetricName compressionRate = producerMetric("compression-rate-avg", "producer-metrics", "average compression rate");
-        MetricName failedBatches = producerMetric("record-error-total", "producer-metrics", "failed publishing batches");
-        MetricName metadataAge = producerMetric("metadata-age", "producer-metrics", "age [s] of metadata");
-        MetricName queueTimeMax = producerMetric("record-queue-time-max", "producer-metrics", "maximum time [ms] that batch spent in the send buffer");
+        MetricName bufferTotalBytes = producerMetricMame("buffer-total-bytes", "producer-metrics", "buffer total bytes");
+        MetricName bufferAvailableBytes = producerMetricMame("buffer-available-bytes", "producer-metrics", "buffer available bytes");
+        MetricName compressionRate = producerMetricMame("compression-rate-avg", "producer-metrics", "average compression rate");
+        MetricName failedBatches = producerMetricMame("record-error-total", "producer-metrics", "failed publishing batches");
+        MetricName metadataAge = producerMetricMame("metadata-age", "producer-metrics", "age [s] of metadata");
+        MetricName queueTimeMax = producerMetricMame("record-queue-time-max", "producer-metrics", "maximum time [ms] that batch spent in the send buffer");
+        MetricName recordSendTotal = producerMetricMame("record-send-total", "producer-metrics", "total number of records sent - including retries");
 
         if (ack == Topic.Ack.ALL) {
-            metricsFacade.producer().registerAckAllTotalBytesGauge(producer, producerGauge(bufferTotalBytes), sender, datacenter);
-            metricsFacade.producer().registerAckAllAvailableBytesGauge(producer, producerGauge(bufferAvailableBytes), sender, datacenter);
-            metricsFacade.producer().registerAckAllCompressionRateGauge(producer, producerGauge(compressionRate), sender, datacenter);
-            metricsFacade.producer().registerAckAllFailedBatchesGauge(producer, producerGauge(failedBatches), sender, datacenter);
-            metricsFacade.producer().registerAckAllMetadataAgeGauge(producer, producerGauge(metadataAge), sender, datacenter);
-            metricsFacade.producer().registerAckAllRecordQueueTimeMaxGauge(producer, producerGauge(queueTimeMax), sender, datacenter);
+            metricsFacade.producer().registerAckAllTotalBytesGauge(producer, producerMetric(bufferTotalBytes), sender, datacenter);
+            metricsFacade.producer().registerAckAllAvailableBytesGauge(producer, producerMetric(bufferAvailableBytes), sender, datacenter);
+            metricsFacade.producer().registerAckAllCompressionRateGauge(producer, producerMetric(compressionRate), sender, datacenter);
+            metricsFacade.producer().registerAckAllFailedBatchesGauge(producer, producerMetric(failedBatches), sender, datacenter);
+            metricsFacade.producer().registerAckAllMetadataAgeGauge(producer, producerMetric(metadataAge), sender, datacenter);
+            metricsFacade.producer().registerAckAllRecordQueueTimeMaxGauge(producer, producerMetric(queueTimeMax), sender, datacenter);
+            metricsFacade.producer().registerAckAllRecordSendCounter(producer, producerMetric(recordSendTotal), sender, datacenter);
         } else if (ack == Topic.Ack.LEADER) {
-            metricsFacade.producer().registerAckLeaderTotalBytesGauge(producer, producerGauge(bufferTotalBytes), sender, datacenter);
-            metricsFacade.producer().registerAckLeaderAvailableBytesGauge(producer, producerGauge(bufferAvailableBytes), sender, datacenter);
-            metricsFacade.producer().registerAckLeaderCompressionRateGauge(producer, producerGauge(compressionRate), sender, datacenter);
-            metricsFacade.producer().registerAckLeaderFailedBatchesGauge(producer, producerGauge(failedBatches), sender, datacenter);
-            metricsFacade.producer().registerAckLeaderMetadataAgeGauge(producer, producerGauge(metadataAge), sender, datacenter);
-            metricsFacade.producer().registerAckLeaderRecordQueueTimeMaxGauge(producer, producerGauge(queueTimeMax), sender, datacenter);
+            metricsFacade.producer().registerAckLeaderTotalBytesGauge(producer, producerMetric(bufferTotalBytes), sender, datacenter);
+            metricsFacade.producer().registerAckLeaderAvailableBytesGauge(producer, producerMetric(bufferAvailableBytes), sender, datacenter);
+            metricsFacade.producer().registerAckLeaderCompressionRateGauge(producer, producerMetric(compressionRate), sender, datacenter);
+            metricsFacade.producer().registerAckLeaderFailedBatchesGauge(producer, producerMetric(failedBatches), sender, datacenter);
+            metricsFacade.producer().registerAckLeaderMetadataAgeGauge(producer, producerMetric(metadataAge), sender, datacenter);
+            metricsFacade.producer().registerAckLeaderRecordQueueTimeMaxGauge(producer, producerMetric(queueTimeMax), sender, datacenter);
+            metricsFacade.producer().registerAckLeaderRecordSendCounter(producer, producerMetric(recordSendTotal), sender, datacenter);
         }
     }
 
@@ -143,13 +146,13 @@ public class KafkaMessageSender<K, V> {
         return value < 0 ? 0.0 : value;
     }
 
-    private ToDoubleFunction<Producer<K, V>> producerGauge(MetricName producerMetricName) {
+    private ToDoubleFunction<Producer<K, V>> producerMetric(MetricName producerMetricName) {
         Predicate<Map.Entry<MetricName, ? extends Metric>> predicate = entry -> entry.getKey().group().equals(producerMetricName.group())
                 && entry.getKey().name().equals(producerMetricName.name());
         return producer -> findProducerMetric(producer, predicate);
     }
 
-    private static MetricName producerMetric(String name, String group, String description) {
+    private static MetricName producerMetricMame(String name, String group, String description) {
         return new MetricName(name, group, description, Collections.emptyMap());
     }
 }

--- a/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/producer/kafka/KafkaMessageSendersFactory.java
+++ b/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/producer/kafka/KafkaMessageSendersFactory.java
@@ -66,16 +66,23 @@ public class KafkaMessageSendersFactory {
         this.brokerLatencyReporter = brokerLatencyReporter;
     }
 
+
     public KafkaMessageSenders provide(KafkaProducerParameters kafkaProducerParameters, String senderName) {
-            KafkaMessageSenders.Tuple localProducers = new KafkaMessageSenders.Tuple(
-                sender(kafkaParameters, kafkaProducerParameters, ACK_LEADER),
-                sender(kafkaParameters, kafkaProducerParameters, ACK_ALL)
+        return provide(kafkaProducerParameters, kafkaProducerParameters, senderName);
+    }
+
+    public KafkaMessageSenders provide(KafkaProducerParameters localKafkaProducerParameters,
+                                       KafkaProducerParameters remoteKafkaProducerParameters,
+                                       String senderName) {
+        KafkaMessageSenders.Tuple localProducers = new KafkaMessageSenders.Tuple(
+                sender(kafkaParameters, localKafkaProducerParameters, ACK_LEADER),
+                sender(kafkaParameters, localKafkaProducerParameters, ACK_ALL)
         );
 
         List<KafkaMessageSenders.Tuple> remoteProducers = remoteKafkaParameters.stream().map(
                 kafkaProperties -> new KafkaMessageSenders.Tuple(
-                        sender(kafkaProperties, kafkaProducerParameters, ACK_LEADER),
-                        sender(kafkaProperties, kafkaProducerParameters, ACK_ALL))).toList();
+                        sender(kafkaProperties, remoteKafkaProducerParameters, ACK_LEADER),
+                        sender(kafkaProperties, remoteKafkaProducerParameters, ACK_ALL))).toList();
         KafkaMessageSenders senders = new KafkaMessageSenders(
                 topicMetadataLoadingExecutor,
                 localMinInSyncReplicasLoader,

--- a/integration-tests/src/common/java/pl/allegro/tech/hermes/integrationtests/assertions/PrometheusMetricsAssertion.java
+++ b/integration-tests/src/common/java/pl/allegro/tech/hermes/integrationtests/assertions/PrometheusMetricsAssertion.java
@@ -96,6 +96,10 @@ public class PrometheusMetricsAssertion {
             assertThat(actualValue).isEqualTo(expectedValue);
         }
 
+        public double withInitialValue() {
+            return extractValue();
+        }
+
         public void withValueGreaterThan(double expectedValue) {
             double actualValue = extractValue();
             assertThat(actualValue).isGreaterThan(expectedValue);

--- a/integration-tests/src/integrationTest/java/pl/allegro/tech/hermes/integrationtests/KafkaProducerMetricsTest.java
+++ b/integration-tests/src/integrationTest/java/pl/allegro/tech/hermes/integrationtests/KafkaProducerMetricsTest.java
@@ -1,0 +1,47 @@
+package pl.allegro.tech.hermes.integrationtests;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import pl.allegro.tech.hermes.api.Topic;
+import pl.allegro.tech.hermes.integrationtests.assertions.PrometheusMetricsAssertion;
+import pl.allegro.tech.hermes.integrationtests.setup.HermesExtension;
+
+import java.util.concurrent.TimeUnit;
+
+import static com.jayway.awaitility.Awaitility.await;
+import static pl.allegro.tech.hermes.integrationtests.assertions.HermesAssertions.assertThatMetrics;
+import static pl.allegro.tech.hermes.test.helper.builder.TopicBuilder.topicWithRandomName;
+
+public class KafkaProducerMetricsTest {
+    @RegisterExtension
+    public static final HermesExtension hermes = new HermesExtension();
+
+    @Test
+    public void shouldRegisterSendMetrics() {
+        // given
+        Topic topic = hermes.initHelper().createTopic(topicWithRandomName().build());
+
+        double initialMetricValue = assertMetricsContainTotalSendMetric().withInitialValue();
+
+        // when
+        hermes.api().publish(topic.getQualifiedName(), "hello world");
+        hermes.api().publish(topic.getQualifiedName(), "hello world");
+
+        // then
+        await().atMost(10, TimeUnit.SECONDS).until(() ->
+                assertMetricsContainTotalSendMetric().withValue(initialMetricValue + 2.0));
+    }
+
+    PrometheusMetricsAssertion.PrometheusMetricAssertion assertMetricsContainTotalSendMetric() {
+        return assertThatMetrics(hermes.api()
+                .getFrontendMetrics().expectStatus().isOk()
+                .expectBody(String.class).returnResult().getResponseBody())
+                .contains("hermes_frontend_kafka_producer_ack_leader_record_send_total")
+                .withLabels(
+                        "storageDc", "dc",
+                        "sender", "default"
+                );
+    }
+
+
+}


### PR DESCRIPTION
1. Split fail fast producer config to local / remote
2. Expose kafka send_total metric which can be used to calculate true record send  rate (with retries) 