### PR TITLE
add support for all unicode characters in message filters debug

### DIFF
--- a/hermes-console/src/composables/subscription/use-subscription-filters-debug/useSubscriptionFiltersDebug.ts
+++ b/hermes-console/src/composables/subscription/use-subscription-filters-debug/useSubscriptionFiltersDebug.ts
@@ -35,6 +35,15 @@ const toFiltersJSON = (
   };
 };
 
+// https://stackoverflow.com/a/30106551
+function b64EncodeUnicode(str: string): string {
+  return btoa(
+    encodeURIComponent(str).replace(/%([0-9A-F]{2})/g, function (match, p1) {
+      return String.fromCharCode(parseInt(p1, 16));
+    }),
+  );
+}
+
 export function useSubscriptionFiltersDebug(): UseSubscriptionFiltersDebug {
   const notificationStore = useNotificationsStore();
   const status: Ref<VerificationStatus | undefined> = ref();
@@ -52,7 +61,7 @@ export function useSubscriptionFiltersDebug(): UseSubscriptionFiltersDebug {
       );
       const response = (
         await verifyFilters(topicName, {
-          message: btoa(message),
+          message: b64EncodeUnicode(message),
           filters: filtersJSON,
         })
       ).data;


### PR DESCRIPTION
This resolves: https://github.com/allegro/hermes/issues/1838

Filter debug endpoint expects message to be base64 encoded byte array. Previous solution using `btoa` was not working with all unicode characters.