### PR TITLE
Fix hermes-management build on ARM+Docker

### DIFF
--- a/hermes-management/build.gradle
+++ b/hermes-management/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'java-library'
     id 'application'
-    id "com.github.node-gradle.node" version "2.2.4"
+    id "com.github.node-gradle.node" version "3.0.0"
 }
 
 mainClassName = 'pl.allegro.tech.hermes.management.HermesManagement'


### PR DESCRIPTION
Running Hermes locally (https://hermes-pubsub.readthedocs.io/en/latest/quickstart/#quickstart) fails on Macbook Pro M1. 

```sh
> uname -msp
Darwin arm64 arm

> ./gradlew --version

------------------------------------------------------------
Gradle 7.6
------------------------------------------------------------

Build time:   2022-11-25 13:35:10 UTC
Revision:     daece9dbc5b79370cc8e4fd6fe4b2cd400e150a8

Kotlin:       1.7.10
Groovy:       3.0.13
Ant:          Apache Ant(TM) version 1.10.11 compiled on July 10 2021
JVM:          17.0.5 (Eclipse Adoptium 17.0.5+8)
OS:           Mac OS X 14.5 aarch64
```


```
> docker-compose -f docker/docker-compose.yml up
...
#10 55.80 > Task :hermes-frontend:distZip
#10 56.50 
#10 56.50 FAILURE: Build failed with an exception.
#10 56.50 
#10 56.50 * What went wrong:
#10 56.50 > Task :hermes-management:nodeSetup FAILED
#10 56.50 Execution failed for task ':hermes-management:nodeSetup'.
#10 56.50 > Could not resolve all files for configuration ':hermes-management:detachedConfiguration1'.
#10 56.50    > Could not find org.nodejs:node:20.4.0.
#10 56.50      Searched in the following locations:
#10 56.50        - https://repo.maven.apache.org/maven2/org/nodejs/node/20.4.0/node-20.4.0.pom
#10 56.50        - https://nodejs.org/dist/v20.4.0/node-v20.4.0-linux-aarch64.tar.gz
#10 56.50      Required by:
#10 56.50          project :hermes-management
```

Problem was fixed in gradle-node-plugin 3.0.0 https://github.com/node-gradle/gradle-node-plugin/blob/main/CHANGELOG.md#version-30-2021-02-06