### PR TITLE
transition to error state upon failing publishing handler

### DIFF
--- a/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/publishing/handlers/PublishingHandler.java
+++ b/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/publishing/handlers/PublishingHandler.java
@@ -35,6 +35,9 @@ class PublishingHandler implements HttpHandler {
             try {
                 handle(exchange);
             } catch (RuntimeException e) {
+                AttachmentContent attachment = exchange.getAttachment(AttachmentContent.KEY);
+                MessageState messageState = attachment.getMessageState();
+                messageState.setErrorInSendingToKafka();
                 messageErrorProcessor.sendAndLog(exchange, "Exception while publishing message to a broker.", e);
             }
         });


### PR DESCRIPTION
Transition to failed state when publishing handler throws exception. Without it a timeout handler would run after a response was already sent. This would in turn always log 

```
Not sending error message to a client as response has already been started.
```