### PR TITLE
Allow for 'empty' broadcast send attempt

### DIFF
--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/Message.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/Message.java
@@ -138,6 +138,10 @@ public class Message implements FilterableMessage {
         return id;
     }
 
+    public synchronized Set<String> getSucceededUris() {
+        return succeededUris;
+    }
+
     @Override
     public Map<String, String> getExternalMetadata() {
         return externalMetadata;


### PR DESCRIPTION
This PR implements a fix for a bug that would cause a broadcast message to be undeliverable. Consider a following scenario:

1. Message is being sent to service `A` with instances `A1`, `A2` and `A3`
2. Message is sent successfully to instances `A1` and `A2` but fails to be delivered to `A3`
3. Sent is being retried
4. The set of instances changes to just `A1` and `A2` (perhaps there was ongoing rolling upgrade and `A3` was terminated)

Previously, when that situation occurred the message would be retried until its TTL expired - `A1` and `A2` were already marked as succeeded and so they were not added to `children` of `MultiMessageSendingResult`. `children` was an empty list which was considered a failure so the message was retried. This would go on as long as the set of uris returned from `EndpointAddressResolver` equals the set of `succeededUris` from message.

Starting from this PR `children` will contain sent messages from all attempts so a 'empty' send would not be considered a failure.