### PR TITLE
InflightSize and retentionTime validation improvements

### DIFF
--- a/hermes-api/src/main/java/pl/allegro/tech/hermes/api/RetentionTime.java
+++ b/hermes-api/src/main/java/pl/allegro/tech/hermes/api/RetentionTime.java
@@ -2,18 +2,21 @@ package pl.allegro.tech.hermes.api;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
-import pl.allegro.tech.hermes.api.constraints.AdminPermitted;
 
+import java.util.EnumSet;
 import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 public class RetentionTime {
     private static final TimeUnit DEFAULT_UNIT = TimeUnit.DAYS;
 
+    public static RetentionTime MAX = new RetentionTime(7, TimeUnit.DAYS);
+    public static Set<TimeUnit> allowedUnits = EnumSet.of(TimeUnit.SECONDS, TimeUnit.MINUTES, TimeUnit.HOURS, TimeUnit.DAYS);
+
+
     @Min(0)
-    @Max(value = 7, groups = AdminPermitted.class)
     private final int duration;
 
     private final TimeUnit retentionUnit;

--- a/hermes-api/src/main/java/pl/allegro/tech/hermes/api/SubscriptionPolicy.java
+++ b/hermes-api/src/main/java/pl/allegro/tech/hermes/api/SubscriptionPolicy.java
@@ -5,8 +5,6 @@ import com.google.common.base.MoreObjects;
 import jakarta.annotation.Nullable;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.Null;
-import pl.allegro.tech.hermes.api.constraints.AdminPermitted;
 import pl.allegro.tech.hermes.api.helpers.Patch;
 
 import java.util.Map;
@@ -42,7 +40,6 @@ public class SubscriptionPolicy {
     private int socketTimeout = DEFAULT_SOCKET_TIMEOUT;
 
     @Min(1)
-    @Null(groups = AdminPermitted.class)
     private Integer inflightSize;
 
     @Min(0)

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/domain/topic/validator/TopicValidator.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/domain/topic/validator/TopicValidator.java
@@ -6,6 +6,7 @@ import pl.allegro.tech.hermes.api.ContentType;
 import pl.allegro.tech.hermes.api.PublishingChaosPolicy;
 import pl.allegro.tech.hermes.api.PublishingChaosPolicy.ChaosMode;
 import pl.allegro.tech.hermes.api.PublishingChaosPolicy.ChaosPolicy;
+import pl.allegro.tech.hermes.api.RetentionTime;
 import pl.allegro.tech.hermes.api.Topic;
 import pl.allegro.tech.hermes.management.api.validator.ApiPreconditions;
 import pl.allegro.tech.hermes.management.domain.auth.RequestUser;
@@ -14,6 +15,9 @@ import pl.allegro.tech.hermes.management.domain.topic.CreatorRights;
 import pl.allegro.tech.hermes.schema.CouldNotLoadSchemaException;
 import pl.allegro.tech.hermes.schema.SchemaNotFoundException;
 import pl.allegro.tech.hermes.schema.SchemaRepository;
+
+import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
 
 @Component
 public class TopicValidator {
@@ -59,6 +63,8 @@ public class TopicValidator {
         if (!creatorRights.allowedToManage(created)) {
             throw new TopicValidationException("Provide an owner that includes you, you would not be able to manage this topic later");
         }
+
+        ensureCreatedTopicRetentionTimeValid(created, createdBy);
     }
 
     public void ensureUpdatedTopicIsValid(Topic updated, Topic previous, RequestUser modifiedBy) {
@@ -90,6 +96,49 @@ public class TopicValidator {
                     "Cannot change content type, except for migration to Avro with setting migratedFromJsonType flag.");
         } else if (migrationFromJsonTypeFlagChangedToFalse(updated, previous)) {
             throw new TopicValidationException("Cannot migrate back to JSON!");
+        }
+
+        ensureUpdatedTopicRetentionTimeValid(updated, previous, modifiedBy);
+    }
+
+    private void ensureCreatedTopicRetentionTimeValid(Topic created, RequestUser modifiedBy) {
+        if (modifiedBy.isAdmin()) {
+            return;
+        }
+
+        checkTopicRetentionTimeUnit(created.getRetentionTime().getRetentionUnit());
+
+        long seconds = created.getRetentionTime().getRetentionUnit().toSeconds(created.getRetentionTime().getDuration());
+
+        checkTopicRetentionLimit(seconds);
+    }
+
+    private void ensureUpdatedTopicRetentionTimeValid(Topic updated, Topic previous, RequestUser modifiedBy) {
+        if (modifiedBy.isAdmin()) {
+            return;
+        }
+
+        checkTopicRetentionTimeUnit(updated.getRetentionTime().getRetentionUnit());
+
+        long updatedSeconds = updated.getRetentionTime().getRetentionUnit().toSeconds(updated.getRetentionTime().getDuration());
+        long previousSeconds = previous.getRetentionTime().getRetentionUnit().toSeconds(previous.getRetentionTime().getDuration());
+
+        if (updatedSeconds == previousSeconds) {
+            return;
+        }
+
+        checkTopicRetentionLimit(updatedSeconds);
+    }
+
+    private void checkTopicRetentionTimeUnit(TimeUnit toCheck) {
+        if (!RetentionTime.allowedUnits.contains(toCheck)) {
+            throw new TopicValidationException("Retention time unit must be one of: " + Arrays.toString(RetentionTime.allowedUnits.toArray()));
+        }
+    }
+
+    private void checkTopicRetentionLimit(long retentionSeconds) {
+        if (retentionSeconds > RetentionTime.MAX.getRetentionUnit().toSeconds(RetentionTime.MAX.getDuration())) {
+            throw new TopicValidationException("Retention time larger than 7 days can't be configured by non admin users");
         }
     }
 

--- a/hermes-management/src/test/groovy/pl/allegro/tech/hermes/management/domain/topic/validator/TopicValidatorWithRealApiPreconditionsTest.groovy
+++ b/hermes-management/src/test/groovy/pl/allegro/tech/hermes/management/domain/topic/validator/TopicValidatorWithRealApiPreconditionsTest.groovy
@@ -1,6 +1,5 @@
 package pl.allegro.tech.hermes.management.domain.topic.validator
 
-import jakarta.validation.ConstraintViolationException
 import pl.allegro.tech.hermes.api.RetentionTime
 import pl.allegro.tech.hermes.management.api.validator.ApiPreconditions
 import pl.allegro.tech.hermes.management.domain.auth.TestRequestUser
@@ -10,14 +9,17 @@ import spock.lang.Specification
 import spock.lang.Subject
 import spock.lang.Unroll
 
+import java.util.concurrent.TimeUnit
+
 import static java.util.concurrent.TimeUnit.DAYS
+import static java.util.concurrent.TimeUnit.HOURS
+import static java.util.concurrent.TimeUnit.MINUTES
+import static java.util.concurrent.TimeUnit.SECONDS
 import static pl.allegro.tech.hermes.test.helper.builder.TopicBuilder.topic
 
 class TopicValidatorWithRealApiPreconditionsTest extends Specification {
 
     private static MANAGEABLE = { true }
-    private static retentionTime7Days = new RetentionTime(7, DAYS)
-    private static retentionTime8Days = new RetentionTime(8, DAYS)
     private static regularUser = new TestRequestUser("regularUser", false)
     private static admin = new TestRequestUser("admin", true)
 
@@ -30,10 +32,10 @@ class TopicValidatorWithRealApiPreconditionsTest extends Specification {
     def topicValidator = new TopicValidator(ownerDescriptorValidator, contentTypeWhitelistValidator, topicLabelsValidator, schemaRepository, new ApiPreconditions())
 
     @Unroll
-    def "creating topic with 7 days retention time should be valid"() {
+    def "creating and updating topic with up to 7 days retention time should be valid"() {
         given:
         def topic = topic('group.topic')
-                .withRetentionTime(retentionTime7Days)
+                .withRetentionTime(retentionTime)
                 .build()
 
         when:
@@ -43,26 +45,47 @@ class TopicValidatorWithRealApiPreconditionsTest extends Specification {
         noExceptionThrown()
 
         where:
-        user << [regularUser, admin]
+        retentionTime                    | user
+        new RetentionTime(1, MINUTES)    | admin
+        new RetentionTime(1, MINUTES)    | regularUser
+        new RetentionTime(1337, MINUTES) | admin
+        new RetentionTime(1337, MINUTES) | regularUser
+        new RetentionTime(24, HOURS)     | admin
+        new RetentionTime(24, HOURS)     | regularUser
+        new RetentionTime(72, HOURS)     | admin
+        new RetentionTime(72, HOURS)     | regularUser
+        new RetentionTime(1, DAYS)       | admin
+        new RetentionTime(1, DAYS)       | regularUser
+        new RetentionTime(7, DAYS)       | admin
+        new RetentionTime(7, DAYS)       | regularUser
     }
 
-    def "creating topic with 8 days retention time should be invalid for regular user"() {
+    def "creating topic with over 7 days of retention time should be invalid for regular user"() {
         given:
         def topic = topic('group.topic')
-                .withRetentionTime(retentionTime8Days)
+                .withRetentionTime(retentionTime)
                 .build()
 
         when:
         topicValidator.ensureCreatedTopicIsValid(topic, regularUser, MANAGEABLE)
 
         then:
-        thrown ConstraintViolationException
+        def exception = thrown(TopicValidationException)
+        exception.message == "Retention time larger than 7 days can't be configured by non admin users"
+
+        where:
+        retentionTime << [
+                new RetentionTime(8, DAYS),
+                new RetentionTime(7 * 24 + 1, HOURS),
+                new RetentionTime(7 * 24 * 60 + 1, MINUTES),
+                new RetentionTime(7 * 24 * 60 * 60 + 1, SECONDS)
+        ]
     }
 
-    def "creating topic with 8 days retention time should be valid for admin"() {
+    def "creating topic with over 7 days retention time should be valid for admin"() {
         given:
         def topic = topic('group.topic')
-                .withRetentionTime(retentionTime8Days)
+                .withRetentionTime(retentionTime)
                 .build()
 
         when:
@@ -70,14 +93,99 @@ class TopicValidatorWithRealApiPreconditionsTest extends Specification {
 
         then:
         noExceptionThrown()
+
+        where:
+        retentionTime << [
+                new RetentionTime(8, DAYS),
+                new RetentionTime(7 * 24 + 1, HOURS),
+                new RetentionTime(7 * 24 * 60 + 1, MINUTES),
+                new RetentionTime(7 * 24 * 60 * 60 + 1, SECONDS)
+        ]
     }
 
     @Unroll
-    def "updating topic with 7 days retention time should be valid"() {
+    def "updating topic with up to 7 days of retention time should be valid"() {
         given:
         def existingTopic = topic('group.topic').build()
         def updatedTopic = topic('group.topic')
-                .withRetentionTime(retentionTime7Days)
+                .withRetentionTime(retentionTime)
+                .build()
+
+        when:
+        topicValidator.ensureUpdatedTopicIsValid(updatedTopic, existingTopic, user)
+
+        then:
+        noExceptionThrown()
+
+        where:
+        retentionTime                    | user
+        new RetentionTime(1, MINUTES)    | admin
+        new RetentionTime(1, MINUTES)    | regularUser
+        new RetentionTime(1337, MINUTES) | admin
+        new RetentionTime(1337, MINUTES) | regularUser
+        new RetentionTime(24, HOURS)     | admin
+        new RetentionTime(24, HOURS)     | regularUser
+        new RetentionTime(72, HOURS)     | admin
+        new RetentionTime(72, HOURS)     | regularUser
+        new RetentionTime(1, DAYS)       | admin
+        new RetentionTime(1, DAYS)       | regularUser
+        new RetentionTime(7, DAYS)       | admin
+        new RetentionTime(7, DAYS)       | regularUser
+    }
+
+    def "updating topic with over 7 days of retention time should be invalid for regular user"() {
+        given:
+        def existingTopic = topic('group.topic').build()
+        def updatedTopic = topic('group.topic')
+                .withRetentionTime(retentionTime)
+                .build()
+
+        when:
+        topicValidator.ensureUpdatedTopicIsValid(updatedTopic, existingTopic, regularUser)
+
+        then:
+        def exception = thrown(TopicValidationException)
+        exception.message == "Retention time larger than 7 days can't be configured by non admin users"
+
+        where:
+        retentionTime << [
+                new RetentionTime(8, DAYS),
+                new RetentionTime(7 * 24 + 1, HOURS),
+                new RetentionTime(7 * 24 * 60 + 1, MINUTES),
+                new RetentionTime(7 * 24 * 60 * 60 + 1, SECONDS)
+        ]
+    }
+
+    def "updating topic with 8 days retention time should be valid for admin"() {
+        given:
+        def existingTopic = topic('group.topic').build()
+        def updatedTopic = topic('group.topic')
+                .withRetentionTime(retentionTime)
+                .build()
+
+        when:
+        topicValidator.ensureUpdatedTopicIsValid(updatedTopic, existingTopic, admin)
+
+        then:
+        noExceptionThrown()
+
+        where:
+        retentionTime << [
+                new RetentionTime(8, DAYS),
+                new RetentionTime(7 * 24 + 1, HOURS),
+                new RetentionTime(7 * 24 * 60 + 1, MINUTES),
+                new RetentionTime(7 * 24 * 60 * 60 + 1, SECONDS)
+        ]
+    }
+
+    def "updating topic without modifying retention time already exceeding maximum should be valid"() {
+        given:
+        def existingTopic = topic('group.topic')
+                .withRetentionTime(new RetentionTime(8, DAYS))
+                .build()
+        def updatedTopic = topic('group.topic')
+                .withRetentionTime(new RetentionTime(8, DAYS))
+                .withDescription("lorem ipsum")
                 .build()
 
         when:
@@ -90,25 +198,32 @@ class TopicValidatorWithRealApiPreconditionsTest extends Specification {
         user << [regularUser, admin]
     }
 
-    def "updating topic with 8 days retention time should be invalid for regular user"() {
+    def "updating topic with modifying retention time already exceeding maximum should be invalid for regular user"() {
         given:
-        def existingTopic = topic('group.topic').build()
+        def existingTopic = topic('group.topic')
+                .withRetentionTime(new RetentionTime(8, DAYS))
+                .build()
         def updatedTopic = topic('group.topic')
-                .withRetentionTime(retentionTime8Days)
+                .withRetentionTime(new RetentionTime(12, DAYS))
+                .withDescription("lorem ipsum")
                 .build()
 
         when:
         topicValidator.ensureUpdatedTopicIsValid(updatedTopic, existingTopic, regularUser)
 
         then:
-        thrown ConstraintViolationException
+        def exception = thrown(TopicValidationException)
+        exception.message == "Retention time larger than 7 days can't be configured by non admin users"
     }
 
-    def "updating topic with 8 days retention time should be valid for admin"() {
+    def "updating topic with modifying retention time already exceeding maximum should be valid for admin"() {
         given:
-        def existingTopic = topic('group.topic').build()
+        def existingTopic = topic('group.topic')
+                .withRetentionTime(new RetentionTime(8, DAYS))
+                .build()
         def updatedTopic = topic('group.topic')
-                .withRetentionTime(retentionTime8Days)
+                .withRetentionTime(new RetentionTime(12, DAYS))
+                .withDescription("lorem ipsum")
                 .build()
 
         when:
@@ -116,5 +231,27 @@ class TopicValidatorWithRealApiPreconditionsTest extends Specification {
 
         then:
         noExceptionThrown()
+    }
+
+    @Unroll
+    def "creating a topic with timeUnit smaller than seconds should be invalid"() {
+        given:
+        def topic = topic('group.topic')
+                .withRetentionTime(retentionTime)
+                .build()
+
+        when:
+        topicValidator.ensureCreatedTopicIsValid(topic, regularUser, MANAGEABLE)
+
+        then:
+        def exception = thrown(TopicValidationException)
+        exception.message == "Retention time unit must be one of: [SECONDS, MINUTES, HOURS, DAYS]"
+
+        where:
+        retentionTime << [
+                new RetentionTime(1, TimeUnit.MICROSECONDS),
+                new RetentionTime(1, TimeUnit.MILLISECONDS),
+                new RetentionTime(1, TimeUnit.NANOSECONDS)
+        ]
     }
 }

--- a/integration-tests/src/integrationTest/java/pl/allegro/tech/hermes/integrationtests/management/SubscriptionManagementTest.java
+++ b/integration-tests/src/integrationTest/java/pl/allegro/tech/hermes/integrationtests/management/SubscriptionManagementTest.java
@@ -645,46 +645,6 @@ public class SubscriptionManagementTest {
     }
 
     @Test
-    public void shouldNotAllowNonAdminUserToSetInflightSize() {
-        // given
-        Topic topic = hermes.initHelper().createTopic(topicWithRandomName().build());
-        Subscription subscription = hermes.initHelper().createSubscription(subscriptionWithRandomName(topic.getName()).build());
-        TestSecurityProvider.setUserIsAdmin(false);
-
-        PatchData patchData = patchData().set("subscriptionPolicy", ImmutableMap.builder()
-                .put("inflightSize", 100)
-                .build()
-        ).build();
-
-        // when
-        WebTestClient.ResponseSpec response = hermes.api().updateSubscription(topic, subscription.getName(), patchData);
-
-        //then
-        response.expectStatus().isBadRequest();
-        assertThat(response.expectBody(String.class).returnResult().getResponseBody())
-                .contains("Subscription.serialSubscriptionPolicy.inflightSize must be null");
-    }
-
-    @Test
-    public void shouldAllowAdminUserToSetInflightSize() {
-        // given
-        Topic topic = hermes.initHelper().createTopic(topicWithRandomName().build());
-        Subscription subscription = hermes.initHelper().createSubscription(subscriptionWithRandomName(topic.getName()).build());
-        TestSecurityProvider.setUserIsAdmin(true);
-
-        PatchData patchData = patchData().set("subscriptionPolicy", ImmutableMap.builder()
-                .put("inflightSize", 100)
-                .build()
-        ).build();
-
-        // when
-        WebTestClient.ResponseSpec response = hermes.api().updateSubscription(topic, subscription.getName(), patchData);
-
-        //then
-        response.expectStatus().isOk();
-    }
-
-    @Test
     public void shouldMoveOffsetsToTheEnd() {
         // given
         TestSubscriber subscriber = subscribers.createSubscriber(503);


### PR DESCRIPTION
Allow topics with `retentionTime` exceeding maximum and subscriptions with not null `inflightSize` to be modifiable by regular users. Previously if admin set a value of one of those fields to admin-only value it made the topic / subscription uneditable by regular users.

 