### PR TITLE
Disable Curator EnsembleTracker by default

### DIFF
--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/common/di/factories/CuratorClientFactory.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/common/di/factories/CuratorClientFactory.java
@@ -61,7 +61,8 @@ public class CuratorClientFactory {
                 new ExponentialBackoffRetry(
                     (int) zookeeperParameters.getBaseSleepTime().toMillis(),
                     zookeeperParameters.getMaxRetries(),
-                    (int) zookeeperParameters.getMaxSleepTime().toMillis()));
+                    (int) zookeeperParameters.getMaxSleepTime().toMillis()))
+            .ensembleTracker(zookeeperParameters.isEnsembleTrackerEnabled());
 
     zookeeperAuthentication.ifPresent(
         it -> {

--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/common/di/factories/ZookeeperParameters.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/common/di/factories/ZookeeperParameters.java
@@ -29,4 +29,6 @@ public interface ZookeeperParameters {
   String getUser();
 
   String getPassword();
+
+  boolean isEnsembleTrackerEnabled();
 }

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/config/ZookeeperProperties.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/config/ZookeeperProperties.java
@@ -9,7 +9,7 @@ public class ZookeeperProperties implements ZookeeperParameters {
 
   private String datacenter = "dc";
 
-  private Duration baseSleepTime = Duration.ofSeconds(1000);
+  private Duration baseSleepTime = Duration.ofSeconds(1);
 
   private Duration maxSleepTime = Duration.ofSeconds(30);
 
@@ -22,6 +22,8 @@ public class ZookeeperProperties implements ZookeeperParameters {
   private String root = "/hermes";
 
   private int processingThreadPoolSize = 5;
+
+  private boolean ensembleTracker = false;
 
   private ZookeeperAuthenticationProperties authentication =
       new ZookeeperAuthenticationProperties();
@@ -124,6 +126,15 @@ public class ZookeeperProperties implements ZookeeperParameters {
 
   public void setProcessingThreadPoolSize(int processingThreadPoolSize) {
     this.processingThreadPoolSize = processingThreadPoolSize;
+  }
+
+  @Override
+  public boolean isEnsembleTrackerEnabled() {
+    return ensembleTracker;
+  }
+
+  public void setEnsembleTrackerEnabled(boolean ensembleTrackerEnabled) {
+    this.ensembleTracker = ensembleTrackerEnabled;
   }
 
   public ZookeeperAuthenticationProperties getAuthentication() {

--- a/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/config/ZookeeperProperties.java
+++ b/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/config/ZookeeperProperties.java
@@ -9,7 +9,7 @@ public class ZookeeperProperties implements ZookeeperParameters {
 
   private String datacenter = "dc";
 
-  private Duration baseSleepTime = Duration.ofMillis(1000);
+  private Duration baseSleepTime = Duration.ofSeconds(1);
 
   private Duration maxSleepTime = Duration.ofSeconds(30);
 
@@ -22,6 +22,8 @@ public class ZookeeperProperties implements ZookeeperParameters {
   private String root = "/hermes";
 
   private int processingThreadPoolSize = 5;
+
+  private boolean ensembleTracker = false;
 
   private ZookeeperAuthenticationProperties authentication =
       new ZookeeperAuthenticationProperties();
@@ -124,6 +126,15 @@ public class ZookeeperProperties implements ZookeeperParameters {
 
   public void setProcessingThreadPoolSize(int processingThreadPoolSize) {
     this.processingThreadPoolSize = processingThreadPoolSize;
+  }
+
+  @Override
+  public boolean isEnsembleTrackerEnabled() {
+    return ensembleTracker;
+  }
+
+  public void setEnsembleTrackerEnabled(boolean ensembleTrackerEnabled) {
+    this.ensembleTracker = ensembleTrackerEnabled;
   }
 
   public ZookeeperAuthenticationProperties getAuthentication() {

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/config/zookeeper/ZookeeperProperties.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/config/zookeeper/ZookeeperProperties.java
@@ -9,7 +9,7 @@ public class ZookeeperProperties implements ZookeeperParameters {
 
   private String datacenter = "dc";
 
-  private Duration baseSleepTime = Duration.ofSeconds(1000);
+  private Duration baseSleepTime = Duration.ofSeconds(1);
 
   private Duration maxSleepTime = Duration.ofSeconds(30);
 
@@ -22,6 +22,8 @@ public class ZookeeperProperties implements ZookeeperParameters {
   private String root = "/hermes";
 
   private int processingThreadPoolSize = 5;
+
+  private boolean ensembleTracker = false;
 
   private ZookeeperAuthenticationProperties authentication =
       new ZookeeperAuthenticationProperties();
@@ -123,6 +125,15 @@ public class ZookeeperProperties implements ZookeeperParameters {
   @Override
   public String getPassword() {
     return authentication.password;
+  }
+
+  @Override
+  public boolean isEnsembleTrackerEnabled() {
+    return ensembleTracker;
+  }
+
+  public void setEnsembleTrackerEnabled(boolean ensembleTrackerEnabled) {
+    this.ensembleTracker = ensembleTrackerEnabled;
   }
 
   public ZookeeperAuthenticationProperties getAuthentication() {

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/infrastructure/zookeeper/ZookeeperClientManager.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/infrastructure/zookeeper/ZookeeperClientManager.java
@@ -69,7 +69,8 @@ public class ZookeeperClientManager {
             .connectString(parameters.getConnectionString())
             .sessionTimeoutMs((int) parameters.getSessionTimeout().toMillis())
             .connectionTimeoutMs((int) parameters.getConnectionTimeout().toMillis())
-            .retryPolicy(retryPolicy);
+            .retryPolicy(retryPolicy)
+            .ensembleTracker(parameters.isEnsembleTrackerEnabled());
 
     if (parameters.isAuthenticationEnabled()) {
       builder.authorization(


### PR DESCRIPTION
Adds a configurable `ensembleTrackerEnabled` property (default: `false`) to ZooKeeper configuration for management, consumers, and frontend.
