### PR TITLE
Allow both decimal and floating point numbers in metrics assertion pattern

### DIFF
--- a/integration-tests/src/common/java/pl/allegro/tech/hermes/integrationtests/assertions/PrometheusMetricsAssertion.java
+++ b/integration-tests/src/common/java/pl/allegro/tech/hermes/integrationtests/assertions/PrometheusMetricsAssertion.java
@@ -9,7 +9,7 @@ import java.util.regex.Pattern;
 public class PrometheusMetricsAssertion {
 
   private static final Pattern METRIC_LINE_PATTERN =
-      Pattern.compile("^[a-z_]+\\{(.*)\\} (\\d+\\.\\d+)$");
+      Pattern.compile("^[a-z_]+\\{(.*)\\} (\\d+(\\.\\d+)?)$");
 
   private final String actualBody;
 


### PR DESCRIPTION
Most probably after update of prometheus dependencies, test `BrokerLatencyReportingTest > shouldReportBrokerLatencyMetrics()` stopped working because `PrometheusMetricsAssertion` always requires the metric value to be in floating point format, which is not the case anymore, the above mentioned test fails with `java.lang.IllegalStateException: Unexpected line: hermes_frontend_broker_latency_seconds_count{ack="LEADER",broker="localhost"} 1` but it should succeed.

I changed the `PrometheusMetricsAssertion` to allow both floating point and decimal numbers in assertions.