### PR TITLE
update batch receiver on subscription update

### DIFF
--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/BatchConsumer.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/BatchConsumer.java
@@ -200,6 +200,7 @@ public class BatchConsumer implements Consumer {
     @Override
     public void updateSubscription(Subscription subscription) {
         this.subscription = subscription;
+        receiver.updateSubscription(subscription);
     }
 
     @Override


### PR DESCRIPTION
Batch subscription currently do not support hot reload of filters, probably someone forgot to call:

`receiver.updateSubscription(subscription)`