### PR TITLE
Include cause details in Avro validation error responses

### DIFF
--- a/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/publishing/handlers/MessageCreateHandler.java
+++ b/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/publishing/handlers/MessageCreateHandler.java
@@ -95,7 +95,7 @@ class MessageCreateHandler implements HttpHandler {
   private static String buildDetailedMessage(Exception exception) {
     String message = exception.getMessage();
     Throwable cause = exception.getCause();
-    if (message == null) {
+    if (message == null || message.isEmpty()) {
       return cause != null && cause.getMessage() != null ? cause.getMessage() : "";
     }
     if (cause != null

--- a/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/publishing/handlers/MessageCreateHandler.java
+++ b/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/publishing/handlers/MessageCreateHandler.java
@@ -50,7 +50,7 @@ class MessageCreateHandler implements HttpHandler {
           exchange,
           attachment.getTopic(),
           attachment.getMessageId(),
-          error("Invalid message: " + exception.getMessage(), VALIDATION_ERROR),
+          error("Invalid message: " + buildDetailedMessage(exception), VALIDATION_ERROR),
           exception);
     } catch (CouldNotLoadSchemaException | SchemaNotFoundException exception) {
       attachment.removeTimeout();
@@ -90,5 +90,20 @@ class MessageCreateHandler implements HttpHandler {
           error("Exception caught while creating message", INTERNAL_ERROR),
           exception);
     }
+  }
+
+  private static String buildDetailedMessage(Exception exception) {
+    String message = exception.getMessage();
+    Throwable cause = exception.getCause();
+    if (message == null) {
+      return cause != null && cause.getMessage() != null ? cause.getMessage() : "";
+    }
+    if (cause != null
+        && cause.getMessage() != null
+        && !cause.getMessage().isEmpty()
+        && !message.contains(cause.getMessage())) {
+      return message + ": " + cause.getMessage();
+    }
+    return message;
   }
 }

--- a/integration-tests/src/integrationTest/java/pl/allegro/tech/hermes/integrationtests/PublishingAvroTest.java
+++ b/integration-tests/src/integrationTest/java/pl/allegro/tech/hermes/integrationtests/PublishingAvroTest.java
@@ -296,6 +296,31 @@ public class PublishingAvroTest {
   }
 
   @Test
+  public void shouldGetBadRequestWithDetailedCauseForMissingRequiredAvroField() {
+    // given
+    TopicWithSchema topicWithSchema =
+        topicWithSchema(
+            topicWithRandomName().withContentType(AVRO).build(), user.getSchemaAsString());
+    Topic topic = hermes.initHelper().createTopicWithSchema(topicWithSchema);
+
+    // when - JSON message missing required "age" field (int type, no default)
+    String message = "{\"name\":\"john\",\"favoriteColor\":\"blue\"}";
+    WebTestClient.ResponseSpec response =
+        hermes.api().publishJSON(topic.getQualifiedName(), message);
+
+    // then - error response should contain the cause details about the missing field
+    response.expectStatus().isBadRequest();
+    response
+        .expectBody(String.class)
+        .value(
+            body -> {
+              assertThat(body).contains("VALIDATION_ERROR");
+              assertThat(body).contains("age");
+              assertThat(body).contains("not set and has no default value");
+            });
+  }
+
+  @Test
   public void shouldGetBadRequestForInvalidJsonWithAvroSchema() {
     // given
     TopicWithSchema topicWithSchema =


### PR DESCRIPTION
When publishing a message that fails Avro validation (e.g. missing required field), Hermes returns a generic error like "Invalid message: Failed to convert JSON to Avro" without any details about the root cause.

This happens because the json2avro library wraps AvroRuntimeException into AvroConversionException without including the cause message. This PR fixes it on the Hermes side by extracting the cause details in MessageCreateHandler and appending them to the error response.

Before: {"message":"Invalid message: Failed to convert JSON to Avro","code":"VALIDATION_ERROR"} 

After: {"message":"Invalid message: Failed to convert JSON to Avro: Field age type:ARRAY pos:15 not set and has no default value","code":"VALIDATION_ERROR"}