### PR TITLE
Require positive values of thresholdsMilliseconds

### DIFF
--- a/hermes-api/src/main/java/pl/allegro/tech/hermes/api/subscription/metrics/MessageProcessingDurationMetricOptions.java
+++ b/hermes-api/src/main/java/pl/allegro/tech/hermes/api/subscription/metrics/MessageProcessingDurationMetricOptions.java
@@ -3,13 +3,14 @@ package pl.allegro.tech.hermes.api.subscription.metrics;
 import static java.util.Collections.emptyList;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.Size;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
 
 public record MessageProcessingDurationMetricOptions(
-    @Size(max = 10) List<Long> thresholdsMilliseconds, boolean enabled) {
+    @Size(max = 10) List<@Positive Long> thresholdsMilliseconds, boolean enabled) {
 
   public static MessageProcessingDurationMetricOptions DISABLED =
       MessageProcessingDurationMetricOptions.disabled();

--- a/hermes-api/src/main/java/pl/allegro/tech/hermes/api/subscription/metrics/SubscriptionMetricsConfig.java
+++ b/hermes-api/src/main/java/pl/allegro/tech/hermes/api/subscription/metrics/SubscriptionMetricsConfig.java
@@ -1,6 +1,9 @@
 package pl.allegro.tech.hermes.api.subscription.metrics;
 
-public record SubscriptionMetricsConfig(MessageProcessingDurationMetricOptions messageProcessing) {
+import jakarta.validation.Valid;
+
+public record SubscriptionMetricsConfig(
+    @Valid MessageProcessingDurationMetricOptions messageProcessing) {
 
   public static final SubscriptionMetricsConfig DISABLED =
       new SubscriptionMetricsConfig(MessageProcessingDurationMetricOptions.DISABLED);


### PR DESCRIPTION
Message processing time metric was introduced in https://github.com/allegro/hermes/pull/1958. 

When `thresholdsMilliseconds` contains invalid, negative value (e.g. `-100`) then:
- `Failed to process signal Signal(2480, UPDATE_SUBSCRIPTION...` is logged. 
  - `hermes_consumers_subscription_message_processing_time metric` is not gathered, because old micrometer meter is removed and new cannot be created
- Invalid value is stored and returned by rest API
After setting valid value of `thresholdsMilliseconds`  everything works properly.

This PR fixes the bug and require positive values of `thresholdsMilliseconds`. 

Now negative vales are not accepted and Bad Request is returned:
```http
PUT http://localhost:8090/topics/g23.t1/subscriptions/s1
Content-Type: application/json

{
  "metricsConfig": {
    "messageProcessing": {
      "enabled": true,
      "thresholdsMilliseconds": [
        -100
      ]
    }
  }
}

HTTP/1.1 400 
{
  "message": "Subscription.metricsConfig.messageProcessing.thresholdsMilliseconds[0].<list element> must be greater than 0",
  "code": "VALIDATION_ERROR"
}
```