### PR TITLE
Fix docker - use existing JDK image

### DIFF
--- a/docker/latest/consumers/Dockerfile
+++ b/docker/latest/consumers/Dockerfile
@@ -1,4 +1,4 @@
-FROM gradle:7.6-jdk21 AS builder
+FROM gradle:8.12-jdk21 AS builder
 
 COPY --chown=gradle:gradle . /home/gradle/src/
 WORKDIR /home/gradle/src/

--- a/docker/latest/frontend/Dockerfile
+++ b/docker/latest/frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM gradle:7.6-jdk21 AS builder
+FROM gradle:8.12-jdk21 AS builder
 
 COPY --chown=gradle:gradle . /home/gradle/src/
 WORKDIR /home/gradle/src/

--- a/docker/latest/management/Dockerfile
+++ b/docker/latest/management/Dockerfile
@@ -1,4 +1,4 @@
-FROM gradle:7.6-jdk21 AS builder
+FROM gradle:8.12-jdk21 AS builder
 
 COPY --chown=gradle:gradle . /home/gradle/src/
 WORKDIR /home/gradle/src/


### PR DESCRIPTION
Currently `docker-compose up` fails (`podman compose up` in my case):
```
>>>> Executing external compose provider "/Users/x/.docker/cli-plugins/docker-compose". Please see podman-compose(1) for how to disable this message. <<<<

WARN[0000] /Users/x/workspaces/github/hermes/docker/docker-compose.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion
[+] Running 0/3
diff --git a/docker/.env b/docker/.env
index bb66fb7f4..e3a99bcdb 100644
--- a/docker/.env
+++ b/docker/.env
 ⠦ Service frontend    Building                                                                                                                                                                                                       31.7s
 ⠦ Service management  Building                                                                                                                                                                                                       31.7s
[+] Running 0/3umers   Building                                                                                                                                                                                                       31.7s
 ⠧ Service frontend    Building                                                                                                                                                                                                       31.8s
 ⠧ Service management  Building                                                                                                                                                                                                       31.8s
 ⠧ Service consumers   Building                                                                                                                                                                                                       31.8s
[1/2] STEP 1/4: FROM gradle:7.6-jdk21 AS builder
[1/2] STEP 1/4: FROM gradle:7.6-jdk21 AS builder
Resolving %!q(<nil>) to docker.io (enforced by caller)
Trying to pull docker.io/library/gradle:7.6-jdk21...
Resolving %!q(<nil>) to docker.io (enforced by caller)
[+] Running 0/3docker.io/library/gradle:7.6-jdk21...
 ⠋ Service frontend    Building                                                                                                                                                                                                       33.1s
 ⠋ Service management  Building                                                                                                                                                                                                       33.1s
 ⠋ Service consumers   Building                                                                                                                                                                                                       33.1s
creating build container: initializing source docker://gradle:7.6-jdk21: reading manifest 7.6-jdk21 in docker.io/library/gradle: manifest unknown

Error: executing /Users/x/.docker/cli-plugins/docker-compose up: exit status 1
```

`gradle:7.6-jdk21` is not available (https://hub.docker.com/_/gradle). The only version with JDK 21 is `gradle:8.12-jdk21`. 