### PR TITLE
Replace deprecated webclient methods

### DIFF
--- a/hermes-client/src/main/java/pl/allegro/tech/hermes/client/webclient/WebClientHermesSender.java
+++ b/hermes-client/src/main/java/pl/allegro/tech/hermes/client/webclient/WebClientHermesSender.java
@@ -28,10 +28,9 @@ public class WebClientHermesSender implements HermesSender, ReactiveHermesSender
     return webClient
         .post()
         .uri(uri)
-        .syncBody(message.getBody())
+        .bodyValue(message.getBody())
         .headers(httpHeaders -> httpHeaders.setAll(message.getHeaders()))
-        .exchange()
-        .flatMap(
+        .exchangeToMono(
             response ->
                 response
                     .bodyToMono(String.class)


### PR DESCRIPTION
* **syncBody(message.getBody()) → bodyValue(message.getBody())** — the direct replacement for sending a synchronous body value.
* **exchange().flatMap(...) → exchangeToMono(...)** — the exchange() method was deprecated because it required callers to always consume the response body to avoid resource leaks; exchangeToMono enforces that by taking a function that must return a Mono, ensuring the body is consumed.