### PR TITLE
allow configuration of default value for remoteDatacenterFallbackEnabled

### DIFF
--- a/hermes-api/src/main/java/pl/allegro/tech/hermes/api/Topic.java
+++ b/hermes-api/src/main/java/pl/allegro/tech/hermes/api/Topic.java
@@ -37,7 +37,8 @@ public class Topic {
     private boolean jsonToAvroDryRunEnabled = false;
     @NotNull
     private Ack ack;
-    private boolean fallbackToRemoteDatacenterEnabled;
+    public static final String DEFAULT_FALLBACK_TO_REMOTE_DATACENTER_KEY = "defaultFallbackToRemoteDatacenterEnabled";
+    private final boolean fallbackToRemoteDatacenterEnabled;
     private PublishingChaosPolicy chaos;
     @NotNull
     private ContentType contentType;
@@ -58,8 +59,10 @@ public class Topic {
     private Instant modifiedAt;
 
     public Topic(TopicName name, String description, OwnerId owner, RetentionTime retentionTime,
-                 boolean migratedFromJsonType, Ack ack, boolean fallbackToRemoteDatacenterEnabled, PublishingChaosPolicy chaos,
-                 boolean trackingEnabled, ContentType contentType, boolean jsonToAvroDryRunEnabled,
+                 boolean migratedFromJsonType, Ack ack,
+                 @JacksonInject(value = DEFAULT_FALLBACK_TO_REMOTE_DATACENTER_KEY, useInput = OptBoolean.TRUE)
+                 Boolean fallbackToRemoteDatacenterEnabled,
+                 PublishingChaosPolicy chaos, boolean trackingEnabled, ContentType contentType, boolean jsonToAvroDryRunEnabled,
                  @JacksonInject(value = DEFAULT_SCHEMA_ID_SERIALIZATION_ENABLED_KEY, useInput = OptBoolean.TRUE)
                  Boolean schemaIdAwareSerializationEnabled,
                  int maxMessageSize, PublishingAuth publishingAuth, boolean subscribingRestricted,
@@ -93,7 +96,8 @@ public class Topic {
             @JsonProperty("retentionTime") RetentionTime retentionTime,
             @JsonProperty("jsonToAvroDryRun") boolean jsonToAvroDryRunEnabled,
             @JsonProperty("ack") Ack ack,
-            @JsonProperty("fallbackToRemoteDatacenterEnabled") boolean fallbackToRemoteDatacenterEnabled,
+            @JacksonInject(value = DEFAULT_FALLBACK_TO_REMOTE_DATACENTER_KEY, useInput = OptBoolean.TRUE)
+            @JsonProperty("fallbackToRemoteDatacenterEnabled") Boolean fallbackToRemoteDatacenterEnabled,
             @JsonProperty("chaos") PublishingChaosPolicy chaos,
             @JsonProperty("trackingEnabled") boolean trackingEnabled,
             @JsonProperty("migratedFromJsonType") boolean migratedFromJsonType,

--- a/hermes-api/src/main/java/pl/allegro/tech/hermes/api/TopicWithSchema.java
+++ b/hermes-api/src/main/java/pl/allegro/tech/hermes/api/TopicWithSchema.java
@@ -32,7 +32,9 @@ public class TopicWithSchema extends Topic {
                            @JsonProperty("retentionTime") RetentionTime retentionTime,
                            @JsonProperty("jsonToAvroDryRun") boolean jsonToAvroDryRunEnabled,
                            @JsonProperty("ack") Ack ack,
-                           @JsonProperty("fallbackToRemoteDatacenterEnabled") boolean fallbackToRemoteDatacenterEnabled,
+                           @JsonProperty("fallbackToRemoteDatacenterEnabled")
+                           @JacksonInject(value = DEFAULT_FALLBACK_TO_REMOTE_DATACENTER_KEY, useInput = OptBoolean.TRUE)
+                           boolean fallbackToRemoteDatacenterEnabled,
                            @JsonProperty("chaos") PublishingChaosPolicy chaos,
                            @JsonProperty("trackingEnabled") boolean trackingEnabled,
                            @JsonProperty("migratedFromJsonType") boolean migratedFromJsonType,

--- a/hermes-api/src/test/java/pl/allegro/tech/hermes/api/TopicTest.java
+++ b/hermes-api/src/test/java/pl/allegro/tech/hermes/api/TopicTest.java
@@ -9,7 +9,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class TopicTest {
 
-    private final ObjectMapper objectMapper = createObjectMapper();
+    private final ObjectMapper objectMapper = createObjectMapper(false);
 
     @Test
     public void shouldDeserializeTopicWithDefaults() throws Exception {
@@ -65,11 +65,42 @@ public class TopicTest {
         assertThat(topic.getName().getName()).isEqualTo("bar");
     }
 
-    private ObjectMapper createObjectMapper() {
+    @Test
+    public void shouldDeserializeFallbackToRemoteDatacenterWithDefaults() throws Exception {
+        // given
+        String json = "{\"name\":\"foo.bar\", \"description\": \"description\"}";
+
+        // when
+        Topic topic = objectMapper.readValue(json, Topic.class);
+
+        // then
+        assertThat(topic.isFallbackToRemoteDatacenterEnabled()).isEqualTo(false);
+
+        // and when
+        Topic topic2 = createObjectMapper(true).readValue(json, Topic.class);
+
+        // then
+        assertThat(topic2.isFallbackToRemoteDatacenterEnabled()).isEqualTo(true);
+    }
+
+    @Test
+    public void shouldDeserializeFallbackToRemoteDatacenter() throws Exception {
+        // given
+        String json = "{\"name\":\"foo.bar\", \"description\": \"description\", \"fallbackToRemoteDatacenterEnabled\": true}";
+
+        // when
+        Topic topic = objectMapper.readValue(json, Topic.class);
+
+        // then
+        assertThat(topic.isFallbackToRemoteDatacenterEnabled()).isEqualTo(true);
+    }
+
+    private ObjectMapper createObjectMapper(boolean fallbackToRemoteDatacenterEnabled) {
         ObjectMapper mapper = new ObjectMapper();
 
         final InjectableValues defaultSchemaIdAwareSerializationEnabled = new InjectableValues
-            .Std().addValue(Topic.DEFAULT_SCHEMA_ID_SERIALIZATION_ENABLED_KEY, true);
+            .Std().addValue(Topic.DEFAULT_SCHEMA_ID_SERIALIZATION_ENABLED_KEY, true)
+                .addValue(Topic.DEFAULT_FALLBACK_TO_REMOTE_DATACENTER_KEY, fallbackToRemoteDatacenterEnabled);
 
         mapper.setInjectableValues(defaultSchemaIdAwareSerializationEnabled);
         mapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);

--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/common/di/factories/ObjectMapperFactory.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/common/di/factories/ObjectMapperFactory.java
@@ -11,9 +11,11 @@ import pl.allegro.tech.hermes.api.Topic;
 public class ObjectMapperFactory {
 
     private final boolean schemaIdSerializationEnabled;
+    private final boolean fallbackToRemoteDatacenterEnabled;
 
-    public ObjectMapperFactory(boolean schemaIdSerializationEnabled) {
+    public ObjectMapperFactory(boolean schemaIdSerializationEnabled, boolean fallbackToRemoteDatacenterEnabled) {
         this.schemaIdSerializationEnabled = schemaIdSerializationEnabled;
+        this.fallbackToRemoteDatacenterEnabled = fallbackToRemoteDatacenterEnabled;
     }
 
     public ObjectMapper provide() {
@@ -23,8 +25,9 @@ public class ObjectMapperFactory {
         objectMapper.disable(SerializationFeature.WRITE_NULL_MAP_VALUES);
         objectMapper.registerModule(new JavaTimeModule());
 
-        final InjectableValues defaultSchemaIdAwareSerializationEnabled = new InjectableValues
-                .Std().addValue(Topic.DEFAULT_SCHEMA_ID_SERIALIZATION_ENABLED_KEY, schemaIdSerializationEnabled);
+        final InjectableValues defaultSchemaIdAwareSerializationEnabled = new InjectableValues.Std()
+                .addValue(Topic.DEFAULT_SCHEMA_ID_SERIALIZATION_ENABLED_KEY, schemaIdSerializationEnabled)
+                .addValue(Topic.DEFAULT_FALLBACK_TO_REMOTE_DATACENTER_KEY, fallbackToRemoteDatacenterEnabled);
         objectMapper.setInjectableValues(defaultSchemaIdAwareSerializationEnabled);
 
         return objectMapper;

--- a/hermes-common/src/test/groovy/pl/allegro/tech/hermes/test/IntegrationTest.groovy
+++ b/hermes-common/src/test/groovy/pl/allegro/tech/hermes/test/IntegrationTest.groovy
@@ -31,7 +31,7 @@ abstract class IntegrationTest extends Specification {
 
     protected RepositoryWaiter wait = new RepositoryWaiter(zookeeperResource.curator(), paths)
 
-    protected ObjectMapper mapper = new ObjectMapperFactory(true).provide()
+    protected ObjectMapper mapper = new ObjectMapperFactory(true, false).provide()
 
     protected ZookeeperGroupRepository groupRepository = new ZookeeperGroupRepository(zookeeper(), mapper, paths)
 

--- a/hermes-common/src/test/java/pl/allegro/tech/hermes/common/di/ObjectMapperFactoryTest.java
+++ b/hermes-common/src/test/java/pl/allegro/tech/hermes/common/di/ObjectMapperFactoryTest.java
@@ -14,7 +14,7 @@ public class ObjectMapperFactoryTest {
 
     @Before
     public void init() {
-        ObjectMapperFactory factory = new ObjectMapperFactory(false);
+        ObjectMapperFactory factory = new ObjectMapperFactory(false, false);
         mapper = factory.provide();
     }
 

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/config/CommonConfiguration.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/config/CommonConfiguration.java
@@ -176,7 +176,11 @@ public class CommonConfiguration {
 
     @Bean
     public ObjectMapper objectMapper(SchemaProperties schemaProperties) {
-        return new ObjectMapperFactory(schemaProperties.isIdSerializationEnabled()).provide();
+        return new ObjectMapperFactory(
+                schemaProperties.isIdSerializationEnabled(),
+                /* fallbackToRemoteDatacenter is frontend specific property, we so don't expose consumer side property for it */
+                false
+        ).provide();
     }
 
 

--- a/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/config/CommonConfiguration.java
+++ b/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/config/CommonConfiguration.java
@@ -83,7 +83,8 @@ import static io.micrometer.core.instrument.Clock.SYSTEM;
         ZookeeperClustersProperties.class,
         KafkaClustersProperties.class,
         ContentRootProperties.class,
-        DatacenterNameProperties.class
+        DatacenterNameProperties.class,
+        TopicDefaultsProperties.class
 })
 public class CommonConfiguration {
 
@@ -183,8 +184,8 @@ public class CommonConfiguration {
     }
 
     @Bean
-    public ObjectMapper objectMapper(SchemaProperties schemaProperties) {
-        return new ObjectMapperFactory(schemaProperties.isIdSerializationEnabled()).provide();
+    public ObjectMapper objectMapper(SchemaProperties schemaProperties, TopicDefaultsProperties topicDefaults) {
+        return new ObjectMapperFactory(schemaProperties.isIdSerializationEnabled(), topicDefaults.isFallbackToRemoteDatacenterEnabled()).provide();
     }
 
     @Bean

--- a/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/config/TopicDefaultsProperties.java
+++ b/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/config/TopicDefaultsProperties.java
@@ -1,0 +1,16 @@
+package pl.allegro.tech.hermes.frontend.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "frontend.topic.defaults")
+public class TopicDefaultsProperties {
+    private boolean fallbackToRemoteDatacenterEnabled = false;
+
+    public boolean isFallbackToRemoteDatacenterEnabled() {
+        return fallbackToRemoteDatacenterEnabled;
+    }
+
+    public void setFallbackToRemoteDatacenterEnabled(boolean fallbackToRemoteDatacenterEnabled) {
+        this.fallbackToRemoteDatacenterEnabled = fallbackToRemoteDatacenterEnabled;
+    }
+}

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/config/ManagementConfiguration.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/config/ManagementConfiguration.java
@@ -46,7 +46,8 @@ public class ManagementConfiguration {
 
         final InjectableValues defaultSchemaIdAwareSerializationEnabled = new InjectableValues.Std().addValue(
                 Topic.DEFAULT_SCHEMA_ID_SERIALIZATION_ENABLED_KEY,
-                topicProperties.isDefaultSchemaIdAwareSerializationEnabled());
+                topicProperties.isDefaultSchemaIdAwareSerializationEnabled())
+                .addValue(Topic.DEFAULT_FALLBACK_TO_REMOTE_DATACENTER_KEY, topicProperties.isDefaultFallbackToRemoteDatacenterEnabled());
 
         mapper.setInjectableValues(defaultSchemaIdAwareSerializationEnabled);
 

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/config/TopicProperties.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/config/TopicProperties.java
@@ -34,6 +34,8 @@ public class TopicProperties {
 
     private boolean defaultSchemaIdAwareSerializationEnabled = false;
 
+    private boolean defaultFallbackToRemoteDatacenterEnabled = false;
+
     private boolean avroContentTypeMetadataRequired = true;
 
     /**
@@ -153,6 +155,14 @@ public class TopicProperties {
 
     public void setDefaultSchemaIdAwareSerializationEnabled(boolean defaultSchemaIdAwareSerializationEnabled) {
         this.defaultSchemaIdAwareSerializationEnabled = defaultSchemaIdAwareSerializationEnabled;
+    }
+
+    public boolean isDefaultFallbackToRemoteDatacenterEnabled() {
+        return defaultFallbackToRemoteDatacenterEnabled;
+    }
+
+    public void setDefaultFallbackToRemoteDatacenterEnabled(boolean defaultFallbackToRemoteDatacenterEnabled) {
+        this.defaultFallbackToRemoteDatacenterEnabled = defaultFallbackToRemoteDatacenterEnabled;
     }
 
     public boolean isAvroContentTypeMetadataRequired() {

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/domain/topic/TopicService.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/domain/topic/TopicService.java
@@ -5,7 +5,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-import pl.allegro.tech.hermes.api.ContentType;
 import pl.allegro.tech.hermes.api.MessageTextPreview;
 import pl.allegro.tech.hermes.api.OwnerId;
 import pl.allegro.tech.hermes.api.PatchData;

--- a/integration-tests/src/integrationTest/java/pl/allegro/tech/hermes/integrationtests/management/TopicManagementTest.java
+++ b/integration-tests/src/integrationTest/java/pl/allegro/tech/hermes/integrationtests/management/TopicManagementTest.java
@@ -766,6 +766,22 @@ public class TopicManagementTest {
     }
 
     @Test
+    public void shouldNotAllowNonAdminUserToEnableChaos2() {
+        // given
+        Topic topic = hermes.initHelper().createTopic(topicWithRandomName().withFallbackToRemoteDatacenterEnabled().build());
+        TestSecurityProvider.setUserIsAdmin(false);
+        PatchData patchData = PatchData.from(ImmutableMap.of("description", "a"));
+
+        // when
+        WebTestClient.ResponseSpec response = hermes.api().updateTopic(topic.getQualifiedName(), patchData);
+
+        //then
+        response.expectStatus().isOk();
+        Topic t = hermes.api().getTopicResponse(topic.getQualifiedName()).returnResult(Topic.class).getResponseBody().blockFirst();
+        System.out.println("Aaa");
+    }
+
+    @Test
     public void shouldAllowAdminUserToEnableChaos() {
         // given
         Topic topic = hermes.initHelper().createTopic(topicWithRandomName().build());

--- a/integration-tests/src/integrationTest/java/pl/allegro/tech/hermes/integrationtests/management/TopicManagementTest.java
+++ b/integration-tests/src/integrationTest/java/pl/allegro/tech/hermes/integrationtests/management/TopicManagementTest.java
@@ -766,22 +766,6 @@ public class TopicManagementTest {
     }
 
     @Test
-    public void shouldNotAllowNonAdminUserToEnableChaos2() {
-        // given
-        Topic topic = hermes.initHelper().createTopic(topicWithRandomName().withFallbackToRemoteDatacenterEnabled().build());
-        TestSecurityProvider.setUserIsAdmin(false);
-        PatchData patchData = PatchData.from(ImmutableMap.of("description", "a"));
-
-        // when
-        WebTestClient.ResponseSpec response = hermes.api().updateTopic(topic.getQualifiedName(), patchData);
-
-        //then
-        response.expectStatus().isOk();
-        Topic t = hermes.api().getTopicResponse(topic.getQualifiedName()).returnResult(Topic.class).getResponseBody().blockFirst();
-        System.out.println("Aaa");
-    }
-
-    @Test
     public void shouldAllowAdminUserToEnableChaos() {
         // given
         Topic topic = hermes.initHelper().createTopic(topicWithRandomName().build());


### PR DESCRIPTION
Make a default value for topic property `fallbackToRemoteDatacenterEnabled` configurable via:

- `topic.defaultFallbackToRemoteDatacenterEnabled` for management
-  `frontend.topic.defaults.fallbackToRemoteDatacenterEnabled` for frontend 

This will enable configuring whether newly created topics and topics with missing property should have fallback turned on by default or not.