### PR TITLE
Downgrade kafka clients

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,7 @@ allprojects {
     targetCompatibility = JavaVersion.VERSION_17
 
     project.ext.versions = [
-            kafka             : '3.6.2',
+            kafka             : '2.8.2',
             guava             : '33.1.0-jre',
             jackson           : '2.17.0',
             jersey            : '3.1.6',

--- a/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/producer/kafka/KafkaMessageSender.java
+++ b/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/producer/kafka/KafkaMessageSender.java
@@ -96,7 +96,7 @@ public class KafkaMessageSender<K, V> {
 
     private static RecordMetadata exceptionalRecordMetadata(CachedTopic cachedTopic) {
         var tp = new TopicPartition(cachedTopic.getKafkaTopics().getPrimary().name().asString(), RecordMetadata.UNKNOWN_PARTITION);
-        return new RecordMetadata(tp, -1, -1, RecordBatch.NO_TIMESTAMP, -1, -1);
+        return new RecordMetadata(tp, -1, -1, RecordBatch.NO_TIMESTAMP, -1L, -1, -1);
     }
 
     List<PartitionInfo> loadPartitionMetadataFor(String topic) {


### PR DESCRIPTION
Downgrade Kafka clients to version prior to https://github.com/allegro/hermes/commit/0a6cfd7a39ba7a5be9063f53fdf02daf8b149824. With Kafka client 3.6.2 Hermes-frontend latency is greatly increased across all percentiles. We suspect that this may be because of internal producer changes or misconfiguration with new version. 