### PR TITLE
Improved topic validation

### DIFF
--- a/hermes-management/src/test/groovy/pl/allegro/tech/hermes/management/domain/topic/validator/TopicValidatorTest.groovy
+++ b/hermes-management/src/test/groovy/pl/allegro/tech/hermes/management/domain/topic/validator/TopicValidatorTest.groovy
@@ -32,6 +32,7 @@ class TopicValidatorTest extends Specification {
     def contentTypeWhitelistValidator = Stub(ContentTypeValidator)
     def apiPreconditions = Stub(ApiPreconditions)
     def topicLabelsValidator
+    def topicProperties = new TopicProperties()
 
     @Subject
     TopicValidator topicValidator
@@ -42,7 +43,7 @@ class TopicValidatorTest extends Specification {
         topicProperties.setAllowedTopicLabels(allowedLabels)
         topicLabelsValidator = new TopicLabelsValidator(topicProperties)
 
-        topicValidator = new TopicValidator(ownerDescriptorValidator, contentTypeWhitelistValidator, topicLabelsValidator, schemaRepository, apiPreconditions)
+        topicValidator = new TopicValidator(ownerDescriptorValidator, contentTypeWhitelistValidator, topicLabelsValidator, schemaRepository, apiPreconditions, topicProperties)
     }
 
     def "topic with basic properties when creating should be valid"() {

--- a/hermes-management/src/test/groovy/pl/allegro/tech/hermes/management/domain/topic/validator/TopicValidatorWithRealApiPreconditionsTest.groovy
+++ b/hermes-management/src/test/groovy/pl/allegro/tech/hermes/management/domain/topic/validator/TopicValidatorWithRealApiPreconditionsTest.groovy
@@ -2,6 +2,7 @@ package pl.allegro.tech.hermes.management.domain.topic.validator
 
 import pl.allegro.tech.hermes.api.RetentionTime
 import pl.allegro.tech.hermes.management.api.validator.ApiPreconditions
+import pl.allegro.tech.hermes.management.config.TopicProperties
 import pl.allegro.tech.hermes.management.domain.auth.TestRequestUser
 import pl.allegro.tech.hermes.management.domain.owner.validator.OwnerIdValidator
 import pl.allegro.tech.hermes.schema.SchemaRepository
@@ -27,9 +28,10 @@ class TopicValidatorWithRealApiPreconditionsTest extends Specification {
     def ownerDescriptorValidator = Stub(OwnerIdValidator)
     def contentTypeWhitelistValidator = Stub(ContentTypeValidator)
     def topicLabelsValidator = Stub(TopicLabelsValidator)
+    def topicProperties = new TopicProperties()
 
     @Subject
-    def topicValidator = new TopicValidator(ownerDescriptorValidator, contentTypeWhitelistValidator, topicLabelsValidator, schemaRepository, new ApiPreconditions())
+    def topicValidator = new TopicValidator(ownerDescriptorValidator, contentTypeWhitelistValidator, topicLabelsValidator, schemaRepository, new ApiPreconditions(), topicProperties)
 
     @Unroll
     def "creating and updating topic with up to 7 days retention time should be valid"() {

--- a/integration-tests/src/integrationTest/java/pl/allegro/tech/hermes/integrationtests/management/TopicManagementTest.java
+++ b/integration-tests/src/integrationTest/java/pl/allegro/tech/hermes/integrationtests/management/TopicManagementTest.java
@@ -603,7 +603,7 @@ public class TopicManagementTest {
     }
 
     @Test
-    public void shouldNotAllowNonAdminUserCreateTopicWithFallbackToRemoteDatacenterEnabled() {
+    public void shouldNotAllowNonAdminUserCreateTopicWithNonDefaultFallbackToRemoteDatacenter() {
         // given
         TestSecurityProvider.setUserIsAdmin(false);
         TopicWithSchema topic = topicWithSchema(
@@ -619,11 +619,11 @@ public class TopicManagementTest {
         //then
         response.expectStatus().isBadRequest();
         assertThat(response.expectBody(String.class).returnResult().getResponseBody())
-                .contains("User is not allowed to enable fallback to remote datacenter");
+                .contains("User is not allowed to set non-default fallback to remote datacenter");
     }
 
     @Test
-    public void shouldAllowAdminUserCreateTopicWithFallbackToRemoteDatacenterEnabled() {
+    public void shouldAllowAdminUserCreateTopicWithNonDefaultFallbackToRemoteDatacenterEnabled() {
         // given
         TestSecurityProvider.setUserIsAdmin(true);
         TopicWithSchema topic = topicWithSchema(
@@ -641,11 +641,12 @@ public class TopicManagementTest {
     }
 
     @Test
-    public void shouldNotAllowNonAdminUserToEnableFallbackToRemoteDatacenter() {
+    public void shouldNotAllowNonAdminUserToChangeFallbackToRemoteDatacenter() {
         // given
-        Topic topic = hermes.initHelper().createTopic(topicWithRandomName().build());
+        Topic topic = hermes.initHelper().createTopic(topicWithRandomName()
+                .withFallbackToRemoteDatacenterEnabled().build());
         TestSecurityProvider.setUserIsAdmin(false);
-        PatchData patchData = PatchData.from(ImmutableMap.of("fallbackToRemoteDatacenterEnabled", true));
+        PatchData patchData = PatchData.from(ImmutableMap.of("fallbackToRemoteDatacenterEnabled", false));
 
         // when
         WebTestClient.ResponseSpec response = hermes.api().updateTopic(topic.getQualifiedName(), patchData);
@@ -653,15 +654,17 @@ public class TopicManagementTest {
         //then
         response.expectStatus().isBadRequest();
         assertThat(response.expectBody(String.class).returnResult().getResponseBody())
-                .contains("User is not allowed to enable fallback to remote datacenter");
+                .contains("User is not allowed to update fallback to remote datacenter for this topic");
     }
 
     @Test
-    public void shouldAllowAdminUserToEnableFallbackToRemoteDatacenter() {
+    public void shouldAllowAdminUserToChangeFallbackToRemoteDatacenter() {
         // given
-        Topic topic = hermes.initHelper().createTopic(topicWithRandomName().build());
+        Topic topic = hermes.initHelper().createTopic(topicWithRandomName()
+                .withFallbackToRemoteDatacenterEnabled()
+                .build());
         TestSecurityProvider.setUserIsAdmin(true);
-        PatchData patchData = PatchData.from(ImmutableMap.of("fallbackToRemoteDatacenterEnabled", true));
+        PatchData patchData = PatchData.from(ImmutableMap.of("fallbackToRemoteDatacenterEnabled", false));
 
         // when
         WebTestClient.ResponseSpec response = hermes.api().updateTopic(topic.getQualifiedName(), patchData);


### PR DESCRIPTION
- Allow regular users to only use default value of fallbackToRemoteDatacenterEnabled when creating topic
- Do not allow users to modify fallbackToRemoteDatacenterEnabled on existing topic