### PR TITLE
Fix topic search redirect link

### DIFF
--- a/hermes-console/src/views/search/topic-search-results/TopicSearchResults.vue
+++ b/hermes-console/src/views/search/topic-search-results/TopicSearchResults.vue
@@ -15,7 +15,7 @@
   }
   function onTopicBlankClick(topic: Topic) {
     const group = groupName(topic.name);
-    window.open(`/ui/groups/${group}//topics/${topic.name}`, '_blank');
+    window.open(`/ui/groups/${group}/topics/${topic.name}`, '_blank');
   }
 </script>
 


### PR DESCRIPTION
## What?
Fixed redirect link for blank click on search topic.

## Why?
Previously links contained double slash.