### PR TITLE
Modernize lang constructs and use jakarta jaxb

### DIFF
--- a/hermes-api/build.gradle
+++ b/hermes-api/build.gradle
@@ -13,9 +13,7 @@ dependencies {
     implementation group: 'com.google.guava', name: 'guava', version: versions.guava
     api group: 'com.damnhandy', name: 'handy-uri-templates', version: '2.1.8'
     api group: 'jakarta.xml.bind', name: 'jakarta.xml.bind-api', version: '4.0.0'
-
-    implementation group: 'com.sun.xml.bind', name: 'jaxb-core', version: '4.0.5'
-    implementation group: 'com.sun.xml.bind', name: 'jaxb-impl', version: '4.0.5'
+    implementation group: 'org.glassfish.jaxb', name: 'jaxb-runtime', version: '4.0.6'
     implementation group: 'jakarta.annotation', name: 'jakarta.annotation-api', version: '3.0.0'
 
     testImplementation group: 'org.spockframework', name: 'spock-core', version: versions.spock

--- a/hermes-benchmark/src/jmh/java/pl/allegro/tech/hermes/benchmark/consumer/InMemoryDelayedMessageSender.java
+++ b/hermes-benchmark/src/jmh/java/pl/allegro/tech/hermes/benchmark/consumer/InMemoryDelayedMessageSender.java
@@ -4,6 +4,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.LongAdder;
 import org.openjdk.jmh.infra.Blackhole;
@@ -30,7 +31,7 @@ public class InMemoryDelayedMessageSender implements MessageSender {
     return CompletableFuture.supplyAsync(
         () -> {
           longAdder.increment();
-          blackhole.consume(message.getOffset() * Math.random());
+          blackhole.consume(message.getOffset() * ThreadLocalRandom.current().nextDouble());
           return MessageSendingResult.succeededResult();
         },
         executor);

--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/infrastructure/zookeeper/ZookeeperGroupRepository.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/infrastructure/zookeeper/ZookeeperGroupRepository.java
@@ -98,8 +98,7 @@ public class ZookeeperGroupRepository extends ZookeeperBasedRepository implement
   public List<Group> listGroups() {
     return listGroupNames().stream()
         .map(n -> getGroupDetails(n, true))
-        .filter(Optional::isPresent)
-        .map(Optional::get)
+        .flatMap(Optional::stream)
         .collect(Collectors.toList());
   }
 

--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/infrastructure/zookeeper/ZookeeperSubscriptionRepository.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/infrastructure/zookeeper/ZookeeperSubscriptionRepository.java
@@ -148,8 +148,7 @@ public class ZookeeperSubscriptionRepository extends ZookeeperBasedRepository
   public List<Subscription> listSubscriptions(TopicName topicName) {
     return listSubscriptionNames(topicName).stream()
         .map(subscription -> getSubscriptionDetails(topicName, subscription, true))
-        .filter(Optional::isPresent)
-        .map(Optional::get)
+        .flatMap(Optional::stream)
         .collect(Collectors.toList());
   }
 

--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/infrastructure/zookeeper/ZookeeperTopicRepository.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/infrastructure/zookeeper/ZookeeperTopicRepository.java
@@ -56,8 +56,7 @@ public class ZookeeperTopicRepository extends ZookeeperBasedRepository implement
   public List<Topic> listTopics(String groupName) {
     return listTopicNames(groupName).stream()
         .map(name -> getTopicDetails(new TopicName(groupName, name), true))
-        .filter(Optional::isPresent)
-        .map(Optional::get)
+        .flatMap(Optional::stream)
         .collect(Collectors.toList());
   }
 
@@ -196,8 +195,7 @@ public class ZookeeperTopicRepository extends ZookeeperBasedRepository implement
   public List<Topic> getTopicsDetails(Collection<TopicName> topicNames) {
     return topicNames.stream()
         .map(topicName -> getTopicDetails(topicName, true))
-        .filter(Optional::isPresent)
-        .map(Optional::get)
+        .flatMap(Optional::stream)
         .collect(Collectors.toList());
   }
 

--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/infrastructure/zookeeper/ZookeeperWorkloadConstraintsCache.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/infrastructure/zookeeper/ZookeeperWorkloadConstraintsCache.java
@@ -58,7 +58,7 @@ class ZookeeperWorkloadConstraintsCache extends PathChildrenCache
 
   private void updateCache(String path, byte[] bytes) {
     Optional<Constraints> constraints = bytesToConstraints(bytes, path);
-    if (!constraints.isPresent()) {
+    if (constraints.isEmpty()) {
       return;
     }
     if (isSubscription(path)) {

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/rate/maxrate/MaxRateBalancer.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/rate/maxrate/MaxRateBalancer.java
@@ -87,7 +87,7 @@ class MaxRateBalancer {
   }
 
   private boolean isUnassigned(ConsumerRateInfo rateInfo) {
-    return !rateInfo.getMaxRate().isPresent();
+    return rateInfo.getMaxRate().isEmpty();
   }
 
   private Map<Boolean, List<ActiveConsumerInfo>> busyOrNot(List<ActiveConsumerInfo> infos) {
@@ -250,7 +250,7 @@ class MaxRateBalancer {
                     return new ConsumerRateChange(
                         share.getConsumerId(), share.currentMax, -toDistribute);
                   })
-              .collect(Collectors.toList());
+              .toList();
 
       double toDistribute =
           freedByNotBusy

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/sender/MultiMessageSendingResult.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/consumer/sender/MultiMessageSendingResult.java
@@ -47,8 +47,7 @@ public class MultiMessageSendingResult implements MessageSendingResult {
   public Optional<Long> getRetryAfterMillis() {
     return children.stream()
         .map(MessageSendingResult::getRetryAfterMillis)
-        .filter(Optional::isPresent)
-        .map(Optional::get)
+        .flatMap(Optional::stream)
         .min(Comparator.naturalOrder());
   }
 
@@ -60,7 +59,7 @@ public class MultiMessageSendingResult implements MessageSendingResult {
   @Override
   public boolean isClientError() {
     List<SingleMessageSendingResult> failed =
-        children.stream().filter(child -> !child.succeeded()).collect(Collectors.toList());
+        children.stream().filter(child -> !child.succeeded()).toList();
     return !failed.isEmpty() && failed.stream().allMatch(MessageSendingResult::isClientError);
   }
 
@@ -89,8 +88,7 @@ public class MultiMessageSendingResult implements MessageSendingResult {
     return children.stream()
         .filter(filter)
         .map(SingleMessageSendingResult::getRequestUri)
-        .filter(Optional::isPresent)
-        .map(Optional::get)
+        .flatMap(Optional::stream)
         .collect(Collectors.toList());
   }
 

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/workload/ConsumerAssignmentCache.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/workload/ConsumerAssignmentCache.java
@@ -86,7 +86,7 @@ public class ConsumerAssignmentCache implements NodeCacheListener {
 
     callbacks.forEach(
         callback -> {
-          if (!callback.watchedConsumerId().isPresent()
+          if (callback.watchedConsumerId().isEmpty()
               || callback.watchedConsumerId().get().equals(consumerId)) {
             assignmentDeletions.forEach(callback::onAssignmentRemoved);
             assignmentsAdditions.forEach(callback::onSubscriptionAssigned);

--- a/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/workload/ConsumerWorkloadEncoder.java
+++ b/hermes-consumers/src/main/java/pl/allegro/tech/hermes/consumers/supervisor/workload/ConsumerWorkloadEncoder.java
@@ -29,8 +29,7 @@ class ConsumerWorkloadEncoder {
     Set<SubscriptionId> ids =
         subscriptions.stream()
             .map(this.subscriptionIds::getSubscriptionId)
-            .filter(Optional::isPresent)
-            .map(Optional::get)
+            .flatMap(Optional::stream)
             .collect(Collectors.toSet());
 
     AssignmentsEncoder.SubscriptionsEncoder subscriptionsEncoder =

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/api/OfflineClientsEndpoint.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/api/OfflineClientsEndpoint.java
@@ -26,7 +26,7 @@ public class OfflineClientsEndpoint {
   private final Optional<OfflineClientsService> offlineClientsService;
 
   OfflineClientsEndpoint(Optional<OfflineClientsService> offlineClientsService) {
-    if (!offlineClientsService.isPresent()) {
+    if (offlineClientsService.isEmpty()) {
       logger.info("Offline clients bean is absent");
     }
     this.offlineClientsService = offlineClientsService;

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/domain/subscription/health/SubscriptionHealthChecker.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/domain/subscription/health/SubscriptionHealthChecker.java
@@ -52,8 +52,7 @@ public class SubscriptionHealthChecker {
       SubscriptionHealthContext healthContext) {
     return problemIndicators.stream()
         .map(indicator -> indicator.getProblem(healthContext))
-        .filter(Optional::isPresent)
-        .map(Optional::get)
+        .flatMap(Optional::stream)
         .collect(toSet());
   }
 }

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/infrastructure/kafka/MultiDCAwareService.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/infrastructure/kafka/MultiDCAwareService.java
@@ -195,8 +195,7 @@ public class MultiDCAwareService {
         .map(
             brokersClusterService ->
                 brokersClusterService.describeConsumerGroup(topic, subscriptionName))
-        .filter(Optional::isPresent)
-        .map(Optional::get)
+        .flatMap(Optional::stream)
         .collect(toList());
   }
 

--- a/hermes-management/src/main/java/pl/allegro/tech/hermes/management/infrastructure/query/matcher/ComparisonMatcher.java
+++ b/hermes-management/src/main/java/pl/allegro/tech/hermes/management/infrastructure/query/matcher/ComparisonMatcher.java
@@ -27,10 +27,10 @@ public class ComparisonMatcher implements Matcher {
     Optional<Double> leftSideValueAsNumber = tryParseNumber(leftSideValue);
     Optional<Double> rightSideValueAsNumber = tryParseNumber(rightSideValue);
 
-    if (!leftSideValueAsNumber.isPresent()) {
+    if (leftSideValueAsNumber.isEmpty()) {
       return true;
     }
-    if (!rightSideValueAsNumber.isPresent()) {
+    if (rightSideValueAsNumber.isEmpty()) {
       throw new MatcherInputException("Comparison operator requires numerical data");
     }
     return makeComparison(leftSideValueAsNumber.get(), rightSideValueAsNumber.get());


### PR DESCRIPTION
This pull request focuses on modernizing and simplifying the codebase by replacing deprecated or verbose Optional handling patterns with more concise and idiomatic Java 11+ constructs. It also updates a dependency to use a more standard JAXB runtime implementation and improves randomness usage in benchmarks.

**Optional Handling Modernization:**

* Replaced `.filter(Optional::isPresent).map(Optional::get)` with `.flatMap(Optional::stream)` in various repository and result-processing methods to simplify extraction of present values from Optionals (`ZookeeperGroupRepository.java`, `ZookeeperSubscriptionRepository.java`, `ZookeeperTopicRepository.java`, `MultiMessageSendingResult.java`, `ConsumerWorkloadEncoder.java`, `SubscriptionHealthChecker.java`, `MultiDCAwareService.java`). [[1]](diffhunk://#diff-ed0279f17733d0d81d2e245bf690c862bea84c96c63f1a6be52678dada893ad9L101-R101) [[2]](diffhunk://#diff-e3aa6163d7d4d27d83bf7f27440f6a7f83e4993d528d6efd32cb66ee0b4c620dL151-R151) [[3]](diffhunk://#diff-dfb544f75f0eb98862430d1d7f471099bb66a56abae91333200949e92b552080L59-R59) [[4]](diffhunk://#diff-dfb544f75f0eb98862430d1d7f471099bb66a56abae91333200949e92b552080L199-R198) [[5]](diffhunk://#diff-242a0bf0fe7c2af0be6aa3b1d0e7098d5bf613d91739a1c08c4bf18a758dc84aL50-R50) [[6]](diffhunk://#diff-242a0bf0fe7c2af0be6aa3b1d0e7098d5bf613d91739a1c08c4bf18a758dc84aL92-R91) [[7]](diffhunk://#diff-8afb5556965af8858b5de1c6660ff88a5181dd658cfe093726ab3886693499e1L32-R32) [[8]](diffhunk://#diff-8250290ee1193bea1e88a3db4435da0cb724e0b23b972c9c0757231ed3b1cf77L55-R55) [[9]](diffhunk://#diff-f1cbadae4736766a9841ce7d702b9d637a7bc3c889a0304148217c7fada5ee92L198-R198)

* Replaced `isPresent()`/`!isPresent()` checks with `isEmpty()` for improved readability and clarity in several places (`ZookeeperWorkloadConstraintsCache.java`, `MaxRateBalancer.java`, `ConsumerAssignmentCache.java`, `OfflineClientsEndpoint.java`, `ComparisonMatcher.java`). [[1]](diffhunk://#diff-ceeb831ca5bf63b251f1aef7b6d394b3282fbc4bded4550aedf0c1ecf0350129L61-R61) [[2]](diffhunk://#diff-9ae74b65b15a86bc80a10e161260e2b567c6146b84552fa76578a01088049448L90-R90) [[3]](diffhunk://#diff-2f13882c75b07ba7fda704ce68e82445a563af9cd60847e51480224536375ae9L89-R89) [[4]](diffhunk://#diff-cfc85eb9c054b0b5e0b4fbe8cd061329e909b539498944bbe77bf9ee72d49accL29-R29) [[5]](diffhunk://#diff-b86ba95fbcc045d788f6b8ad3f9beb5ff04149b60b04e8476530964b02a39a89L30-R33)

* Replaced `.collect(Collectors.toList())` with `.toList()` for brevity where applicable (`MaxRateBalancer.java`, `MultiMessageSendingResult.java`). [[1]](diffhunk://#diff-9ae74b65b15a86bc80a10e161260e2b567c6146b84552fa76578a01088049448L253-R253) [[2]](diffhunk://#diff-242a0bf0fe7c2af0be6aa3b1d0e7098d5bf613d91739a1c08c4bf18a758dc84aL63-R62)

**Dependency Update:**

* Switched JAXB dependency from `com.sun.xml.bind:jaxb-core` and `jaxb-impl` to `org.glassfish.jaxb:jaxb-runtime` for better compatibility and maintenance (`hermes-api/build.gradle`).

**Benchmark Improvement:**

* Updated randomness generation in `InMemoryDelayedMessageSender` to use `ThreadLocalRandom.current().nextDouble()` instead of `Math.random()` for better performance and thread safety in benchmarks (`InMemoryDelayedMessageSender.java`). [[1]](diffhunk://#diff-1880bdbfcfccc45efd00b0d0e7c5926664d0e9e3d870cbabee07cf0268eeea06R7) [[2]](diffhunk://#diff-1880bdbfcfccc45efd00b0d0e7c5926664d0e9e3d870cbabee07cf0268eeea06L33-R34)