### PR TITLE
SKYEDEN-3020 | Handle retransmission zookeeper race condition

### DIFF
--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/common/kafka/offset/SubscriptionOffsetChangeIndicator.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/common/kafka/offset/SubscriptionOffsetChangeIndicator.java
@@ -1,6 +1,7 @@
 package pl.allegro.tech.hermes.common.kafka.offset;
 
 import java.util.List;
+import java.util.Set;
 import pl.allegro.tech.hermes.api.TopicName;
 import pl.allegro.tech.hermes.common.kafka.KafkaTopic;
 import pl.allegro.tech.hermes.common.kafka.KafkaTopicName;
@@ -14,7 +15,7 @@ public interface SubscriptionOffsetChangeIndicator {
       PartitionOffset partitionOffset);
 
   PartitionOffsets getSubscriptionOffsets(
-      TopicName topic, String subscriptionName, String brokersClusterName);
+      TopicName topic, String subscriptionName, String brokersClusterName, Set<Integer> partitions);
 
   boolean areOffsetsMoved(
       TopicName topicName,

--- a/hermes-common/src/test/groovy/pl/allegro/tech/hermes/infrastructure/zookeeper/ZookeeperSubscriptionOffsetChangeIndicatorTest.groovy
+++ b/hermes-common/src/test/groovy/pl/allegro/tech/hermes/infrastructure/zookeeper/ZookeeperSubscriptionOffsetChangeIndicatorTest.groovy
@@ -1,6 +1,6 @@
 package pl.allegro.tech.hermes.infrastructure.zookeeper
 
-import com.google.common.primitives.Longs
+
 import pl.allegro.tech.hermes.api.Topic
 import pl.allegro.tech.hermes.api.TopicName
 import pl.allegro.tech.hermes.common.kafka.KafkaTopicName
@@ -8,8 +8,6 @@ import pl.allegro.tech.hermes.common.kafka.offset.PartitionOffset
 import pl.allegro.tech.hermes.common.kafka.offset.PartitionOffsets
 import pl.allegro.tech.hermes.domain.subscription.SubscriptionNotExistsException
 import pl.allegro.tech.hermes.test.IntegrationTest
-
-import java.nio.charset.StandardCharsets
 
 import static pl.allegro.tech.hermes.test.helper.builder.GroupBuilder.group
 import static pl.allegro.tech.hermes.test.helper.builder.SubscriptionBuilder.subscription
@@ -43,7 +41,7 @@ class ZookeeperSubscriptionOffsetChangeIndicatorTest extends IntegrationTest {
         indicator.setSubscriptionOffset(TOPIC.name, 'override', 'primary', new PartitionOffset(primaryKafkaTopicName, 10, 1))
 
         then:
-        def offsets = indicator.getSubscriptionOffsets(TOPIC.name, 'override', 'primary')
+        def offsets = indicator.getSubscriptionOffsets(TOPIC.name, 'override', 'primary', [1] as Set)
         offsets.find { it.partition == 1 } == new PartitionOffset(primaryKafkaTopicName, 10, 1)
     }
 
@@ -54,7 +52,7 @@ class ZookeeperSubscriptionOffsetChangeIndicatorTest extends IntegrationTest {
         indicator.setSubscriptionOffset(TOPIC.name, 'read', 'primary', new PartitionOffset(primaryKafkaTopicName, 10, 1))
 
         when:
-        PartitionOffsets offsets = indicator.getSubscriptionOffsets(TOPIC.name, 'read', 'primary')
+        PartitionOffsets offsets = indicator.getSubscriptionOffsets(TOPIC.name, 'read', 'primary', [1] as Set)
 
         then:
         (offsets.find { it.partition == 1 } as PartitionOffset).offset == 10

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/BatchConsumer.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/BatchConsumer.java
@@ -251,6 +251,11 @@ public class BatchConsumer implements Consumer {
     return subscription;
   }
 
+  @Override
+  public Set<Integer> getAssignedPartitions() {
+    return receiver.getAssignedPartitions();
+  }
+
   private Retryer<MessageSendingResult> createRetryer(
       MessageBatch batch, BatchSubscriptionPolicy policy) {
     return createRetryer(

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/Consumer.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/Consumer.java
@@ -29,4 +29,6 @@ public interface Consumer {
   boolean moveOffset(PartitionOffset subscriptionPartitionOffset);
 
   Subscription getSubscription();
+
+  Set<Integer> getAssignedPartitions();
 }

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/SerialConsumer.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/SerialConsumer.java
@@ -270,4 +270,9 @@ public class SerialConsumer implements Consumer {
   public Subscription getSubscription() {
     return subscription;
   }
+
+  @Override
+  public Set<Integer> getAssignedPartitions() {
+    return messageReceiver.getAssignedPartitions();
+  }
 }

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/batch/MessageBatchReceiver.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/batch/MessageBatchReceiver.java
@@ -183,4 +183,8 @@ public class MessageBatchReceiver {
   public boolean moveOffset(PartitionOffset offset) {
     return receiver.moveOffset(offset);
   }
+
+  public Set<Integer> getAssignedPartitions() {
+    return receiver.getAssignedPartitions();
+  }
 }

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/offset/ConsumerPartitionAssignmentState.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/offset/ConsumerPartitionAssignmentState.java
@@ -66,6 +66,10 @@ public class ConsumerPartitionAssignmentState {
             subscriptionPartition.getSubscriptionName(), subscriptionPartition.getPartition());
   }
 
+  public Set<Integer> getAssignedPartitions(SubscriptionName subscriptionName) {
+    return assigned.get(subscriptionName);
+  }
+
   private boolean isAssigned(SubscriptionName name, int partition) {
     return assigned.containsKey(name) && assigned.get(name).contains(partition);
   }

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/receiver/MessageReceiver.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/receiver/MessageReceiver.java
@@ -34,4 +34,6 @@ public interface MessageReceiver {
   void commit(Set<SubscriptionPartitionOffset> offsets);
 
   boolean moveOffset(PartitionOffset offset);
+
+  Set<Integer> getAssignedPartitions();
 }

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/receiver/ThrottlingMessageReceiver.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/receiver/ThrottlingMessageReceiver.java
@@ -58,6 +58,11 @@ public class ThrottlingMessageReceiver implements MessageReceiver {
   }
 
   @Override
+  public Set<Integer> getAssignedPartitions() {
+    return receiver.getAssignedPartitions();
+  }
+
+  @Override
   public void stop() {
     receiver.stop();
   }

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/receiver/UninitializedMessageReceiver.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/receiver/UninitializedMessageReceiver.java
@@ -21,4 +21,9 @@ public class UninitializedMessageReceiver implements MessageReceiver {
   public boolean moveOffset(PartitionOffset offset) {
     throw new ConsumerNotInitializedException();
   }
+
+  @Override
+  public Set<Integer> getAssignedPartitions() {
+    throw new ConsumerNotInitializedException();
+  }
 }

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/receiver/kafka/FilteringMessageReceiver.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/receiver/kafka/FilteringMessageReceiver.java
@@ -68,4 +68,9 @@ public class FilteringMessageReceiver implements MessageReceiver {
   public boolean moveOffset(PartitionOffset offset) {
     return receiver.moveOffset(offset);
   }
+
+  @Override
+  public Set<Integer> getAssignedPartitions() {
+    return receiver.getAssignedPartitions();
+  }
 }

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/receiver/kafka/KafkaSingleThreadedMessageReceiver.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/receiver/kafka/KafkaSingleThreadedMessageReceiver.java
@@ -226,4 +226,8 @@ public class KafkaSingleThreadedMessageReceiver implements MessageReceiver {
   public boolean moveOffset(PartitionOffset offset) {
     return offsetMover.move(offset);
   }
+
+  public Set<Integer> getAssignedPartitions() {
+    return partitionAssignmentState.getAssignedPartitions(subscription.getQualifiedName());
+  }
 }

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/process/Retransmitter.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/process/Retransmitter.java
@@ -28,7 +28,10 @@ public class Retransmitter {
     try {
       PartitionOffsets offsets =
           subscriptionOffsetChangeIndicator.getSubscriptionOffsets(
-              subscriptionName.getTopicName(), subscriptionName.getName(), brokersClusterName);
+              subscriptionName.getTopicName(),
+              subscriptionName.getName(),
+              brokersClusterName,
+              consumer.getAssignedPartitions());
 
       for (PartitionOffset partitionOffset : offsets) {
         if (moveOffset(subscriptionName, consumer, partitionOffset)) {

--- a/hermes-consumers/src/test/groovy/pl/allegro/tech/hermes/consumers/supervisor/process/ConsumerStub.groovy
+++ b/hermes-consumers/src/test/groovy/pl/allegro/tech/hermes/consumers/supervisor/process/ConsumerStub.groovy
@@ -65,6 +65,11 @@ class ConsumerStub implements Consumer {
     }
 
     @Override
+    Set<Integer> getAssignedPartitions() {
+        return null
+    }
+
+    @Override
     void updateTopic(Topic topic) {
     }
 


### PR DESCRIPTION
**Why:**
The current implementation of the Retransmitter::reloadOffsets method contains a race condition. Multiple consumer instances can execute this code simultaneously, which may lead to unpredictable behavior.

Offsets are stored in ZooKeeper per partition, for example: `[1:{123}, 2:{345}, 3:{567}, 4:{678}]`.

The method first fetches the entire list of available partitions from ZooKeeper (`[1,2,3,4]`), then retrieves the specific offsets for each partition. The fetched offsets are processed for partitions assigned to the consumer and subsequently deleted from ZooKeeper. For instance, if consumer1 is assigned partitions `[1,2]`, it will process these offsets and delete them, leaving only partitions `[3,4]` in ZooKeeper.

The issue arises when multiple consumers execute this process simultaneously. A consumer may fetch the list of available partitions, but by the time it attempts to fetch the offset for a partition, the offset may no longer exist because it has already been deleted by another consumer.

**Fix:**
To resolve this, the step of listing all available partitions from zookeper was removed. Instead, the method now directly fetches the partitions assigned to the consumer. This ensures that the consumer only retrieves data for partitions it is responsible for, eliminating the possibility of fetching offsets that may have been deleted by another consumer.
