### PR TITLE
Fix thread interruption for batch

### DIFF
--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/BatchConsumer.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/BatchConsumer.java
@@ -330,17 +330,38 @@ public class BatchConsumer implements Consumer {
                 subscription.getBatchSubscriptionPolicy().getRequestTimeout());
           });
     } catch (Exception e) {
-      logger.error(
-          "Batch was rejected [batch_id={}, subscription={}].",
-          batch.getId(),
-          subscription.getQualifiedName(),
-          e);
-      metrics.recordAttemptAsFinished(batch.getMessageCount());
-      metrics.markDiscarded(batch);
-      batch
-          .getMessagesMetadata()
-          .forEach(m -> trackers.get(subscription).logDiscarded(m, e.getMessage()));
+      if (hasInterruptedException(e)) {
+        logger.debug(
+            "Batch sending was interrupted [batch_id={}, subscription={}].",
+            batch.getId(),
+            subscription.getQualifiedName(),
+            e);
+        logger.info("Restoring interrupted status", e);
+        Thread.currentThread().interrupt();
+      } else {
+        logger.error(
+            "Batch was rejected [batch_id={}, subscription={}].",
+            batch.getId(),
+            subscription.getQualifiedName(),
+            e);
+        metrics.recordAttemptAsFinished(batch.getMessageCount());
+        metrics.markDiscarded(batch);
+        batch
+            .getMessagesMetadata()
+            .forEach(m -> trackers.get(subscription).logDiscarded(m, e.getMessage()));
+      }
     }
+  }
+
+  private static boolean hasInterruptedException(Throwable e) {
+    Throwable currentException = e;
+    while (currentException != null) {
+      if (currentException instanceof InterruptedException) {
+        return true;
+      }
+      currentException = currentException.getCause();
+    }
+    return false;
   }
 
   private void clean(MessageBatch batch) {

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/BatchConsumer.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/BatchConsumer.java
@@ -331,11 +331,12 @@ public class BatchConsumer implements Consumer {
           });
     } catch (Exception e) {
       if (hasInterruptedException(e)) {
-        logger.debug(
+        logger.info(
             "Batch sending was interrupted [batch_id={}, subscription={}].",
             batch.getId(),
             subscription.getQualifiedName(),
             e);
+        metrics.recordAttemptAsFinished(batch.getMessageCount());
         logger.info("Restoring interrupted status", e);
         Thread.currentThread().interrupt();
       } else {


### PR DESCRIPTION
Thread interruptions during batch sending should not result in batch messages being discarded.