### PR TITLE
bump kafka clients to version 3.6.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,7 @@ allprojects {
     targetCompatibility = JavaVersion.VERSION_17
 
     project.ext.versions = [
-            kafka             : '2.8.2',
+            kafka             : '3.6.2',
             guava             : '23.0',
             jackson           : '2.15.2',
             jersey            : '3.1.2',

--- a/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/config/FailFastLocalKafkaProducerProperties.java
+++ b/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/config/FailFastLocalKafkaProducerProperties.java
@@ -33,6 +33,8 @@ public class FailFastLocalKafkaProducerProperties implements KafkaProducerParame
 
     private boolean reportNodeMetricsEnabled = false;
 
+    private boolean idempotenceEnabled = false;
+
     @Override
     public Duration getMaxBlock() {
         return maxBlock;
@@ -157,5 +159,13 @@ public class FailFastLocalKafkaProducerProperties implements KafkaProducerParame
 
     public void setDeliveryTimeout(Duration deliveryTimeout) {
         this.deliveryTimeout = deliveryTimeout;
+    }
+
+    public boolean isIdempotenceEnabled() {
+        return idempotenceEnabled;
+    }
+
+    public void setIdempotenceEnabled(boolean idempotenceEnabled) {
+        this.idempotenceEnabled = idempotenceEnabled;
     }
 }

--- a/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/config/FailFastRemoteKafkaProducerProperties.java
+++ b/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/config/FailFastRemoteKafkaProducerProperties.java
@@ -33,6 +33,8 @@ public class FailFastRemoteKafkaProducerProperties implements KafkaProducerParam
 
     private boolean reportNodeMetricsEnabled = false;
 
+    private boolean idempotenceEnabled = false;
+
     @Override
     public Duration getMaxBlock() {
         return maxBlock;
@@ -157,5 +159,14 @@ public class FailFastRemoteKafkaProducerProperties implements KafkaProducerParam
 
     public void setDeliveryTimeout(Duration deliveryTimeout) {
         this.deliveryTimeout = deliveryTimeout;
+    }
+
+    @Override
+    public boolean isIdempotenceEnabled() {
+        return idempotenceEnabled;
+    }
+
+    public void setIdempotenceEnabled(boolean idempotenceEnabled) {
+        this.idempotenceEnabled = idempotenceEnabled;
     }
 }

--- a/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/config/KafkaProducerProperties.java
+++ b/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/config/KafkaProducerProperties.java
@@ -36,6 +36,8 @@ public class KafkaProducerProperties implements KafkaProducerParameters {
 
     private boolean reportNodeMetricsEnabled = false;
 
+    private boolean enableIdempotence = false;
+
     @Override
     public Duration getMaxBlock() {
         return maxBlock;
@@ -160,5 +162,13 @@ public class KafkaProducerProperties implements KafkaProducerParameters {
 
     public void setDeliveryTimeout(Duration deliveryTimeout) {
         this.deliveryTimeout = deliveryTimeout;
+    }
+
+    public boolean enableIdempotence() {
+        return enableIdempotence;
+    }
+
+    public void setEnableIdempotence(boolean enableIdempotence) {
+        this.enableIdempotence = enableIdempotence;
     }
 }

--- a/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/config/KafkaProducerProperties.java
+++ b/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/config/KafkaProducerProperties.java
@@ -36,7 +36,7 @@ public class KafkaProducerProperties implements KafkaProducerParameters {
 
     private boolean reportNodeMetricsEnabled = false;
 
-    private boolean enableIdempotence = false;
+    private boolean idempotenceEnabled = false;
 
     @Override
     public Duration getMaxBlock() {
@@ -164,11 +164,11 @@ public class KafkaProducerProperties implements KafkaProducerParameters {
         this.deliveryTimeout = deliveryTimeout;
     }
 
-    public boolean enableIdempotence() {
-        return enableIdempotence;
+    public boolean isIdempotenceEnabled() {
+        return idempotenceEnabled;
     }
 
-    public void setEnableIdempotence(boolean enableIdempotence) {
-        this.enableIdempotence = enableIdempotence;
+    public void setIdempotenceEnabled(boolean idempotenceEnabled) {
+        this.idempotenceEnabled = idempotenceEnabled;
     }
 }

--- a/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/producer/kafka/KafkaMessageSender.java
+++ b/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/producer/kafka/KafkaMessageSender.java
@@ -142,8 +142,12 @@ public class KafkaMessageSender<K, V> {
                                       Predicate<Map.Entry<MetricName, ? extends Metric>> predicate) {
         Optional<? extends Map.Entry<MetricName, ? extends Metric>> first =
                 producer.metrics().entrySet().stream().filter(predicate).findFirst();
-        double value = first.map(metricNameEntry -> metricNameEntry.getValue().value()).orElse(0.0);
-        return value < 0 ? 0.0 : value;
+        Object value = first.map(metricNameEntry -> metricNameEntry.getValue().metricValue()).orElse(0.0d);
+        if (value instanceof Number) {
+            return ((Number) value).doubleValue();
+        } else {
+            return 0.0;
+        }
     }
 
     private ToDoubleFunction<Producer<K, V>> producerMetric(MetricName producerMetricName) {

--- a/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/producer/kafka/KafkaMessageSendersFactory.java
+++ b/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/producer/kafka/KafkaMessageSendersFactory.java
@@ -115,7 +115,7 @@ public class KafkaMessageSendersFactory {
         props.put(LINGER_MS_CONFIG, (int) kafkaProducerParameters.getLinger().toMillis());
         props.put(METRICS_SAMPLE_WINDOW_MS_CONFIG, (int) kafkaProducerParameters.getMetricsSampleWindow().toMillis());
         props.put(MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION, kafkaProducerParameters.getMaxInflightRequestsPerConnection());
-        props.put(ENABLE_IDEMPOTENCE_CONFIG, kafkaProducerParameters.enableIdempotence());
+        props.put(ENABLE_IDEMPOTENCE_CONFIG, kafkaProducerParameters.isIdempotenceEnabled());
         props.put(ACKS_CONFIG, acks);
 
         if (kafkaParameters.isAuthenticationEnabled()) {

--- a/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/producer/kafka/KafkaMessageSendersFactory.java
+++ b/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/producer/kafka/KafkaMessageSendersFactory.java
@@ -18,6 +18,7 @@ import static org.apache.kafka.clients.producer.ProducerConfig.BOOTSTRAP_SERVERS
 import static org.apache.kafka.clients.producer.ProducerConfig.BUFFER_MEMORY_CONFIG;
 import static org.apache.kafka.clients.producer.ProducerConfig.COMPRESSION_TYPE_CONFIG;
 import static org.apache.kafka.clients.producer.ProducerConfig.DELIVERY_TIMEOUT_MS_CONFIG;
+import static org.apache.kafka.clients.producer.ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG;
 import static org.apache.kafka.clients.producer.ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG;
 import static org.apache.kafka.clients.producer.ProducerConfig.LINGER_MS_CONFIG;
 import static org.apache.kafka.clients.producer.ProducerConfig.MAX_BLOCK_MS_CONFIG;
@@ -114,6 +115,7 @@ public class KafkaMessageSendersFactory {
         props.put(LINGER_MS_CONFIG, (int) kafkaProducerParameters.getLinger().toMillis());
         props.put(METRICS_SAMPLE_WINDOW_MS_CONFIG, (int) kafkaProducerParameters.getMetricsSampleWindow().toMillis());
         props.put(MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION, kafkaProducerParameters.getMaxInflightRequestsPerConnection());
+        props.put(ENABLE_IDEMPOTENCE_CONFIG, kafkaProducerParameters.enableIdempotence());
         props.put(ACKS_CONFIG, acks);
 
         if (kafkaParameters.isAuthenticationEnabled()) {

--- a/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/producer/kafka/KafkaProducerParameters.java
+++ b/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/producer/kafka/KafkaProducerParameters.java
@@ -31,4 +31,6 @@ public interface KafkaProducerParameters {
     int getMaxInflightRequestsPerConnection();
 
     boolean isReportNodeMetricsEnabled();
+
+    boolean enableIdempotence();
 }

--- a/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/producer/kafka/KafkaProducerParameters.java
+++ b/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/producer/kafka/KafkaProducerParameters.java
@@ -32,5 +32,5 @@ public interface KafkaProducerParameters {
 
     boolean isReportNodeMetricsEnabled();
 
-    boolean enableIdempotence();
+    boolean isIdempotenceEnabled();
 }

--- a/hermes-frontend/src/test/groovy/pl/allegro/tech/hermes/frontend/producer/kafka/LocalDatacenterMessageProducerIntegrationTest.groovy
+++ b/hermes-frontend/src/test/groovy/pl/allegro/tech/hermes/frontend/producer/kafka/LocalDatacenterMessageProducerIntegrationTest.groovy
@@ -13,11 +13,7 @@ import org.apache.kafka.common.TopicPartition
 import org.testcontainers.containers.KafkaContainer
 import org.testcontainers.containers.wait.strategy.Wait
 import org.testcontainers.spock.Testcontainers
-import pl.allegro.tech.hermes.api.ContentType
-import pl.allegro.tech.hermes.api.DeliveryType
-import pl.allegro.tech.hermes.api.Subscription
-import pl.allegro.tech.hermes.api.SubscriptionMode
-import pl.allegro.tech.hermes.api.Topic
+import pl.allegro.tech.hermes.api.*
 import pl.allegro.tech.hermes.common.kafka.ConsumerGroupId
 import pl.allegro.tech.hermes.common.kafka.JsonToAvroMigrationKafkaNamesMapper
 import pl.allegro.tech.hermes.common.kafka.KafkaNamesMapper
@@ -33,6 +29,7 @@ import pl.allegro.tech.hermes.frontend.server.CachedTopicsTestHelper
 import pl.allegro.tech.hermes.metrics.PathsCompiler
 import pl.allegro.tech.hermes.test.helper.avro.AvroUser
 import pl.allegro.tech.hermes.test.helper.builder.TopicBuilder
+import pl.allegro.tech.hermes.test.helper.containers.ImageTags
 import spock.lang.Shared
 import spock.lang.Specification
 
@@ -42,10 +39,7 @@ import java.util.stream.Collectors
 import static java.util.Collections.emptyList
 import static java.util.Collections.emptyMap
 import static java.util.concurrent.TimeUnit.MILLISECONDS
-import static org.apache.kafka.clients.consumer.ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG
-import static org.apache.kafka.clients.consumer.ConsumerConfig.GROUP_ID_CONFIG
-import static org.apache.kafka.clients.consumer.ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG
-import static org.apache.kafka.clients.consumer.ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG
+import static org.apache.kafka.clients.consumer.ConsumerConfig.*
 import static org.apache.kafka.clients.producer.ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG
 import static org.apache.kafka.clients.producer.ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG
 
@@ -58,7 +52,7 @@ class LocalDatacenterMessageProducerIntegrationTest extends Specification {
     BrokerLatencyReporter brokerLatencyReporter = new BrokerLatencyReporter(false, null, null, null)
 
     @Shared
-    KafkaContainer kafkaContainer = new KafkaContainer()
+    KafkaContainer kafkaContainer = new KafkaContainer(ImageTags.confluentImagesTag())
 
     @Shared
     KafkaProducer<byte[], byte[]> leaderConfirms
@@ -159,34 +153,6 @@ class LocalDatacenterMessageProducerIntegrationTest extends Specification {
 
         partitionsWithMessagesData.size() == 1
         partitionsWithMessagesData.get(0).offset() == 10
-    }
-
-    def "should publish messages with random distribiution when pratition-key is not present"() {
-        Topic topic = createAvroTopic("pl.allegro.test.randomFoo")
-        Subscription subscription = createTestSubscription(topic, "test-subscription")
-        String kafkaTopicName = topic.getName().toString()
-        ConsumerGroupId consumerGroupId = kafkaNamesMapper.toConsumerGroupId(subscription.qualifiedName)
-        createTopicInKafka(kafkaTopicName, NUMBER_OF_PARTITION)
-        CachedTopic cachedTopic = CachedTopicsTestHelper.cachedTopic(topic)
-        KafkaConsumer consumer = createConsumer(consumerGroupId, kafkaTopicName)
-
-        when:
-        1.upto(10) {
-            brokerMessageProducer.send(generateAvroMessage(null), cachedTopic, null)
-            waitForRecordPublishing(consumer)
-        }
-
-        then:
-        consumer.close()
-
-        List<OffsetAndMetadata> partitionsWithMessagesData = adminClient
-                .listConsumerGroupOffsets(consumerGroupId.asString())
-                .partitionsToOffsetAndMetadata()
-                .get().values().stream()
-                .filter { metadata -> metadata.offset() != 0 }
-                .collect(Collectors.toList())
-
-        partitionsWithMessagesData.size() == NUMBER_OF_PARTITION
     }
 
     private static AvroMessage generateAvroMessage(String partitionKey) {

--- a/hermes-test-helper/src/main/java/pl/allegro/tech/hermes/test/helper/containers/ImageTags.java
+++ b/hermes-test-helper/src/main/java/pl/allegro/tech/hermes/test/helper/containers/ImageTags.java
@@ -1,7 +1,7 @@
 package pl.allegro.tech.hermes.test.helper.containers;
 
 public class ImageTags {
-    static String confluentImagesTag() {
+    public static String confluentImagesTag() {
         return System.getProperty("confluentImagesTag", "6.1.0");
     }
 }


### PR DESCRIPTION
Bump kafka clients in order to make use of [Strictly Uniform Sticky Partitioner](https://cwiki.apache.org/confluence/display/KAFKA/KIP-794%3A+Strictly+Uniform+Sticky+Partitioner). Rewrite / remove tests which depend on previous partitioner behaviour i.e. round robin.