### PR TITLE
Omit creating backup storage beans when it is disabled

### DIFF
--- a/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/config/FrontendConfiguration.java
+++ b/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/config/FrontendConfiguration.java
@@ -3,6 +3,7 @@ package pl.allegro.tech.hermes.frontend.config;
 import jakarta.inject.Named;
 import java.time.Clock;
 import java.util.List;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -52,6 +53,7 @@ public class FrontendConfiguration {
   }
 
   @Bean
+  @ConditionalOnProperty(name = "frontend.messages.local.storage.enabled", havingValue = "true")
   public BackupMessagesLoader backupMessagesLoader(
       @Named("localDatacenterBrokerProducer") BrokerMessageProducer brokerMessageProducer,
       BrokerListeners brokerListeners,
@@ -71,6 +73,7 @@ public class FrontendConfiguration {
   }
 
   @Bean(initMethod = "extend")
+  @ConditionalOnProperty(name = "frontend.messages.local.storage.enabled", havingValue = "true")
   public PersistentBufferExtension persistentBufferExtension(
       LocalMessageStorageProperties localMessageStorageProperties,
       Clock clock,

--- a/integration-tests/src/slowIntegrationTest/java/pl/allegro/tech/hermes/integrationtests/MessageBufferLoadingTest.java
+++ b/integration-tests/src/slowIntegrationTest/java/pl/allegro/tech/hermes/integrationtests/MessageBufferLoadingTest.java
@@ -124,6 +124,7 @@ public class MessageBufferLoadingTest {
     HermesFrontendTestApp frontend =
         new HermesFrontendTestApp(infra.hermesZookeeper(), infra.kafka(), infra.schemaRegistry());
     frontend.withProperty(MESSAGES_LOCAL_STORAGE_DIRECTORY, tempDirPath);
+    frontend.withProperty(MESSAGES_LOCAL_STORAGE_ENABLED, true);
 
     // when
     frontend.start();


### PR DESCRIPTION
Otherwise, when starting hermes-frontend without a disk attached we are getting an error.