### PR TITLE
do not remove subscription if it already existed before subscription creation

### DIFF
--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/domain/blacklist/commands/AddTopicToBlacklistRepositoryCommand.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/domain/blacklist/commands/AddTopicToBlacklistRepositoryCommand.java
@@ -21,7 +21,7 @@ public class AddTopicToBlacklistRepositoryCommand extends RepositoryCommand<Topi
     }
 
     @Override
-    public void rollback(DatacenterBoundRepositoryHolder<TopicBlacklistRepository> holder) {
+    public void rollback(DatacenterBoundRepositoryHolder<TopicBlacklistRepository> holder, Exception exception) {
         holder.getRepository().remove(qualifiedTopicName);
     }
 

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/domain/blacklist/commands/RemoveTopicFromBlacklistRepositoryCommand.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/domain/blacklist/commands/RemoveTopicFromBlacklistRepositoryCommand.java
@@ -23,7 +23,7 @@ public class RemoveTopicFromBlacklistRepositoryCommand extends RepositoryCommand
     }
 
     @Override
-    public void rollback(DatacenterBoundRepositoryHolder<TopicBlacklistRepository> holder) {
+    public void rollback(DatacenterBoundRepositoryHolder<TopicBlacklistRepository> holder, Exception exception) {
         if (exists) {
             holder.getRepository().add(qualifiedTopicName);
         }

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/domain/credentials/commands/UpdateCredentialsRepositoryCommand.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/domain/credentials/commands/UpdateCredentialsRepositoryCommand.java
@@ -24,7 +24,7 @@ public class UpdateCredentialsRepositoryCommand extends RepositoryCommand<Creden
     }
 
     @Override
-    public void rollback(DatacenterBoundRepositoryHolder<CredentialsRepository> holder) {
+    public void rollback(DatacenterBoundRepositoryHolder<CredentialsRepository> holder, Exception exception) {
     }
 
     @Override

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/domain/dc/MultiDatacenterRepositoryCommandExecutor.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/domain/dc/MultiDatacenterRepositoryCommandExecutor.java
@@ -55,7 +55,7 @@ public class MultiDatacenterRepositoryCommandExecutor {
             } catch (RepositoryNotAvailableException e) {
                 logger.warn("Execute failed with an RepositoryNotAvailableException error", e);
                 if (isRollbackEnabled) {
-                    rollback(executedRepoHolders, command);
+                    rollback(executedRepoHolders, command, e);
                 }
                 if (shouldStopExecutionOnFailure) {
                     throw ExceptionWrapper.wrapInInternalProcessingExceptionIfNeeded(e, command.toString(), repoHolder.getDatacenterName());
@@ -63,19 +63,19 @@ public class MultiDatacenterRepositoryCommandExecutor {
             } catch (Exception e) {
                 logger.warn("Failed to execute repository command: {} in ZK dc: {} in: {} ms", command, repoHolder.getDatacenterName(), System.currentTimeMillis() - start, e);
                 if (isRollbackEnabled) {
-                    rollback(executedRepoHolders, command);
+                    rollback(executedRepoHolders, command, e);
                 }
                 throw ExceptionWrapper.wrapInInternalProcessingExceptionIfNeeded(e, command.toString(), repoHolder.getDatacenterName());
             }
         }
     }
 
-    private <T> void rollback(List<DatacenterBoundRepositoryHolder<T>> repoHolders, RepositoryCommand<T> command) {
+    private <T> void rollback(List<DatacenterBoundRepositoryHolder<T>> repoHolders, RepositoryCommand<T> command, Exception exception) {
         long start = System.currentTimeMillis();
         for (DatacenterBoundRepositoryHolder<T> repoHolder : repoHolders) {
             logger.info("Executing rollback of repository command: {} in ZK dc: {}", command, repoHolder.getDatacenterName());
             try {
-                command.rollback(repoHolder);
+                command.rollback(repoHolder, exception);
                 logger.info("Successfully executed rollback of repository command: {} in ZK dc: {} in: {} ms", command, repoHolder.getDatacenterName(), System.currentTimeMillis() - start);
             } catch (Exception e) {
                 logger.error("Rollback procedure failed for command {} on DC {}", command, repoHolder.getDatacenterName(), e);

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/domain/dc/RepositoryCommand.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/domain/dc/RepositoryCommand.java
@@ -6,7 +6,7 @@ public abstract class RepositoryCommand<T> {
 
     public abstract void execute(DatacenterBoundRepositoryHolder<T> holder);
 
-    public abstract void rollback(DatacenterBoundRepositoryHolder<T> holder);
+    public abstract void rollback(DatacenterBoundRepositoryHolder<T> holder, Exception exception);
 
     public abstract Class<T> getRepositoryType();
 

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/domain/group/commands/CreateGroupRepositoryCommand.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/domain/group/commands/CreateGroupRepositoryCommand.java
@@ -25,7 +25,7 @@ public class CreateGroupRepositoryCommand extends RepositoryCommand<GroupReposit
     }
 
     @Override
-    public void rollback(DatacenterBoundRepositoryHolder<GroupRepository> holder) {
+    public void rollback(DatacenterBoundRepositoryHolder<GroupRepository> holder, Exception exception) {
         if (!exists) {
             holder.getRepository().removeGroup(group.getGroupName());
         }

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/domain/group/commands/RemoveGroupRepositoryCommand.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/domain/group/commands/RemoveGroupRepositoryCommand.java
@@ -26,7 +26,7 @@ public class RemoveGroupRepositoryCommand extends RepositoryCommand<GroupReposit
     }
 
     @Override
-    public void rollback(DatacenterBoundRepositoryHolder<GroupRepository> holder) {
+    public void rollback(DatacenterBoundRepositoryHolder<GroupRepository> holder, Exception exception) {
         holder.getRepository().createGroup(backup);
     }
 

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/domain/group/commands/UpdateGroupRepositoryCommand.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/domain/group/commands/UpdateGroupRepositoryCommand.java
@@ -26,7 +26,7 @@ public class UpdateGroupRepositoryCommand extends RepositoryCommand<GroupReposit
     }
 
     @Override
-    public void rollback(DatacenterBoundRepositoryHolder<GroupRepository> holder) {
+    public void rollback(DatacenterBoundRepositoryHolder<GroupRepository> holder, Exception exception) {
         holder.getRepository().updateGroup(backup);
     }
 

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/domain/oauth/commands/CreateOAuthProviderRepositoryCommand.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/domain/oauth/commands/CreateOAuthProviderRepositoryCommand.java
@@ -22,7 +22,7 @@ public class CreateOAuthProviderRepositoryCommand extends RepositoryCommand<OAut
     }
 
     @Override
-    public void rollback(DatacenterBoundRepositoryHolder<OAuthProviderRepository> holder) {
+    public void rollback(DatacenterBoundRepositoryHolder<OAuthProviderRepository> holder, Exception exception) {
         holder.getRepository().removeOAuthProvider(provider.getName());
     }
 

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/domain/oauth/commands/RemoveOAuthProviderRepositoryCommand.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/domain/oauth/commands/RemoveOAuthProviderRepositoryCommand.java
@@ -26,7 +26,7 @@ public class RemoveOAuthProviderRepositoryCommand extends RepositoryCommand<OAut
     }
 
     @Override
-    public void rollback(DatacenterBoundRepositoryHolder<OAuthProviderRepository> holder) {
+    public void rollback(DatacenterBoundRepositoryHolder<OAuthProviderRepository> holder, Exception exception) {
         holder.getRepository().createOAuthProvider(backup);
     }
 

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/domain/oauth/commands/UpdateOAuthProviderRepositoryCommand.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/domain/oauth/commands/UpdateOAuthProviderRepositoryCommand.java
@@ -26,7 +26,7 @@ public class UpdateOAuthProviderRepositoryCommand extends RepositoryCommand<OAut
     }
 
     @Override
-    public void rollback(DatacenterBoundRepositoryHolder<OAuthProviderRepository> holder) {
+    public void rollback(DatacenterBoundRepositoryHolder<OAuthProviderRepository> holder, Exception exception) {
         holder.getRepository().updateOAuthProvider(backup);
     }
 

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/domain/readiness/SetReadinessCommand.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/domain/readiness/SetReadinessCommand.java
@@ -22,7 +22,7 @@ public class SetReadinessCommand extends RepositoryCommand<DatacenterReadinessRe
     }
 
     @Override
-    public void rollback(DatacenterBoundRepositoryHolder<DatacenterReadinessRepository> holder) { }
+    public void rollback(DatacenterBoundRepositoryHolder<DatacenterReadinessRepository> holder, Exception exception) { }
 
     @Override
     public Class<DatacenterReadinessRepository> getRepositoryType() {

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/domain/retransmit/CreateOfflineRetransmissionTaskCommand.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/domain/retransmit/CreateOfflineRetransmissionTaskCommand.java
@@ -21,7 +21,7 @@ class CreateOfflineRetransmissionTaskCommand extends RepositoryCommand<OfflineRe
     }
 
     @Override
-    public void rollback(DatacenterBoundRepositoryHolder<OfflineRetransmissionRepository> holder) {
+    public void rollback(DatacenterBoundRepositoryHolder<OfflineRetransmissionRepository> holder, Exception exception) {
         holder.getRepository().deleteTask(task.getTaskId());
     }
 

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/domain/retransmit/DeleteOfflineRetransmissionTaskCommand.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/domain/retransmit/DeleteOfflineRetransmissionTaskCommand.java
@@ -21,7 +21,7 @@ class DeleteOfflineRetransmissionTaskCommand extends RepositoryCommand<OfflineRe
     }
 
     @Override
-    public void rollback(DatacenterBoundRepositoryHolder<OfflineRetransmissionRepository> holder) {
+    public void rollback(DatacenterBoundRepositoryHolder<OfflineRetransmissionRepository> holder, Exception exception) {
 
     }
 

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/domain/retransmit/RetransmitCommand.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/domain/retransmit/RetransmitCommand.java
@@ -23,7 +23,7 @@ public class RetransmitCommand extends RepositoryCommand<AdminTool> {
     }
 
     @Override
-    public void rollback(DatacenterBoundRepositoryHolder<AdminTool> holder) {
+    public void rollback(DatacenterBoundRepositoryHolder<AdminTool> holder, Exception exception) {
 
     }
 

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/domain/subscription/commands/CreateSubscriptionRepositoryCommand.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/domain/subscription/commands/CreateSubscriptionRepositoryCommand.java
@@ -1,6 +1,7 @@
 package pl.allegro.tech.hermes.management.domain.subscription.commands;
 
 import pl.allegro.tech.hermes.api.Subscription;
+import pl.allegro.tech.hermes.domain.subscription.SubscriptionAlreadyExistsException;
 import pl.allegro.tech.hermes.domain.subscription.SubscriptionRepository;
 import pl.allegro.tech.hermes.management.domain.dc.DatacenterBoundRepositoryHolder;
 import pl.allegro.tech.hermes.management.domain.dc.RepositoryCommand;
@@ -22,7 +23,11 @@ public class CreateSubscriptionRepositoryCommand extends RepositoryCommand<Subsc
     }
 
     @Override
-    public void rollback(DatacenterBoundRepositoryHolder<SubscriptionRepository> holder) {
+    public void rollback(DatacenterBoundRepositoryHolder<SubscriptionRepository> holder, Exception exception) {
+        if (exception instanceof SubscriptionAlreadyExistsException) {
+            // prevents removal of already existing subscription
+            return;
+        }
         holder.getRepository().removeSubscription(subscription.getTopicName(), subscription.getName());
     }
 

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/domain/subscription/commands/RemoveSubscriptionRepositoryCommand.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/domain/subscription/commands/RemoveSubscriptionRepositoryCommand.java
@@ -30,7 +30,7 @@ public class RemoveSubscriptionRepositoryCommand extends RepositoryCommand<Subsc
     }
 
     @Override
-    public void rollback(DatacenterBoundRepositoryHolder<SubscriptionRepository> holder) {
+    public void rollback(DatacenterBoundRepositoryHolder<SubscriptionRepository> holder, Exception exception) {
         holder.getRepository().createSubscription(backup);
     }
 

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/domain/subscription/commands/UpdateSubscriptionRepositoryCommand.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/domain/subscription/commands/UpdateSubscriptionRepositoryCommand.java
@@ -25,7 +25,7 @@ public class UpdateSubscriptionRepositoryCommand extends RepositoryCommand<Subsc
     }
 
     @Override
-    public void rollback(DatacenterBoundRepositoryHolder<SubscriptionRepository> holder) {
+    public void rollback(DatacenterBoundRepositoryHolder<SubscriptionRepository> holder, Exception exception) {
         holder.getRepository().updateSubscription(backup);
     }
 

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/domain/topic/commands/CreateTopicRepositoryCommand.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/domain/topic/commands/CreateTopicRepositoryCommand.java
@@ -22,7 +22,7 @@ public class CreateTopicRepositoryCommand extends RepositoryCommand<TopicReposit
     }
 
     @Override
-    public void rollback(DatacenterBoundRepositoryHolder<TopicRepository> holder) {
+    public void rollback(DatacenterBoundRepositoryHolder<TopicRepository> holder, Exception exception) {
         /*
         We don't want to do a rollback due to possible race conditions with creating a topic on Kafka.
         It increases the probability of discrepancies between Kafka and Zookeeper: topic exists in Kafka,

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/domain/topic/commands/RemoveTopicRepositoryCommand.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/domain/topic/commands/RemoveTopicRepositoryCommand.java
@@ -22,7 +22,7 @@ public class RemoveTopicRepositoryCommand extends RepositoryCommand<TopicReposit
     }
 
     @Override
-    public void rollback(DatacenterBoundRepositoryHolder<TopicRepository> holder) {
+    public void rollback(DatacenterBoundRepositoryHolder<TopicRepository> holder, Exception exception) {
         /*
         We don't want to do a rollback due to possible race conditions with creating a topic on Kafka.
         It increases the probability of discrepancies between Kafka and Zookeeper: topic exists in Kafka,

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/domain/topic/commands/TouchTopicRepositoryCommand.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/domain/topic/commands/TouchTopicRepositoryCommand.java
@@ -22,7 +22,7 @@ public class TouchTopicRepositoryCommand extends RepositoryCommand<TopicReposito
     }
 
     @Override
-    public void rollback(DatacenterBoundRepositoryHolder<TopicRepository> holder) {}
+    public void rollback(DatacenterBoundRepositoryHolder<TopicRepository> holder, Exception exception) {}
 
     @Override
     public Class<TopicRepository> getRepositoryType() {

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/domain/topic/commands/UpdateTopicRepositoryCommand.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/domain/topic/commands/UpdateTopicRepositoryCommand.java
@@ -26,7 +26,7 @@ public class UpdateTopicRepositoryCommand extends RepositoryCommand<TopicReposit
     }
 
     @Override
-    public void rollback(DatacenterBoundRepositoryHolder<TopicRepository> holder) {
+    public void rollback(DatacenterBoundRepositoryHolder<TopicRepository> holder, Exception exception) {
         holder.getRepository().updateTopic(backup);
     }
 

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/domain/workload/constraints/command/CreateSubscriptionConstraintsRepositoryCommand.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/domain/workload/constraints/command/CreateSubscriptionConstraintsRepositoryCommand.java
@@ -28,7 +28,7 @@ public class CreateSubscriptionConstraintsRepositoryCommand extends RepositoryCo
     }
 
     @Override
-    public void rollback(DatacenterBoundRepositoryHolder<WorkloadConstraintsRepository> holder) {
+    public void rollback(DatacenterBoundRepositoryHolder<WorkloadConstraintsRepository> holder, Exception exception) {
         if (!exists) {
             holder.getRepository().deleteConstraints(subscriptionName);
         }

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/domain/workload/constraints/command/CreateTopicConstraintsRepositoryCommand.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/domain/workload/constraints/command/CreateTopicConstraintsRepositoryCommand.java
@@ -28,7 +28,7 @@ public class CreateTopicConstraintsRepositoryCommand extends RepositoryCommand<W
     }
 
     @Override
-    public void rollback(DatacenterBoundRepositoryHolder<WorkloadConstraintsRepository> holder) {
+    public void rollback(DatacenterBoundRepositoryHolder<WorkloadConstraintsRepository> holder, Exception exception) {
         if (!exist) {
             holder.getRepository().deleteConstraints(topicName);
         }

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/domain/workload/constraints/command/DeleteSubscriptionConstraintsRepositoryCommand.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/domain/workload/constraints/command/DeleteSubscriptionConstraintsRepositoryCommand.java
@@ -26,7 +26,7 @@ public class DeleteSubscriptionConstraintsRepositoryCommand extends RepositoryCo
     }
 
     @Override
-    public void rollback(DatacenterBoundRepositoryHolder<WorkloadConstraintsRepository> holder) {
+    public void rollback(DatacenterBoundRepositoryHolder<WorkloadConstraintsRepository> holder, Exception exception) {
         if (backup != null) {
             holder.getRepository().createConstraints(subscriptionName, backup);
         }

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/domain/workload/constraints/command/DeleteTopicConstraintsRepositoryCommand.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/domain/workload/constraints/command/DeleteTopicConstraintsRepositoryCommand.java
@@ -26,7 +26,7 @@ public class DeleteTopicConstraintsRepositoryCommand extends RepositoryCommand<W
     }
 
     @Override
-    public void rollback(DatacenterBoundRepositoryHolder<WorkloadConstraintsRepository> holder) {
+    public void rollback(DatacenterBoundRepositoryHolder<WorkloadConstraintsRepository> holder, Exception exception) {
         if (backup != null) {
             holder.getRepository().createConstraints(topicName, backup);
         }

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/domain/workload/constraints/command/UpdateSubscriptionConstraintsRepositoryCommand.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/domain/workload/constraints/command/UpdateSubscriptionConstraintsRepositoryCommand.java
@@ -28,7 +28,7 @@ public class UpdateSubscriptionConstraintsRepositoryCommand extends RepositoryCo
     }
 
     @Override
-    public void rollback(DatacenterBoundRepositoryHolder<WorkloadConstraintsRepository> holder) {
+    public void rollback(DatacenterBoundRepositoryHolder<WorkloadConstraintsRepository> holder, Exception exception) {
         if (backup != null) {
             holder.getRepository().updateConstraints(subscriptionName, backup);
         }

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/domain/workload/constraints/command/UpdateTopicConstraintsRepositoryCommand.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/domain/workload/constraints/command/UpdateTopicConstraintsRepositoryCommand.java
@@ -28,7 +28,7 @@ public class UpdateTopicConstraintsRepositoryCommand extends RepositoryCommand<W
     }
 
     @Override
-    public void rollback(DatacenterBoundRepositoryHolder<WorkloadConstraintsRepository> holder) {
+    public void rollback(DatacenterBoundRepositoryHolder<WorkloadConstraintsRepository> holder, Exception exception) {
         if (backup != null) {
             holder.getRepository().updateConstraints(topicName, backup);
         }

--- a/hermes-management/src/test/groovy/pl/allegro/tech/hermes/management/domain/subscription/commands/CreateSubscriptionRepositoryCommandTest.groovy
+++ b/hermes-management/src/test/groovy/pl/allegro/tech/hermes/management/domain/subscription/commands/CreateSubscriptionRepositoryCommandTest.groovy
@@ -1,0 +1,53 @@
+package pl.allegro.tech.hermes.management.domain.subscription.commands
+
+import pl.allegro.tech.hermes.api.Subscription
+import pl.allegro.tech.hermes.api.TopicName
+import pl.allegro.tech.hermes.domain.subscription.SubscriptionAlreadyExistsException
+import pl.allegro.tech.hermes.domain.subscription.SubscriptionRepository
+import pl.allegro.tech.hermes.management.domain.dc.DatacenterBoundRepositoryHolder
+import spock.lang.Shared
+import spock.lang.Specification
+
+import static pl.allegro.tech.hermes.test.helper.builder.SubscriptionBuilder.subscription
+
+class CreateSubscriptionRepositoryCommandTest extends Specification {
+
+    @Shared
+    def topicName = new TopicName("group", "topic")
+
+    @Shared
+    def subscriptionName = "subscription"
+
+    @Shared
+    Subscription subscription = subscription(topicName, subscriptionName).build()
+
+    def "should not remove subscription if subscription already exists during rollback"() {
+        given:
+        SubscriptionRepository subscriptionRepository = Mock(SubscriptionRepository)
+        DatacenterBoundRepositoryHolder<SubscriptionRepository> repository = Mock(DatacenterBoundRepositoryHolder) {
+            getRepository() >> subscriptionRepository
+        }
+        def command = new CreateSubscriptionRepositoryCommand(subscription)
+
+        when:
+        command.rollback(repository, new SubscriptionAlreadyExistsException(subscription))
+
+        then:
+        0 * subscriptionRepository.removeSubscription(topicName, subscriptionName)
+    }
+
+    def "should remove subscription during rollback"() {
+        given:
+        SubscriptionRepository subscriptionRepository = Mock(SubscriptionRepository)
+        DatacenterBoundRepositoryHolder<SubscriptionRepository> repository = Mock(DatacenterBoundRepositoryHolder) {
+            getRepository() >> subscriptionRepository
+        }
+        def command = new CreateSubscriptionRepositoryCommand(subscription)
+
+        when:
+        command.rollback(repository, new RuntimeException())
+
+        then:
+        1 * subscriptionRepository.removeSubscription(topicName, subscriptionName)
+    }
+}


### PR DESCRIPTION
This PR changes rollbacks of multi dc commands to be exception aware and changes `CreateSubscriptionRepositoryCommand` so that subscription is not removed if it already existed before. 

That could happen if two subscription creation requests are made concurrently so that both requests are [marked as valid](https://github.com/allegro/hermes/blob/master/hermes-management/src/main/java/pl/allegro/tech/hermes/management/domain/subscription/validator/SubscriptionValidator.java#L54), one creates subscription in storage and the other fails and performs rollback which causes the subscription to be removed. 

In multi DC setup, this would result in inconsistent state:

dc 1 -> null
dc 2 -> susbscription