### PR TITLE
Synchronize zookeeper clusters with UI

### DIFF
--- a/hermes-console/json-server/db.json
+++ b/hermes-console/json-server/db.json
@@ -91,6 +91,32 @@
       ]
     }
   ],
+  "inconsistentGroups3":[
+    {
+      "name": "pl.allegro.public.group",
+      "inconsistentMetadata": [],
+      "inconsistentTopics": [
+        {
+          "name": "pl.allegro.public.group.DummyEvent",
+          "inconsistentMetadata": [],
+          "inconsistentSubscriptions": [
+            {
+              "name": "pl.allegro.public.group.DummyEvent$foobar-service",
+              "inconsistentMetadata": [
+                {
+                  "datacenter": "DC1"
+                },
+                {
+                  "datacenter": "DC2",
+                  "content": "{\n  \"id\": \"foobar-service\",\n  \"topicName\": \"pl.allegro.public.group.DummyEvent\",\n  \"name\": \"foobar-service\",\n  \"endpoint\": \"service://foobar-service/events/dummy-event\",\n  \"state\": \"ACTIVE\",\n  \"description\": \"Test Hermes endpoint\",\n  \"subscriptionPolicy\": {\n    \"rate\": 10,\n    \"messageTtl\": 60,\n    \"messageBackoff\": 100,\n    \"requestTimeout\": 1000,\n    \"socketTimeout\": 0,\n    \"sendingDelay\": 0,\n    \"backoffMultiplier\": 1.0,\n    \"backoffMaxIntervalInSec\": 600,\n    \"retryClientErrors\": true,\n    \"backoffMaxIntervalMillis\": 600000\n  },\n  \"trackingEnabled\": false,\n  \"trackingMode\": \"trackingOff\",\n  \"owner\": {\n    \"source\": \"Service Catalog\",\n    \"id\": \"42\"\n  },\n  \"monitoringDetails\": {\n    \"severity\": \"NON_IMPORTANT\",\n    \"reaction\": \"\"\n  },\n  \"contentType\": \"JSON\",\n  \"deliveryType\": \"SERIAL\",\n  \"filters\": [\n    {\n      \"type\": \"avropath\",\n      \"path\": \"foobar\",\n      \"matcher\": \"^FOO_BAR$|^BAZ_BAR$\",\n      \"matchingStrategy\": \"any\"\n    },\n    {\n      \"type\": \"avropath\",\n      \"path\": \".foo.bar.baz\",\n      \"matcher\": \"true\",\n      \"matchingStrategy\": \"all\"\n    }\n  ],\n  \"mode\": \"ANYCAST\",\n  \"headers\": [\n    {\n      \"name\": \"X-My-Header\",\n      \"value\": \"boobar\"\n    },\n    {\n      \"name\": \"X-Another-Header\",\n      \"value\": \"foobar\"\n    }\n  ],\n  \"endpointAddressResolverMetadata\": {\n    \"additionalMetadata\": false,\n    \"nonSupportedProperty\": 2\n  },\n  \"http2Enabled\": false,\n  \"subscriptionIdentityHeadersEnabled\": false,\n  \"autoDeleteWithTopicEnabled\": false,\n  \"createdAt\": 1579507131.238,\n  \"modifiedAt\": 1672140855.813\n}"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
   "topicNames": [
     "pl.allegro.public.offer.product.ProductEventV1",
     "pl.allegro.public.offer.product.ProductEventV2",

--- a/hermes-console/json-server/routes.json
+++ b/hermes-console/json-server/routes.json
@@ -3,6 +3,7 @@
   "/consistency/groups": "/consistencyGroups",
   "/consistency/inconsistencies/groups?groupNames=pl.allegro.public.offer*": "/inconsistentGroups",
   "/consistency/inconsistencies/groups?groupNames=pl.allegro.public.group2*": "/inconsistentGroups2",
+  "/consistency/inconsistencies/groups?groupNames=pl.allegro.public.group": "/inconsistentGroups3",
   "/groups": "/groups",
   "/owners/sources/Service%20Catalog/:id": "/topicsOwners/:id",
   "/readiness/datacenters": "/readinessDatacenters",

--- a/hermes-console/json-server/server.ts
+++ b/hermes-console/json-server/server.ts
@@ -88,10 +88,11 @@ server.put(
 );
 
 server.post(
-    '/consistency/sync/topics/pl.allegro.public.group.DummyEvent/subscriptions/barbaz-service*', (req, res) => {
-      res.sendStatus(200)
-    }
-)
+  '/consistency/sync/topics/pl.allegro.public.group.DummyEvent/subscriptions/barbaz-service*',
+  (req, res) => {
+    res.sendStatus(200);
+  },
+);
 
 server.post('/filters/:topic', (req, res) => {
   res.jsonp(filterDebug);

--- a/hermes-console/json-server/server.ts
+++ b/hermes-console/json-server/server.ts
@@ -87,6 +87,12 @@ server.put(
   },
 );
 
+server.post(
+    '/consistency/sync/topics/pl.allegro.public.group.DummyEvent/subscriptions/barbaz-service*', (req, res) => {
+      res.sendStatus(200)
+    }
+)
+
 server.post('/filters/:topic', (req, res) => {
   res.jsonp(filterDebug);
 });

--- a/hermes-console/json-server/server.ts
+++ b/hermes-console/json-server/server.ts
@@ -94,6 +94,15 @@ server.post(
   },
 );
 
+server.post(
+  '/consistency/sync/topics/pl.allegro.public.group.DummyEvent*',
+  (req, res) => {
+    res.status(404).jsonp({
+      message: 'Group pl.allegro.public.group not found',
+    });
+  },
+);
+
 server.post('/filters/:topic', (req, res) => {
   res.jsonp(filterDebug);
 });

--- a/hermes-console/src/api/hermes-client/index.ts
+++ b/hermes-console/src/api/hermes-client/index.ts
@@ -464,3 +464,45 @@ export function verifyFilters(
     },
   );
 }
+
+export function syncGroups(
+  groupName: string,
+  primaryDatacenter: string,
+): ResponsePromise<void> {
+  return axios.post<void>(`/consistency/sync/groups/${groupName}`, null, {
+    params: {
+      primaryDatacenter: primaryDatacenter,
+    },
+  });
+}
+
+export function syncTopics(
+  topicQualifiedName: string,
+  primaryDatacenter: string,
+): ResponsePromise<void> {
+  return axios.post<void>(
+    `/consistency/sync/topics/${topicQualifiedName}`,
+    null,
+    {
+      params: {
+        primaryDatacenter: primaryDatacenter,
+      },
+    },
+  );
+}
+
+export function syncSubscriptions(
+  topicQualifiedName: string,
+  subscriptionName: string,
+  primaryDatacenter: string,
+): ResponsePromise<void> {
+  return axios.post<void>(
+    `/consistency/sync/topics/${topicQualifiedName}/subscriptions/${subscriptionName}`,
+    null,
+    {
+      params: {
+        primaryDatacenter: primaryDatacenter,
+      },
+    },
+  );
+}

--- a/hermes-console/src/api/hermes-client/index.ts
+++ b/hermes-console/src/api/hermes-client/index.ts
@@ -465,7 +465,7 @@ export function verifyFilters(
   );
 }
 
-export function syncGroups(
+export function syncGroup(
   groupName: string,
   primaryDatacenter: string,
 ): ResponsePromise<void> {
@@ -476,7 +476,7 @@ export function syncGroups(
   });
 }
 
-export function syncTopics(
+export function syncTopic(
   topicQualifiedName: string,
   primaryDatacenter: string,
 ): ResponsePromise<void> {
@@ -491,7 +491,7 @@ export function syncTopics(
   );
 }
 
-export function syncSubscriptions(
+export function syncSubscription(
   topicQualifiedName: string,
   subscriptionName: string,
   primaryDatacenter: string,

--- a/hermes-console/src/composables/sync/use-sync/useSync.spec.ts
+++ b/hermes-console/src/composables/sync/use-sync/useSync.spec.ts
@@ -47,7 +47,7 @@ describe('useSync', () => {
     await waitFor(() => {
       expectNotificationDispatched(notificationStore, {
         type: 'error',
-        title: 'notifications.sync.failure',
+        title: 'notifications.consistency.sync.failure',
       });
     });
   });
@@ -70,7 +70,7 @@ describe('useSync', () => {
     await waitFor(() => {
       expectNotificationDispatched(notificationStore, {
         type: 'error',
-        title: 'notifications.sync.failure',
+        title: 'notifications.consistency.sync.failure',
       });
     });
   });
@@ -96,7 +96,7 @@ describe('useSync', () => {
     await waitFor(() => {
       expectNotificationDispatched(notificationStore, {
         type: 'error',
-        title: 'notifications.sync.failure',
+        title: 'notifications.consistency.sync.failure',
       });
     });
   });
@@ -119,7 +119,7 @@ describe('useSync', () => {
     await waitFor(() => {
       expectNotificationDispatched(notificationStore, {
         type: 'success',
-        text: 'notifications.sync.success',
+        text: 'notifications.consistency.sync.success',
       });
     });
   });
@@ -142,7 +142,7 @@ describe('useSync', () => {
     await waitFor(() => {
       expectNotificationDispatched(notificationStore, {
         type: 'success',
-        text: 'notifications.sync.success',
+        text: 'notifications.consistency.sync.success',
       });
     });
   });
@@ -168,7 +168,7 @@ describe('useSync', () => {
     await waitFor(() => {
       expectNotificationDispatched(notificationStore, {
         type: 'success',
-        text: 'notifications.sync.success',
+        text: 'notifications.consistency.sync.success',
       });
     });
   });

--- a/hermes-console/src/composables/sync/use-sync/useSync.spec.ts
+++ b/hermes-console/src/composables/sync/use-sync/useSync.spec.ts
@@ -1,0 +1,103 @@
+import { afterEach, describe, expect } from 'vitest';
+import { createTestingPinia } from '@pinia/testing';
+import {
+  expectNotificationDispatched,
+  notificationStoreSpy,
+} from '@/utils/test-utils';
+import { setActivePinia } from 'pinia';
+import { setupServer } from 'msw/node';
+import {
+  syncGroupHandler,
+  syncSubscriptionHandler,
+  syncTopicHandler,
+} from '@/mocks/handlers';
+import { useSync } from '@/composables/sync/use-sync/useSync';
+import { waitFor } from '@testing-library/vue';
+
+describe('useSync', () => {
+  const server = setupServer();
+
+  const pinia = createTestingPinia({
+    fakeApp: true,
+  });
+
+  beforeEach(() => {
+    setActivePinia(pinia);
+  });
+
+  afterEach(() => {
+    server.resetHandlers();
+  });
+
+  it('should show error notification when group sync fails', async () => {
+    // given
+    const groupName = 'group';
+    server.use(syncGroupHandler({ groupName, statusCode: 500 }));
+    server.listen();
+
+    const notificationStore = notificationStoreSpy();
+
+    // when
+    const { syncGroup } = useSync();
+    const result = await syncGroup(groupName, 'DC1');
+
+    // then
+    expect(result).toBeFalsy();
+
+    await waitFor(() => {
+      expectNotificationDispatched(notificationStore, {
+        type: 'error',
+        title: 'notifications.sync.failure',
+      });
+    });
+  });
+
+  it('should show error notification when topic sync fails', async () => {
+    // given
+    const topicName = 'group.topic';
+    server.use(syncTopicHandler({ topicName, statusCode: 500 }));
+    server.listen();
+
+    const notificationStore = notificationStoreSpy();
+
+    // when
+    const { syncTopic } = useSync();
+    const result = await syncTopic(topicName, 'DC1');
+
+    // then
+    expect(result).toBeFalsy();
+
+    await waitFor(() => {
+      expectNotificationDispatched(notificationStore, {
+        type: 'error',
+        title: 'notifications.sync.failure',
+      });
+    });
+  });
+
+  it('should show error notification when subscription sync fails', async () => {
+    // given
+    const topicName = 'group.topic';
+    const subscriptionName = 'subscription';
+    server.use(
+      syncSubscriptionHandler({ topicName, subscriptionName, statusCode: 500 }),
+    );
+    server.listen();
+
+    const notificationStore = notificationStoreSpy();
+
+    // when
+    const { syncSubscription } = useSync();
+    const result = await syncSubscription(topicName, subscriptionName, 'DC1');
+
+    // then
+    expect(result).toBeFalsy();
+
+    await waitFor(() => {
+      expectNotificationDispatched(notificationStore, {
+        type: 'error',
+        title: 'notifications.sync.failure',
+      });
+    });
+  });
+});

--- a/hermes-console/src/composables/sync/use-sync/useSync.spec.ts
+++ b/hermes-console/src/composables/sync/use-sync/useSync.spec.ts
@@ -100,4 +100,76 @@ describe('useSync', () => {
       });
     });
   });
+
+  it('should show success notification when group sync is successful', async () => {
+    const groupName = 'group';
+
+    server.use(syncGroupHandler({ groupName, statusCode: 200 }));
+    server.listen();
+
+    const notificationStore = notificationStoreSpy();
+
+    // when
+    const { syncGroup } = useSync();
+    const result = await syncGroup(groupName, 'DC1');
+
+    // then
+    expect(result).toBeTruthy();
+
+    await waitFor(() => {
+      expectNotificationDispatched(notificationStore, {
+        type: 'success',
+        text: 'notifications.sync.success',
+      });
+    });
+  });
+
+  it('should show success notification when topic sync is successful', async () => {
+    // given
+    const topicName = 'group.topic';
+    server.use(syncTopicHandler({ topicName, statusCode: 200 }));
+    server.listen();
+
+    const notificationStore = notificationStoreSpy();
+
+    // when
+    const { syncTopic } = useSync();
+    const result = await syncTopic(topicName, 'DC1');
+
+    // then
+    expect(result).toBeTruthy();
+
+    await waitFor(() => {
+      expectNotificationDispatched(notificationStore, {
+        type: 'success',
+        text: 'notifications.sync.success',
+      });
+    });
+  });
+
+  it('should show success notification when subscription sync is successful', async () => {
+    // given
+    const topicName = 'group.topic';
+    const subscriptionName = 'subscription';
+    server.use(
+      syncSubscriptionHandler({ topicName, subscriptionName, statusCode: 200 }),
+    );
+    server.listen();
+
+    const notificationStore = notificationStoreSpy();
+
+    // when
+    const { syncSubscription } = useSync();
+    const result = await syncSubscription(topicName, subscriptionName, 'DC1');
+
+    // then
+    expect(result).toBeTruthy();
+
+    await waitFor(() => {
+      expectNotificationDispatched(notificationStore, {
+        type: 'error',
+        text: 'notifications.sync.failure',
+      });
+    });
+  });
 });

--- a/hermes-console/src/composables/sync/use-sync/useSync.spec.ts
+++ b/hermes-console/src/composables/sync/use-sync/useSync.spec.ts
@@ -167,8 +167,8 @@ describe('useSync', () => {
 
     await waitFor(() => {
       expectNotificationDispatched(notificationStore, {
-        type: 'error',
-        text: 'notifications.sync.failure',
+        type: 'success',
+        text: 'notifications.sync.success',
       });
     });
   });

--- a/hermes-console/src/composables/sync/use-sync/useSync.ts
+++ b/hermes-console/src/composables/sync/use-sync/useSync.ts
@@ -3,30 +3,51 @@ import {
   syncSubscription as doSyncSubscription,
   syncTopic as doSyncTopic,
 } from '@/api/hermes-client';
+import { groupName } from '@/utils/topic-utils/topic-utils';
 import { ref, type Ref } from 'vue';
+import { useConsistencyStore } from '@/store/consistency/useConsistencyStore';
+import { useGlobalI18n } from '@/i18n';
+import { useNotificationsStore } from '@/store/app-notifications/useAppNotifications';
 
 export interface UseSync {
   errorMessage: Ref<Error | null | undefined>;
-  syncGroup: (groupName: string, primaryDatacenter: string) => Promise<void>;
+  syncGroup: (groupName: string, primaryDatacenter: string) => Promise<boolean>;
   syncTopic: (
     topicQualifiedName: string,
     primaryDatacenter: string,
-  ) => Promise<void>;
+  ) => Promise<boolean>;
   syncSubscription: (
     topicQualifiedName: string,
     subscriptionName: string,
     primaryDatacenter: string,
-  ) => Promise<void>;
+  ) => Promise<boolean>;
 }
 
 export function useSync(): UseSync {
   const errorMessage: Ref<Error | null | undefined> = ref();
 
+  const notificationStore = useNotificationsStore();
+  const consistencyStore = useConsistencyStore();
+
   const syncGroup = async (groupName: string, primaryDatacenter: string) => {
     try {
       await doSyncGroup(groupName, primaryDatacenter);
-    } catch (e) {
-      errorMessage.value = e as Error;
+      await notificationStore.dispatchNotification({
+        text: useGlobalI18n().t('notifications.sync.success', {
+          group: groupName,
+        }),
+        type: 'success',
+      });
+      await consistencyStore.refresh(groupName);
+      return true;
+    } catch (e: any) {
+      await notificationStore.dispatchNotification({
+        text: useGlobalI18n().t('notifications.sync.failure', {
+          group: groupName,
+        }),
+        type: 'error',
+      });
+      return false;
     }
   };
 
@@ -34,10 +55,26 @@ export function useSync(): UseSync {
     topicQualifiedName: string,
     primaryDatacenter: string,
   ) => {
+    const group = groupName(topicQualifiedName);
     try {
       await doSyncTopic(topicQualifiedName, primaryDatacenter);
-    } catch (e) {
+      await notificationStore.dispatchNotification({
+        text: useGlobalI18n().t('notifications.sync.success', {
+          group,
+        }),
+        type: 'success',
+      });
+      await consistencyStore.refresh(group);
+      return true;
+    } catch (e: any) {
       errorMessage.value = e as Error;
+      await notificationStore.dispatchNotification({
+        text: useGlobalI18n().t('notifications.sync.failure', {
+          group,
+        }),
+        type: 'error',
+      });
+      return false;
     }
   };
 
@@ -46,14 +83,30 @@ export function useSync(): UseSync {
     subscriptionName: string,
     primaryDatacenter: string,
   ) => {
+    const group = groupName(topicQualifiedName);
     try {
       await doSyncSubscription(
         topicQualifiedName,
         subscriptionName,
         primaryDatacenter,
       );
+      await notificationStore.dispatchNotification({
+        text: useGlobalI18n().t('notifications.sync.success', {
+          group,
+        }),
+        type: 'success',
+      });
+      await consistencyStore.refresh(group);
+      return true;
     } catch (e) {
       errorMessage.value = e as Error;
+      await notificationStore.dispatchNotification({
+        text: useGlobalI18n().t('notifications.sync.failure', {
+          group,
+        }),
+        type: 'error',
+      });
+      return false;
     }
   };
 

--- a/hermes-console/src/composables/sync/use-sync/useSync.ts
+++ b/hermes-console/src/composables/sync/use-sync/useSync.ts
@@ -1,0 +1,62 @@
+import { ref, type Ref } from 'vue';
+import { syncGroups, syncSubscriptions, syncTopics } from '@/api/hermes-client';
+
+export interface UseSync {
+  errorMessage: Ref<Error | null | undefined>;
+  syncGroup: (groupName: string, primaryDatacenter: string) => Promise<void>;
+  syncTopic: (
+    topicQualifiedName: string,
+    primaryDatacenter: string,
+  ) => Promise<void>;
+  syncSubscription: (
+    topicQualifiedName: string,
+    subscriptionName: string,
+    primaryDatacenter: string,
+  ) => Promise<void>;
+}
+
+export function useSync(): UseSync {
+  const errorMessage: Ref<Error | null | undefined> = ref();
+
+  const syncGroup = async (groupName: string, primaryDatacenter: string) => {
+    try {
+      await syncGroups(groupName, primaryDatacenter);
+    } catch (e) {
+      errorMessage.value = e as Error;
+    }
+  };
+
+  const syncTopic = async (
+    topicQualifiedName: string,
+    primaryDatacenter: string,
+  ) => {
+    try {
+      await syncTopics(topicQualifiedName, primaryDatacenter);
+    } catch (e) {
+      errorMessage.value = e as Error;
+    }
+  };
+
+  const syncSubscription = async (
+    topicQualifiedName: string,
+    subscriptionName: string,
+    primaryDatacenter: string,
+  ) => {
+    try {
+      await syncSubscriptions(
+        topicQualifiedName,
+        subscriptionName,
+        primaryDatacenter,
+      );
+    } catch (e) {
+      errorMessage.value = e as Error;
+    }
+  };
+
+  return {
+    errorMessage,
+    syncGroup,
+    syncSubscription,
+    syncTopic,
+  };
+}

--- a/hermes-console/src/composables/sync/use-sync/useSync.ts
+++ b/hermes-console/src/composables/sync/use-sync/useSync.ts
@@ -1,5 +1,9 @@
+import {
+  syncGroup as doSyncGroup,
+  syncSubscription as doSyncSubscription,
+  syncTopic as doSyncTopic,
+} from '@/api/hermes-client';
 import { ref, type Ref } from 'vue';
-import { syncGroups, syncSubscriptions, syncTopics } from '@/api/hermes-client';
 
 export interface UseSync {
   errorMessage: Ref<Error | null | undefined>;
@@ -20,7 +24,7 @@ export function useSync(): UseSync {
 
   const syncGroup = async (groupName: string, primaryDatacenter: string) => {
     try {
-      await syncGroups(groupName, primaryDatacenter);
+      await doSyncGroup(groupName, primaryDatacenter);
     } catch (e) {
       errorMessage.value = e as Error;
     }
@@ -31,7 +35,7 @@ export function useSync(): UseSync {
     primaryDatacenter: string,
   ) => {
     try {
-      await syncTopics(topicQualifiedName, primaryDatacenter);
+      await doSyncTopic(topicQualifiedName, primaryDatacenter);
     } catch (e) {
       errorMessage.value = e as Error;
     }
@@ -43,7 +47,7 @@ export function useSync(): UseSync {
     primaryDatacenter: string,
   ) => {
     try {
-      await syncSubscriptions(
+      await doSyncSubscription(
         topicQualifiedName,
         subscriptionName,
         primaryDatacenter,

--- a/hermes-console/src/composables/sync/use-sync/useSync.ts
+++ b/hermes-console/src/composables/sync/use-sync/useSync.ts
@@ -5,13 +5,11 @@ import {
   syncTopic as doSyncTopic,
 } from '@/api/hermes-client';
 import { groupName } from '@/utils/topic-utils/topic-utils';
-import { ref, type Ref } from 'vue';
 import { useConsistencyStore } from '@/store/consistency/useConsistencyStore';
 import { useGlobalI18n } from '@/i18n';
 import { useNotificationsStore } from '@/store/app-notifications/useAppNotifications';
 
 export interface UseSync {
-  errorMessage: Ref<Error | null | undefined>;
   syncGroup: (groupName: string, primaryDatacenter: string) => Promise<boolean>;
   syncTopic: (
     topicQualifiedName: string,
@@ -25,8 +23,6 @@ export interface UseSync {
 }
 
 export function useSync(): UseSync {
-  const errorMessage: Ref<Error | null | undefined> = ref();
-
   const notificationStore = useNotificationsStore();
   const consistencyStore = useConsistencyStore();
 
@@ -34,7 +30,7 @@ export function useSync(): UseSync {
     try {
       await doSyncGroup(groupName, primaryDatacenter);
       await notificationStore.dispatchNotification({
-        text: useGlobalI18n().t('notifications.sync.success', {
+        text: useGlobalI18n().t('notifications.consistency.sync.success', {
           group: groupName,
         }),
         type: 'success',
@@ -42,11 +38,10 @@ export function useSync(): UseSync {
       await consistencyStore.refresh(groupName);
       return true;
     } catch (e: any) {
-      errorMessage.value = e as Error;
       dispatchErrorNotification(
         e,
         notificationStore,
-        useGlobalI18n().t('notifications.sync.failure', {
+        useGlobalI18n().t('notifications.consistency.sync.failure', {
           group: groupName,
         }),
       );
@@ -62,7 +57,7 @@ export function useSync(): UseSync {
     try {
       await doSyncTopic(topicQualifiedName, primaryDatacenter);
       await notificationStore.dispatchNotification({
-        text: useGlobalI18n().t('notifications.sync.success', {
+        text: useGlobalI18n().t('notifications.consistency.sync.success', {
           group,
         }),
         type: 'success',
@@ -70,11 +65,10 @@ export function useSync(): UseSync {
       await consistencyStore.refresh(group);
       return true;
     } catch (e: any) {
-      errorMessage.value = e as Error;
       dispatchErrorNotification(
         e,
         notificationStore,
-        useGlobalI18n().t('notifications.sync.failure', {
+        useGlobalI18n().t('notifications.consistency.sync.failure', {
           group,
         }),
       );
@@ -95,7 +89,7 @@ export function useSync(): UseSync {
         primaryDatacenter,
       );
       await notificationStore.dispatchNotification({
-        text: useGlobalI18n().t('notifications.sync.success', {
+        text: useGlobalI18n().t('notifications.consistency.sync.success', {
           group,
         }),
         type: 'success',
@@ -103,11 +97,10 @@ export function useSync(): UseSync {
       await consistencyStore.refresh(group);
       return true;
     } catch (e: any) {
-      errorMessage.value = e as Error;
       dispatchErrorNotification(
         e,
         notificationStore,
-        useGlobalI18n().t('notifications.sync.failure', {
+        useGlobalI18n().t('notifications.consistency.sync.failure', {
           group,
         }),
       );
@@ -116,7 +109,6 @@ export function useSync(): UseSync {
   };
 
   return {
-    errorMessage,
     syncGroup,
     syncSubscription,
     syncTopic,

--- a/hermes-console/src/composables/sync/use-sync/useSync.ts
+++ b/hermes-console/src/composables/sync/use-sync/useSync.ts
@@ -1,3 +1,4 @@
+import { dispatchErrorNotification } from '@/utils/notification-utils';
 import {
   syncGroup as doSyncGroup,
   syncSubscription as doSyncSubscription,
@@ -41,12 +42,14 @@ export function useSync(): UseSync {
       await consistencyStore.refresh(groupName);
       return true;
     } catch (e: any) {
-      await notificationStore.dispatchNotification({
-        text: useGlobalI18n().t('notifications.sync.failure', {
+      errorMessage.value = e as Error;
+      dispatchErrorNotification(
+        e,
+        notificationStore,
+        useGlobalI18n().t('notifications.sync.failure', {
           group: groupName,
         }),
-        type: 'error',
-      });
+      );
       return false;
     }
   };
@@ -68,12 +71,13 @@ export function useSync(): UseSync {
       return true;
     } catch (e: any) {
       errorMessage.value = e as Error;
-      await notificationStore.dispatchNotification({
-        text: useGlobalI18n().t('notifications.sync.failure', {
+      dispatchErrorNotification(
+        e,
+        notificationStore,
+        useGlobalI18n().t('notifications.sync.failure', {
           group,
         }),
-        type: 'error',
-      });
+      );
       return false;
     }
   };
@@ -98,14 +102,15 @@ export function useSync(): UseSync {
       });
       await consistencyStore.refresh(group);
       return true;
-    } catch (e) {
+    } catch (e: any) {
       errorMessage.value = e as Error;
-      await notificationStore.dispatchNotification({
-        text: useGlobalI18n().t('notifications.sync.failure', {
+      dispatchErrorNotification(
+        e,
+        notificationStore,
+        useGlobalI18n().t('notifications.sync.failure', {
           group,
         }),
-        type: 'error',
-      });
+      );
       return false;
     }
   };

--- a/hermes-console/src/dummy/groupInconsistency.ts
+++ b/hermes-console/src/dummy/groupInconsistency.ts
@@ -58,3 +58,34 @@ export const dummyGroupInconsistency3: InconsistentGroup[] = [
     inconsistentTopics: [],
   },
 ];
+
+export const dummyGroupInconsistency4: InconsistentGroup[] = [
+  {
+    name: 'pl.allegro.public.group',
+    inconsistentMetadata: [
+      {
+        datacenter: 'DC1',
+        content: '{"lorem": "ipsum"}',
+      },
+      {
+        datacenter: 'DC2',
+        content: '{"lorem": "ipsum"}',
+      },
+    ],
+    inconsistentTopics: [],
+  },
+  {
+    name: 'pl.allegro.public.group2',
+    inconsistentMetadata: [
+      {
+        datacenter: 'DC1',
+        content: '{"lorem": "ipsum"}',
+      },
+      {
+        datacenter: 'DC2',
+        content: '{"lorem": "ipsum"}',
+      },
+    ],
+    inconsistentTopics: [],
+  },
+];

--- a/hermes-console/src/i18n/en-US/index.ts
+++ b/hermes-console/src/i18n/en-US/index.ts
@@ -708,6 +708,10 @@ const en_US = {
         failure: "Couldn't delete topic {topic}",
       },
     },
+    sync: {
+      success: 'Synchronization of {group} succeeded',
+      failure: 'Synchronization of {group} failed',
+    },
     subscription: {
       create: {
         success: 'Subscription {subscriptionName} successfully created',

--- a/hermes-console/src/i18n/en-US/index.ts
+++ b/hermes-console/src/i18n/en-US/index.ts
@@ -708,9 +708,11 @@ const en_US = {
         failure: "Couldn't delete topic {topic}",
       },
     },
-    sync: {
-      success: 'Synchronization of {group} succeeded',
-      failure: 'Synchronization of {group} failed',
+    consistency: {
+      sync: {
+        success: 'Synchronization of {group} succeeded',
+        failure: 'Synchronization of {group} failed',
+      },
     },
     subscription: {
       create: {

--- a/hermes-console/src/i18n/en-US/index.ts
+++ b/hermes-console/src/i18n/en-US/index.ts
@@ -47,6 +47,12 @@ const en_US = {
     confirmText: "Type 'prod' to confirm action.",
   },
   consistency: {
+    sync: {
+      header: 'Sync datacenters',
+      explanation:
+        'Pick DC which contains correct data. Data from that DC will be propagated to other DCs.',
+      cta: 'Correct data is in DC:',
+    },
     connectionError: {
       title: 'Connection error',
       text: 'Could not fetch information about consistency',

--- a/hermes-console/src/mocks/handlers.ts
+++ b/hermes-console/src/mocks/handlers.ts
@@ -975,3 +975,47 @@ export const subscriptionFilterVerificationErrorHandler = ({
       status: 500,
     });
   });
+
+export const syncGroupHandler = ({
+  groupName,
+  statusCode,
+}: {
+  groupName: string;
+  statusCode: number;
+}) =>
+  http.post(`${url}/consistency/sync/groups/${groupName}`, () => {
+    return new HttpResponse(undefined, {
+      status: statusCode,
+    });
+  });
+
+export const syncTopicHandler = ({
+  topicName,
+  statusCode,
+}: {
+  topicName: string;
+  statusCode: number;
+}) =>
+  http.post(`${url}/consistency/sync/topics/${topicName}`, () => {
+    return new HttpResponse(undefined, {
+      status: statusCode,
+    });
+  });
+
+export const syncSubscriptionHandler = ({
+  topicName,
+  statusCode,
+  subscriptionName,
+}: {
+  topicName: string;
+  subscriptionName: string;
+  statusCode: number;
+}) =>
+  http.post(
+    `${url}/consistency/sync/topics/${topicName}/subscriptions/${subscriptionName}`,
+    () => {
+      return new HttpResponse(undefined, {
+        status: statusCode,
+      });
+    },
+  );

--- a/hermes-console/src/store/consistency/useConsistencyStore.spec.ts
+++ b/hermes-console/src/store/consistency/useConsistencyStore.spec.ts
@@ -1,6 +1,10 @@
 import { beforeEach, describe, expect } from 'vitest';
 import { createPinia, setActivePinia } from 'pinia';
-import { dummyGroupInconsistency } from '@/dummy/groupInconsistency';
+import {
+  dummyGroupInconsistency,
+  dummyGroupInconsistency2,
+  dummyGroupInconsistency4,
+} from '@/dummy/groupInconsistency';
 import { dummyInconsistentGroups } from '@/dummy/inconsistentGroups';
 import {
   fetchConsistencyGroupsErrorHandler,
@@ -85,5 +89,42 @@ describe('useConsistencyStore', () => {
     await consistencyStore.fetch();
 
     expect(consistencyStore.error.fetchError).not.toBeNull();
+  });
+
+  it('should remove group from store when refresh returns that it is consistent', async () => {
+    // given
+    server.use(fetchGroupInconsistenciesHandler({ groupsInconsistency: [] }));
+    server.listen();
+    const consistencyStore = useConsistencyStore();
+    consistencyStore.groups = dummyGroupInconsistency4;
+    // make a copy of initial state
+    const expected = JSON.parse(JSON.stringify(dummyGroupInconsistency4[1]));
+
+    // when
+    await consistencyStore.refresh(dummyGroupInconsistency4[0].name);
+
+    // then
+    expect(consistencyStore.groups.length).toEqual(1);
+    expect(consistencyStore.groups[0]).toEqual(expected);
+  });
+
+  it('should update group in store when refresh returns different value', async () => {
+    // given
+    server.use(
+      fetchGroupInconsistenciesHandler({
+        groupsInconsistency: dummyGroupInconsistency2,
+      }),
+    );
+    server.listen();
+    const consistencyStore = useConsistencyStore();
+    consistencyStore.groups = dummyGroupInconsistency;
+    // make a copy of initial state
+
+    // when
+    await consistencyStore.refresh(dummyGroupInconsistency[0].name);
+
+    // then
+    expect(consistencyStore.groups.length).toEqual(1);
+    expect(consistencyStore.groups).toEqual(dummyGroupInconsistency2);
   });
 });

--- a/hermes-console/src/store/consistency/useConsistencyStore.ts
+++ b/hermes-console/src/store/consistency/useConsistencyStore.ts
@@ -65,7 +65,7 @@ export const useConsistencyStore = defineStore('consistency', {
         }
         if (groupIndex == -1) return;
         if (refreshedGroup.length == 0) {
-          this.groups = this.groups.splice(groupIndex, 1);
+          this.groups.splice(groupIndex, 1);
         } else {
           this.groups[groupIndex] = refreshedGroup[0];
         }

--- a/hermes-console/src/store/consistency/useConsistencyStore.ts
+++ b/hermes-console/src/store/consistency/useConsistencyStore.ts
@@ -52,6 +52,29 @@ export const useConsistencyStore = defineStore('consistency', {
         this.fetchInProgress = false;
       }
     },
+    async refresh(group: string) {
+      this.fetchInProgress = true;
+      try {
+        const refreshedGroup = (await fetchInconsistentGroups([group])).data;
+        let groupIndex = -1;
+        for (let i = 0; i < this.groups.length; i++) {
+          if (this.groups[i].name == group) {
+            groupIndex = i;
+            break;
+          }
+        }
+        if (groupIndex == -1) return;
+        if (refreshedGroup.length == 0) {
+          this.groups = this.groups.splice(groupIndex, 1);
+        } else {
+          this.groups[groupIndex] = refreshedGroup[0];
+        }
+      } catch (e) {
+        this.error.fetchError = e as Error;
+      } finally {
+        this.fetchInProgress = false;
+      }
+    },
   },
   getters: {
     group(

--- a/hermes-console/src/views/admin/consistency/inconsistent-group/InconsistentGroup.vue
+++ b/hermes-console/src/views/admin/consistency/inconsistent-group/InconsistentGroup.vue
@@ -2,6 +2,7 @@
   import { useConsistencyStore } from '@/store/consistency/useConsistencyStore';
   import { useI18n } from 'vue-i18n';
   import { useRouter } from 'vue-router';
+  import { useSync } from '@/composables/sync/use-sync/useSync';
   import InconsistentMetadata from '@/views/admin/consistency/inconsistent-metadata/InconsistentMetadata.vue';
 
   const router = useRouter();
@@ -13,6 +14,7 @@
   >;
 
   const consistencyStore = useConsistencyStore();
+  const { syncGroup } = useSync();
 
   const group = consistencyStore.group(groupId);
 
@@ -33,6 +35,10 @@
       title: groupId,
     },
   ];
+
+  function sync(datacenter: string) {
+    syncGroup(groupId, datacenter);
+  }
 </script>
 
 <template>
@@ -52,6 +58,7 @@
     <InconsistentMetadata
       :metadata="group.inconsistentMetadata"
       v-if="group"
+      @sync="sync"
       class="mt-8"
     ></InconsistentMetadata>
     <v-card

--- a/hermes-console/src/views/admin/consistency/inconsistent-group/InconsistentGroup.vue
+++ b/hermes-console/src/views/admin/consistency/inconsistent-group/InconsistentGroup.vue
@@ -36,8 +36,11 @@
     },
   ];
 
-  function sync(datacenter: string) {
-    syncGroup(groupId, datacenter);
+  async function sync(datacenter: string) {
+    const succeeded = await syncGroup(groupId, datacenter);
+    if (succeeded) {
+      router.push('/ui/consistency');
+    }
   }
 </script>
 

--- a/hermes-console/src/views/admin/consistency/inconsistent-metadata/InconsistentMetadata.spec.ts
+++ b/hermes-console/src/views/admin/consistency/inconsistent-metadata/InconsistentMetadata.spec.ts
@@ -1,9 +1,16 @@
-import { describe, expect } from 'vitest';
+import { beforeEach, describe, expect } from 'vitest';
+import { createPinia, setActivePinia } from 'pinia';
 import { inconsistentMetadata } from '@/dummy/inconsistentMetadata';
-import { render } from '@/utils/test-utils';
+import { render, renderWithEmits } from '@/utils/test-utils';
+import { waitFor } from '@testing-library/vue';
 import InconsistentMetadata from '@/views/admin/consistency/inconsistent-metadata/InconsistentMetadata.vue';
+import router from '@/router';
 
 describe('InconsistentMetadataView', () => {
+  beforeEach(async () => {
+    setActivePinia(createPinia());
+  });
+
   it('should render metadata inconsistencies', () => {
     // when
     const { getByText } = render(InconsistentMetadata, {
@@ -30,5 +37,25 @@ describe('InconsistentMetadataView', () => {
     expect(
       getByText('consistency.inconsistentGroup.metadata.consistent'),
     ).toBeVisible();
+  });
+
+  it('should emit event with selected datacenter when sync button is clicked', async () => {
+    const group = 'pl.allegro.public.group';
+    await router.push(`/ui/consistency/${group}`);
+
+    const wrapper = renderWithEmits(InconsistentMetadata, {
+      props: {
+        metadata: inconsistentMetadata,
+      },
+    });
+
+    const buttonId = `sync-datacenter-${inconsistentMetadata[0].datacenter}`;
+    await wrapper.find(`[data-testid="${buttonId}"]`).trigger('click');
+
+    await waitFor(() => {
+      const syncEvents = wrapper.emitted('sync')!!;
+      expect(syncEvents.length).toEqual(1);
+      expect(syncEvents[0]).toEqual([inconsistentMetadata[0].datacenter]);
+    });
   });
 });

--- a/hermes-console/src/views/admin/consistency/inconsistent-metadata/InconsistentMetadata.vue
+++ b/hermes-console/src/views/admin/consistency/inconsistent-metadata/InconsistentMetadata.vue
@@ -48,9 +48,16 @@
         </tr>
       </tbody>
     </v-table>
-    <v-card-text dev> Sync state to Datacenter </v-card-text>
+    <v-card-text>
+      <p class="text-h5">{{ $t('consistency.sync.header') }}</p>
+      <p class="text-subtitle-1 mt-2">
+        {{ $t('consistency.sync.explanation') }}
+      </p>
+    </v-card-text>
     <v-card-actions>
+      <p class="text mt-2 mr-4 ml-2">{{ $t('consistency.sync.cta') }}</p>
       <v-btn
+        class="bg-primary"
         v-for="meta in metadata"
         @click="sync(meta.datacenter)"
         :key="meta.datacenter"

--- a/hermes-console/src/views/admin/consistency/inconsistent-metadata/InconsistentMetadata.vue
+++ b/hermes-console/src/views/admin/consistency/inconsistent-metadata/InconsistentMetadata.vue
@@ -8,6 +8,10 @@
 
   const { t } = useI18n();
 
+  const emit = defineEmits<{
+    sync: [datacenter: string];
+  }>();
+
   const prettyJson = (jsonString: string | undefined): string => {
     if (jsonString === undefined) {
       return 'null';
@@ -15,6 +19,10 @@
       return JSON.parse(jsonString);
     }
   };
+
+  function sync(datacenter: string) {
+    emit('sync', datacenter);
+  }
 </script>
 
 <template>
@@ -40,6 +48,16 @@
         </tr>
       </tbody>
     </v-table>
+    <v-card-text dev> Sync state to Datacenter </v-card-text>
+    <v-card-actions>
+      <v-btn
+        v-for="meta in metadata"
+        @click="sync(meta.datacenter)"
+        :key="meta.datacenter"
+      >
+        {{ meta.datacenter }}
+      </v-btn>
+    </v-card-actions>
   </v-card>
   <v-banner
     v-else

--- a/hermes-console/src/views/admin/consistency/inconsistent-metadata/InconsistentMetadata.vue
+++ b/hermes-console/src/views/admin/consistency/inconsistent-metadata/InconsistentMetadata.vue
@@ -54,6 +54,7 @@
         v-for="meta in metadata"
         @click="sync(meta.datacenter)"
         :key="meta.datacenter"
+        :data-testid="`sync-datacenter-${meta.datacenter}`"
       >
         {{ meta.datacenter }}
       </v-btn>

--- a/hermes-console/src/views/admin/consistency/inconsistent-topic/InconsistentTopic.vue
+++ b/hermes-console/src/views/admin/consistency/inconsistent-topic/InconsistentTopic.vue
@@ -2,10 +2,11 @@
   import { parseSubscriptionFqn } from '@/utils/subscription-utils/subscription-utils';
   import { useConsistencyStore } from '@/store/consistency/useConsistencyStore';
   import { useI18n } from 'vue-i18n';
-  import { useRoute } from 'vue-router';
+  import { useRoute, useRouter } from 'vue-router';
   import { useSync } from '@/composables/sync/use-sync/useSync';
   import InconsistentMetadata from '@/views/admin/consistency/inconsistent-metadata/InconsistentMetadata.vue';
 
+  const router = useRouter();
   const route = useRoute();
   const { t } = useI18n();
 
@@ -35,20 +36,26 @@
     },
   ];
 
-  function doSyncTopic(datacenter: string) {
-    syncTopic(topicId, datacenter);
+  async function doSyncTopic(datacenter: string) {
+    const succeeded = await syncTopic(topicId, datacenter);
+    if (succeeded) {
+      router.push('/ui/consistency');
+    }
   }
 
-  function doSyncSubscription(
+  async function doSyncSubscription(
     subscriptionQualifiedName: string,
     datacenter: string,
   ) {
     const subscriptionName = parseSubscriptionFqn(subscriptionQualifiedName);
-    syncSubscription(
+    const succeeded = await syncSubscription(
       subscriptionName.topicName,
       subscriptionName.subscriptionName,
       datacenter,
     );
+    if (succeeded) {
+      router.push('/ui/consistency');
+    }
   }
 </script>
 

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/api/ConsistencyEndpoint.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/api/ConsistencyEndpoint.java
@@ -3,7 +3,9 @@ package pl.allegro.tech.hermes.management.api;
 import jakarta.annotation.security.RolesAllowed;
 import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.container.ContainerRequestContext;
@@ -12,6 +14,8 @@ import jakarta.ws.rs.core.GenericEntity;
 import jakarta.ws.rs.core.Response;
 import org.springframework.stereotype.Component;
 import pl.allegro.tech.hermes.api.InconsistentGroup;
+import pl.allegro.tech.hermes.api.SubscriptionName;
+import pl.allegro.tech.hermes.api.TopicName;
 import pl.allegro.tech.hermes.management.api.auth.HermesSecurityAwareRequestUser;
 import pl.allegro.tech.hermes.management.api.auth.Roles;
 import pl.allegro.tech.hermes.management.domain.consistency.DcConsistencyService;
@@ -45,6 +49,38 @@ public class ConsistencyEndpoint {
                 .entity(new GenericEntity<List<InconsistentGroup>>(inconsistentGroups) {
                 })
                 .build();
+    }
+
+    @POST
+    @Produces({APPLICATION_JSON})
+    @Path("/sync/groups/{groupName}")
+    public Response syncGroup(@PathParam("groupName") String groupName,
+                              @QueryParam("primaryDatacenter") String primaryDatacenter
+    ) {
+        dcConsistencyService.syncGroup(groupName, primaryDatacenter);
+        return Response.ok().build();
+    }
+
+    @POST
+    @Produces({APPLICATION_JSON})
+    @Path("/sync/topics/{topicName}")
+    public Response syncTopic(@PathParam("topicName") String topicName,
+                              @QueryParam("primaryDatacenter") String primaryDatacenter
+    ) {
+        dcConsistencyService.syncTopic(TopicName.fromQualifiedName(topicName), primaryDatacenter);
+        return Response.ok().build();
+    }
+
+    @POST
+    @Produces({APPLICATION_JSON})
+    @Path("/sync/topics/{topicName}/subscriptions/{subscriptionName}")
+    public Response syncSubscription(@PathParam("topicName") String topicName,
+                                     @PathParam("subscriptionName") String subscriptionName,
+                                     @QueryParam("primaryDatacenter") String primaryDatacenter
+    ) {
+        SubscriptionName name = new SubscriptionName(subscriptionName, TopicName.fromQualifiedName(topicName));
+        dcConsistencyService.syncSubscription(name, primaryDatacenter);
+        return Response.ok().build();
     }
 
     @GET

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/domain/consistency/DcConsistencyService.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/domain/consistency/DcConsistencyService.java
@@ -19,6 +19,7 @@ import pl.allegro.tech.hermes.api.TopicName;
 import pl.allegro.tech.hermes.common.metric.MetricsFacade;
 import pl.allegro.tech.hermes.domain.group.GroupNotExistsException;
 import pl.allegro.tech.hermes.domain.group.GroupRepository;
+import pl.allegro.tech.hermes.domain.subscription.SubscriptionNotExistsException;
 import pl.allegro.tech.hermes.domain.subscription.SubscriptionRepository;
 import pl.allegro.tech.hermes.domain.topic.TopicNotExistsException;
 import pl.allegro.tech.hermes.domain.topic.TopicRepository;
@@ -124,7 +125,7 @@ public class DcConsistencyService {
         List<DatacenterBoundRepositoryHolder<R>> replicas = new ArrayList<>();
         DatacenterBoundRepositoryHolder<R> primary = null;
         for (DatacenterBoundRepositoryHolder<R> repositoryHolder : repositoryHolders) {
-            if (repositoryHolder.getRepository().equals(primaryDatacenter)) {
+            if (repositoryHolder.getDatacenterName().equals(primaryDatacenter)) {
                 primary = repositoryHolder;
             } else {
                 replicas.add(repositoryHolder);
@@ -174,7 +175,7 @@ public class DcConsistencyService {
                 repo -> {
                     try {
                         return Optional.of(repo.getSubscriptionDetails(subscriptionName));
-                    } catch (TopicNotExistsException ignored) {
+                    } catch (SubscriptionNotExistsException ignored) {
                         return Optional.empty();
                     }
                 },

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/domain/consistency/SynchronizationException.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/domain/consistency/SynchronizationException.java
@@ -1,0 +1,7 @@
+package pl.allegro.tech.hermes.management.domain.consistency;
+
+public class SynchronizationException extends RuntimeException {
+    public SynchronizationException(String message) {
+        super(message);
+    }
+}

--- a/hermes-management/src/test/groovy/pl/allegro/tech/hermes/management/domain/consistency/StorageSyncSpec.groovy
+++ b/hermes-management/src/test/groovy/pl/allegro/tech/hermes/management/domain/consistency/StorageSyncSpec.groovy
@@ -2,9 +2,11 @@ package pl.allegro.tech.hermes.management.domain.consistency
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import pl.allegro.tech.hermes.api.Group
 import pl.allegro.tech.hermes.api.Subscription
 import pl.allegro.tech.hermes.api.Topic
+import pl.allegro.tech.hermes.common.metric.MetricsFacade
 import pl.allegro.tech.hermes.domain.group.GroupNotExistsException
 import pl.allegro.tech.hermes.domain.subscription.SubscriptionRepository
 import pl.allegro.tech.hermes.domain.topic.TopicNotExistsException
@@ -36,6 +38,7 @@ class StorageSyncSpec extends MultiZookeeperIntegrationTest {
 
     ModeService modeService
     MultiDatacenterRepositoryCommandExecutor executor
+    MetricsFacade metricsFacade = new MetricsFacade(new SimpleMeterRegistry())
 
     def objectMapper = new ObjectMapper().registerModule(new JavaTimeModule())
     def paths = new ZookeeperPaths('/hermes')
@@ -70,7 +73,7 @@ class StorageSyncSpec extends MultiZookeeperIntegrationTest {
         assertNodeContains(DC_2_NAME, groupPath, group)
 
         and:
-        def consistencyService = new DcConsistencyService(repositoryManager, objectMapper, new ConsistencyCheckerProperties())
+        def consistencyService = new DcConsistencyService(repositoryManager, objectMapper, new ConsistencyCheckerProperties(), metricsFacade)
 
         when:
         consistencyService.syncGroup(group.groupName, DC_2_NAME)
@@ -91,7 +94,7 @@ class StorageSyncSpec extends MultiZookeeperIntegrationTest {
         assertNodeContains(DC_2_NAME, groupPath, group)
 
         and:
-        def consistencyService = new DcConsistencyService(repositoryManager, objectMapper, new ConsistencyCheckerProperties())
+        def consistencyService = new DcConsistencyService(repositoryManager, objectMapper, new ConsistencyCheckerProperties(), metricsFacade)
 
         when:
         consistencyService.syncGroup(group.groupName, DC_1_NAME)
@@ -112,7 +115,7 @@ class StorageSyncSpec extends MultiZookeeperIntegrationTest {
         assertNodeContains(DC_2_NAME, topicPath, topic)
 
         and:
-        def consistencyService = new DcConsistencyService(repositoryManager, objectMapper, new ConsistencyCheckerProperties())
+        def consistencyService = new DcConsistencyService(repositoryManager, objectMapper, new ConsistencyCheckerProperties(), metricsFacade)
 
         when:
         consistencyService.syncTopic(topic.getName(), DC_2_NAME)
@@ -133,7 +136,7 @@ class StorageSyncSpec extends MultiZookeeperIntegrationTest {
         assertNodeContains(DC_2_NAME, topicPath, topic)
 
         and:
-        def consistencyService = new DcConsistencyService(repositoryManager, objectMapper, new ConsistencyCheckerProperties())
+        def consistencyService = new DcConsistencyService(repositoryManager, objectMapper, new ConsistencyCheckerProperties(), metricsFacade)
 
         when:
         consistencyService.syncTopic(topic.getName(), DC_1_NAME)
@@ -156,7 +159,7 @@ class StorageSyncSpec extends MultiZookeeperIntegrationTest {
         assertNodesAreDifferent(topicPath, Topic.class)
 
         and:
-        def consistencyService = new DcConsistencyService(repositoryManager, objectMapper, new ConsistencyCheckerProperties())
+        def consistencyService = new DcConsistencyService(repositoryManager, objectMapper, new ConsistencyCheckerProperties(), metricsFacade)
 
         when:
         consistencyService.syncTopic(topic.getName(), DC_1_NAME)
@@ -177,7 +180,7 @@ class StorageSyncSpec extends MultiZookeeperIntegrationTest {
         assertNodeContains(DC_2_NAME, subscriptionPath, subscription)
 
         and:
-        def consistencyService = new DcConsistencyService(repositoryManager, objectMapper, new ConsistencyCheckerProperties())
+        def consistencyService = new DcConsistencyService(repositoryManager, objectMapper, new ConsistencyCheckerProperties(), metricsFacade)
 
         when:
         consistencyService.syncSubscription(subscription.getQualifiedName(), DC_2_NAME)
@@ -200,7 +203,7 @@ class StorageSyncSpec extends MultiZookeeperIntegrationTest {
         assertNodesAreDifferent(subscriptionPath, Subscription.class)
 
         and:
-        def consistencyService = new DcConsistencyService(repositoryManager, objectMapper, new ConsistencyCheckerProperties())
+        def consistencyService = new DcConsistencyService(repositoryManager, objectMapper, new ConsistencyCheckerProperties(), metricsFacade)
 
         when:
         consistencyService.syncSubscription(subscription.getQualifiedName(), DC_1_NAME)
@@ -221,7 +224,7 @@ class StorageSyncSpec extends MultiZookeeperIntegrationTest {
         assertNodeContains(DC_2_NAME, subscriptionPath, subscription)
 
         and:
-        def consistencyService = new DcConsistencyService(repositoryManager, objectMapper, new ConsistencyCheckerProperties())
+        def consistencyService = new DcConsistencyService(repositoryManager, objectMapper, new ConsistencyCheckerProperties(), metricsFacade)
 
         when:
         consistencyService.syncSubscription(subscription.getQualifiedName(), DC_1_NAME)
@@ -238,7 +241,7 @@ class StorageSyncSpec extends MultiZookeeperIntegrationTest {
         removeNode(DC_1_NAME, paths.groupPath(group.getGroupName()))
 
         and:
-        def consistencyService = new DcConsistencyService(repositoryManager, objectMapper, new ConsistencyCheckerProperties())
+        def consistencyService = new DcConsistencyService(repositoryManager, objectMapper, new ConsistencyCheckerProperties(), metricsFacade)
 
         when:
         consistencyService.syncTopic(topic.getName(), DC_2_NAME)
@@ -255,7 +258,7 @@ class StorageSyncSpec extends MultiZookeeperIntegrationTest {
         removeNode(DC_1_NAME, paths.groupPath(group.getGroupName()))
 
         and:
-        def consistencyService = new DcConsistencyService(repositoryManager, objectMapper, new ConsistencyCheckerProperties())
+        def consistencyService = new DcConsistencyService(repositoryManager, objectMapper, new ConsistencyCheckerProperties(), metricsFacade)
 
         when:
         consistencyService.syncSubscription(subscription.getQualifiedName(), DC_2_NAME)
@@ -272,7 +275,7 @@ class StorageSyncSpec extends MultiZookeeperIntegrationTest {
         removeNode(DC_1_NAME, paths.topicPath(topic.getName()))
 
         and:
-        def consistencyService = new DcConsistencyService(repositoryManager, objectMapper, new ConsistencyCheckerProperties())
+        def consistencyService = new DcConsistencyService(repositoryManager, objectMapper, new ConsistencyCheckerProperties(), metricsFacade)
 
         when:
         consistencyService.syncSubscription(subscription.getQualifiedName(), DC_2_NAME)

--- a/hermes-management/src/test/groovy/pl/allegro/tech/hermes/management/domain/consistency/StorageSyncSpec.groovy
+++ b/hermes-management/src/test/groovy/pl/allegro/tech/hermes/management/domain/consistency/StorageSyncSpec.groovy
@@ -1,0 +1,366 @@
+package pl.allegro.tech.hermes.management.domain.consistency
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import pl.allegro.tech.hermes.api.Group
+import pl.allegro.tech.hermes.api.Subscription
+import pl.allegro.tech.hermes.api.Topic
+import pl.allegro.tech.hermes.domain.group.GroupNotExistsException
+import pl.allegro.tech.hermes.domain.subscription.SubscriptionRepository
+import pl.allegro.tech.hermes.domain.topic.TopicNotExistsException
+import pl.allegro.tech.hermes.domain.topic.TopicRepository
+import pl.allegro.tech.hermes.infrastructure.zookeeper.ZookeeperPaths
+import pl.allegro.tech.hermes.management.config.ConsistencyCheckerProperties
+import pl.allegro.tech.hermes.management.config.storage.DefaultZookeeperGroupRepositoryFactory
+import pl.allegro.tech.hermes.management.domain.dc.MultiDatacenterRepositoryCommandExecutor
+import pl.allegro.tech.hermes.management.domain.group.commands.CreateGroupRepositoryCommand
+import pl.allegro.tech.hermes.management.domain.mode.ModeService
+import pl.allegro.tech.hermes.management.domain.subscription.commands.CreateSubscriptionRepositoryCommand
+import pl.allegro.tech.hermes.management.domain.topic.commands.CreateTopicRepositoryCommand
+import pl.allegro.tech.hermes.management.infrastructure.zookeeper.ZookeeperClient
+import pl.allegro.tech.hermes.management.infrastructure.zookeeper.ZookeeperClientManager
+import pl.allegro.tech.hermes.management.infrastructure.zookeeper.ZookeeperRepositoryManager
+import pl.allegro.tech.hermes.management.utils.MultiZookeeperIntegrationTest
+import pl.allegro.tech.hermes.test.helper.builder.SubscriptionBuilder
+import pl.allegro.tech.hermes.test.helper.builder.TopicBuilder
+
+import static pl.allegro.tech.hermes.test.helper.builder.GroupBuilder.groupWithRandomName
+import static pl.allegro.tech.hermes.test.helper.builder.SubscriptionBuilder.subscriptionWithRandomName
+import static pl.allegro.tech.hermes.test.helper.builder.TopicBuilder.randomTopic
+
+class StorageSyncSpec extends MultiZookeeperIntegrationTest {
+
+    static GROUPS_PATH = '/hermes/groups'
+    ZookeeperClientManager manager
+    ZookeeperRepositoryManager repositoryManager
+
+    ModeService modeService
+    MultiDatacenterRepositoryCommandExecutor executor
+
+    def objectMapper = new ObjectMapper().registerModule(new JavaTimeModule())
+    def paths = new ZookeeperPaths('/hermes')
+
+    def setup() {
+        manager = buildZookeeperClientManager()
+        manager.start()
+        assertZookeeperClientsConnected(manager.clients)
+        manager.clients.each { client -> setupZookeeperPath(client, GROUPS_PATH) }
+        repositoryManager = new ZookeeperRepositoryManager(
+                manager, new TestDatacenterNameProvider(DC_1_NAME), objectMapper,
+                paths, new DefaultZookeeperGroupRepositoryFactory())
+        repositoryManager.start()
+
+        modeService = new ModeService()
+        executor = new MultiDatacenterRepositoryCommandExecutor(repositoryManager, true, modeService)
+    }
+
+    def cleanup() {
+        manager.stop()
+    }
+
+    def "should create group in all DCs if primary datacenter contains group"() {
+        given:
+        def (Group group, String groupPath) = setupGroup()
+
+        and:
+        removeNode(DC_1_NAME, groupPath)
+
+        and:
+        assertNodeDoesNotExist(DC_1_NAME, groupPath)
+        assertNodeContains(DC_2_NAME, groupPath, group)
+
+        and:
+        def consistencyService = new DcConsistencyService(repositoryManager, objectMapper, new ConsistencyCheckerProperties())
+
+        when:
+        consistencyService.syncGroup(group.groupName, DC_2_NAME)
+
+        then:
+        assertNodesContains(groupPath, group)
+    }
+
+    def "should delete group in all DCs if primary datacenter does not contain group"() {
+        given:
+        def (Group group, String groupPath) = setupGroup()
+
+        and:
+        removeNode(DC_1_NAME, groupPath)
+
+        and:
+        assertNodeDoesNotExist(DC_1_NAME, groupPath)
+        assertNodeContains(DC_2_NAME, groupPath, group)
+
+        and:
+        def consistencyService = new DcConsistencyService(repositoryManager, objectMapper, new ConsistencyCheckerProperties())
+
+        when:
+        consistencyService.syncGroup(group.groupName, DC_1_NAME)
+
+        then:
+        assertNodesDoNotExist(groupPath)
+    }
+
+    def "should create topic in all DCs if primary datacenter contains topic"() {
+        given:
+        def (Group _, Topic topic, String topicPath) = setupTopic()
+
+        and:
+        removeNode(DC_1_NAME, topicPath)
+
+        and:
+        assertNodeDoesNotExist(DC_1_NAME, topicPath)
+        assertNodeContains(DC_2_NAME, topicPath, topic)
+
+        and:
+        def consistencyService = new DcConsistencyService(repositoryManager, objectMapper, new ConsistencyCheckerProperties())
+
+        when:
+        consistencyService.syncTopic(topic.getName(), DC_2_NAME)
+
+        then:
+        assertNodesContains(topicPath, topic)
+    }
+
+    def "should delete topic in all DCs if primary datacenter contains topic"() {
+        given:
+        def (Group _, Topic topic, String topicPath) = setupTopic()
+
+        and:
+        removeNode(DC_1_NAME, topicPath)
+
+        and:
+        assertNodeDoesNotExist(DC_1_NAME, topicPath)
+        assertNodeContains(DC_2_NAME, topicPath, topic)
+
+        and:
+        def consistencyService = new DcConsistencyService(repositoryManager, objectMapper, new ConsistencyCheckerProperties())
+
+        when:
+        consistencyService.syncTopic(topic.getName(), DC_1_NAME)
+
+        then:
+        assertNodesDoNotExist(topicPath)
+    }
+
+    def "should sync topic in all DCs to primary datacenter value"() {
+        given:
+        def (Group _, Topic topic, String topicPath) = setupTopic()
+
+        and:
+        TopicRepository topicRepository = repositoryManager.getLocalRepository(TopicRepository.class).getRepository()
+        Topic updatedTopic = TopicBuilder.topic(topic.name.getGroupName(), topic.name.getName())
+                .withDescription("foo bar").build()
+        topicRepository.updateTopic(updatedTopic)
+
+        and:
+        assertNodesAreDifferent(topicPath, Topic.class)
+
+        and:
+        def consistencyService = new DcConsistencyService(repositoryManager, objectMapper, new ConsistencyCheckerProperties())
+
+        when:
+        consistencyService.syncTopic(topic.getName(), DC_1_NAME)
+
+        then:
+        assertNodesContains(topicPath, updatedTopic)
+    }
+
+    def "should create subscription in all DCs if primary datacenter contains subscription"() {
+        given:
+        def (Group _, Topic __, Subscription subscription, String subscriptionPath) = setupSubscription()
+
+        and:
+        removeNode(DC_1_NAME, subscriptionPath)
+
+        and:
+        assertNodeDoesNotExist(DC_1_NAME, subscriptionPath)
+        assertNodeContains(DC_2_NAME, subscriptionPath, subscription)
+
+        and:
+        def consistencyService = new DcConsistencyService(repositoryManager, objectMapper, new ConsistencyCheckerProperties())
+
+        when:
+        consistencyService.syncSubscription(subscription.getQualifiedName(), DC_2_NAME)
+
+        then:
+        assertNodesContains(subscriptionPath, subscription)
+    }
+
+    def "should delete subscription in all DCs if primary datacenter does not contain subscription"() {
+        given:
+        def (Group _, Topic __, Subscription subscription, String subscriptionPath) = setupSubscription()
+
+        and:
+        SubscriptionRepository subscriptionRepository = repositoryManager.getLocalRepository(SubscriptionRepository.class).getRepository()
+        Subscription updatedSubscription = SubscriptionBuilder.subscription(subscription.getQualifiedName())
+                .withDescription("foo bar").build()
+        subscriptionRepository.updateSubscription(updatedSubscription)
+
+        and:
+        assertNodesAreDifferent(subscriptionPath, Subscription.class)
+
+        and:
+        def consistencyService = new DcConsistencyService(repositoryManager, objectMapper, new ConsistencyCheckerProperties())
+
+        when:
+        consistencyService.syncSubscription(subscription.getQualifiedName(), DC_1_NAME)
+
+        then:
+        assertNodesContains(subscriptionPath, updatedSubscription)
+    }
+
+    def "should sync subscription in all DCs to primary datacenter value"() {
+        given:
+        def (Group _, Topic __, Subscription subscription, String subscriptionPath) = setupSubscription()
+
+        and:
+        removeNode(DC_1_NAME, subscriptionPath)
+
+        and:
+        assertNodeDoesNotExist(DC_1_NAME, subscriptionPath)
+        assertNodeContains(DC_2_NAME, subscriptionPath, subscription)
+
+        and:
+        def consistencyService = new DcConsistencyService(repositoryManager, objectMapper, new ConsistencyCheckerProperties())
+
+        when:
+        consistencyService.syncSubscription(subscription.getQualifiedName(), DC_1_NAME)
+
+        then:
+        assertNodesDoNotExist(subscriptionPath)
+    }
+
+    def "topic sync should fail if group does not exist in replica datacenter"() {
+        given:
+        def (Group group, Topic topic, String _) = setupTopic()
+
+        and:
+        removeNode(DC_1_NAME, paths.groupPath(group.getGroupName()))
+
+        and:
+        def consistencyService = new DcConsistencyService(repositoryManager, objectMapper, new ConsistencyCheckerProperties())
+
+        when:
+        consistencyService.syncTopic(topic.getName(), DC_2_NAME)
+
+        then:
+        thrown GroupNotExistsException
+    }
+
+    def "subscription sync should fail if group does not exist in replica datacenter"() {
+        given:
+        def (Group group, Topic _, Subscription subscription, String __) = setupSubscription()
+
+        and:
+        removeNode(DC_1_NAME, paths.groupPath(group.getGroupName()))
+
+        and:
+        def consistencyService = new DcConsistencyService(repositoryManager, objectMapper, new ConsistencyCheckerProperties())
+
+        when:
+        consistencyService.syncSubscription(subscription.getQualifiedName(), DC_2_NAME)
+
+        then:
+        thrown TopicNotExistsException
+    }
+
+    def "subscription sync should fail if topic does not exist in replica datacenter"() {
+        given:
+        def (Group _, Topic topic, Subscription subscription, String __) = setupSubscription()
+
+        and:
+        removeNode(DC_1_NAME, paths.topicPath(topic.getName()))
+
+        and:
+        def consistencyService = new DcConsistencyService(repositoryManager, objectMapper, new ConsistencyCheckerProperties())
+
+        when:
+        consistencyService.syncSubscription(subscription.getQualifiedName(), DC_2_NAME)
+
+        then:
+        thrown TopicNotExistsException
+    }
+
+    private def setupGroup() {
+        Group group = groupWithRandomName().build()
+        executor.execute(new CreateGroupRepositoryCommand(group))
+        String groupPath = paths.groupPath(group.groupName)
+        return [group, groupPath]
+    }
+
+    private def setupTopic() {
+        Group group = groupWithRandomName().build()
+        Topic topic = randomTopic(group.getGroupName(), "").build()
+        executor.execute(new CreateGroupRepositoryCommand(group))
+        executor.execute(new CreateTopicRepositoryCommand(topic))
+        String topicPath = paths.topicPath(topic.getName())
+        return [group, topic, topicPath]
+    }
+
+    private def setupSubscription() {
+        Group group = groupWithRandomName().build()
+        Topic topic = randomTopic(group.getGroupName(), "").build()
+        Subscription subscription = subscriptionWithRandomName(topic.getName()).build()
+        executor.execute(new CreateGroupRepositoryCommand(group))
+        executor.execute(new CreateTopicRepositoryCommand(topic))
+        executor.execute(new CreateSubscriptionRepositoryCommand(subscription))
+        String subscriptionPath = paths.subscriptionPath(subscription)
+        return [group, topic, subscription, subscriptionPath]
+    }
+
+
+    private <T> void assertNodeContains(String dc, String path, T expected) {
+        def zkClient = findClientByDc(manager.clients, dc)
+        def data = zkClient.curatorFramework.getData().forPath(path)
+        def actual = objectMapper.readValue(data, expected.class)
+        assert actual == expected
+    }
+
+    private <T> void assertNodesContains(String path, T expected) {
+        manager.clients.each {
+            def data = it.curatorFramework.getData().forPath(path)
+            def actual = objectMapper.readValue(data, expected.class)
+            assert actual == expected
+        }
+    }
+
+    private def assertNodeDoesNotExist(String dc, String path) {
+        def zkClient = findClientByDc(manager.clients, dc)
+        zkClient.curatorFramework.checkExists().forPath(path) == null
+    }
+
+    private def assertNodesDoNotExist(String path) {
+        manager.clients.each {
+            assert it.curatorFramework.checkExists().forPath(path) == null
+        }
+    }
+
+    private <T> void assertNodesAreDifferent(String path, Class<T> clazz) {
+        Set<T> values = new HashSet<>()
+        manager.clients.each {
+            def data = it.curatorFramework.getData().forPath(path)
+            def value = objectMapper.readValue(data, clazz)
+            values.add(value)
+        }
+        assert values.size() > 1
+    }
+
+    private def removeNode(String dc, String path) {
+        def zkClient = findClientByDc(manager.clients, dc)
+        zkClient.curatorFramework.delete()
+                .deletingChildrenIfNeeded()
+                .forPath(path)
+    }
+
+    private static setupZookeeperPath(ZookeeperClient zookeeperClient, String path) {
+        def healthCheckPathExists = zookeeperClient.curatorFramework
+                .checkExists()
+                .forPath(path) != null
+        if (!healthCheckPathExists) {
+            zookeeperClient.curatorFramework
+                    .create()
+                    .creatingParentContainersIfNeeded()
+                    .forPath(path)
+        }
+    }
+}


### PR DESCRIPTION
Allow admins to perform storage synchronization using UI. Admin selects "primary" DC for group/topic/subscription and its content is propagated to nodes in other DCs.

After synchronization only the group that was synchronized is refreshed so consistency view shows up to date information without making an expensive check for all groups
![Screenshot 2024-08-21 at 11 41 43](https://github.com/user-attachments/assets/8fa8e2f7-c430-4ebd-9965-5874374d49fc)
