### PR TITLE
Hermes client metrics descriptions 

### DIFF
--- a/docs/docs/user/java-client.md
+++ b/docs/docs/user/java-client.md
@@ -54,14 +54,14 @@ Once created, you can start publishing messages. Hermes Client API is asynchrono
 JSON sender sets `application/json` content type.
 
 ```java
-hermesClient.publishJSON("com.group.json", "{hello: 1}");
+hermesClient.publishJSON("com.group.json","{hello: 1}");
 ```
 
 Avro sender sets `avro/binary` content type. It also requires to pass Avro schema version of this message, which is
 passed on to Hermes in `Schema-Version` header.
 
 ```java
-hermesClient.publishAvro("com.group.avro", 1, avroMessage.getBytes());
+hermesClient.publishAvro("com.group.avro",1,avroMessage.getBytes());
 ```
 
 You can also use `HermesMessage#Builder` to create HermesMessage object, to e.g. pass custom headers:
@@ -151,31 +151,31 @@ become underscores, counters get the `_total` suffix, timers get `_seconds` suff
 
 #### Counters
 
-| Micrometer name | Prometheus name | Tags | Description |
-|---|---|---|---|
-| `hermes-client.status` | `hermes_client_status_total` | `topic`, `code` | Total number of HTTP responses received from Hermes, partitioned by HTTP status code. |
-| `hermes-client.publish.attempt` | `hermes_client_publish_attempt_total` | `topic` | Total number of messages for which the publish process has completed (either successfully or after exhausting all retries). |
-| `hermes-client.publish.failure` | `hermes_client_publish_failure_total` | `topic` | Total number of individual publish attempts that received a failure (non-2xx) HTTP response. |
-| `hermes-client.publish.finally.success` | `hermes_client_publish_finally_success_total` | `topic` | Total number of messages that were ultimately published successfully (with or without retries). |
-| `hermes-client.publish.finally.failure` | `hermes_client_publish_finally_failure_total` | `topic` | Total number of messages that ultimately failed to be published (after all retries were exhausted or a non-2xx response was final). |
-| `hermes-client.publish.retry.attempt` | `hermes_client_publish_retry_attempt_total` | `topic` | Total number of messages for which at least one retry was attempted, regardless of the final outcome. |
-| `hermes-client.publish.retry.success` | `hermes_client_publish_retry_success_total` | `topic` | Total number of messages that were published successfully after at least one retry. |
-| `hermes-client.publish.retry.failure` | `hermes_client_publish_retry_failure_total` | `topic` | Total number of individual retry attempts that resulted in a failure response. |
-| `hermes-client.failure` | `hermes_client_failure_total` | `topic` | Total number of failed publish attempts (exceptions or non-2xx responses), including each failed retry. |
-| `hermes-client.retries.count` | `hermes_client_retries_count_total` | `topic` | Total number of retry attempts triggered by a failed previous attempt (exception or response matching retry condition). |
-| `hermes-client.retries.success` | `hermes_client_retries_success_total` | `topic` | Total number of messages for which the publish completed without exhausting all retries (including first-attempt successes). |
-| `hermes-client.retries.exhausted` | `hermes_client_retries_exhausted_total` | `topic` | Total number of messages for which all retry attempts were exhausted without success. |
+| Micrometer name                         | Prometheus name                               | Tags            | Description                                                                                                                         |
+|-----------------------------------------|-----------------------------------------------|-----------------|-------------------------------------------------------------------------------------------------------------------------------------|
+| `hermes-client.status`                  | `hermes_client_status_total`                  | `topic`, `code` | Total number of HTTP responses received from Hermes, partitioned by HTTP status code.                                               |
+| `hermes-client.publish.attempt`         | `hermes_client_publish_attempt_total`         | `topic`         | Total number of messages for which the publish process has completed (either successfully or after exhausting all retries).         |
+| `hermes-client.publish.failure`         | `hermes_client_publish_failure_total`         | `topic`         | Total number of individual publish attempts that received a failure (non-2xx) HTTP response.                                        |
+| `hermes-client.publish.finally.success` | `hermes_client_publish_finally_success_total` | `topic`         | Total number of messages that were ultimately published successfully (with or without retries).                                     |
+| `hermes-client.publish.finally.failure` | `hermes_client_publish_finally_failure_total` | `topic`         | Total number of messages that ultimately failed to be published (after all retries were exhausted or a non-2xx response was final). |
+| `hermes-client.publish.retry.attempt`   | `hermes_client_publish_retry_attempt_total`   | `topic`         | Total number of messages for which at least one retry was attempted, regardless of the final outcome.                               |
+| `hermes-client.publish.retry.success`   | `hermes_client_publish_retry_success_total`   | `topic`         | Total number of messages that were published successfully after at least one retry.                                                 |
+| `hermes-client.publish.retry.failure`   | `hermes_client_publish_retry_failure_total`   | `topic`         | Total number of individual retry attempts that resulted in a failure response.                                                      |
+| `hermes-client.failure`                 | `hermes_client_failure_total`                 | `topic`         | Total number of failed publish attempts (exceptions or non-2xx responses), including each failed retry.                             |
+| `hermes-client.retries.count`           | `hermes_client_retries_count_total`           | `topic`         | Total number of retry attempts triggered by a failed previous attempt (exception or response matching retry condition).             |
+| `hermes-client.retries.success`         | `hermes_client_retries_success_total`         | `topic`         | Total number of messages for which the publish completed without exhausting all retries (including first-attempt successes).        |
+| `hermes-client.retries.exhausted`       | `hermes_client_retries_exhausted_total`       | `topic`         | Total number of messages for which all retry attempts were exhausted without success.                                               |
 
 #### Timer
 
-| Micrometer name | Prometheus name | Tags | Description |
-|---|---|---|---|
+| Micrometer name         | Prometheus name                                                                                                   | Tags    | Description                                                                                   |
+|-------------------------|-------------------------------------------------------------------------------------------------------------------|---------|-----------------------------------------------------------------------------------------------|
 | `hermes-client.latency` | `hermes_client_latency_seconds_count` / `hermes_client_latency_seconds_sum` / `hermes_client_latency_seconds_max` | `topic` | Time spent sending a message to Hermes, recorded for every publish attempt including retries. |
 
 #### Distribution summary (histogram)
 
-| Micrometer name | Prometheus name | Tags | Description |
-|---|---|---|---|
+| Micrometer name                  | Prometheus name                                                                                                      | Tags    | Description                                                                                                                                                                                                         |
+|----------------------------------|----------------------------------------------------------------------------------------------------------------------|---------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `hermes-client.retries.attempts` | `hermes_client_retries_attempts_count` / `hermes_client_retries_attempts_sum` / `hermes_client_retries_attempts_max` | `topic` | Distribution of the number of retry attempts per message. Recorded when the publish completes without exhausting all retries — value is 0 when no retries were needed. Not recorded when all retries are exhausted. |
 
 ### Example dashboard queries
@@ -183,6 +183,7 @@ become underscores, counters get the `_total` suffix, timers get `_seconds` suff
 Below are example PromQL / MetricsQL queries that can be used to build a Hermes topic monitoring dashboard.
 
 **Publish success rate (%):**
+
 ```promql
 sum(rate(hermes_client_publish_finally_success_total{topic="com_group.topic"}[5m]))
 /
@@ -201,6 +202,7 @@ histogram_quantile(0.99, rate(hermes_client_latency_seconds_bucket{topic="com_gr
 ```
 
 **Retry rate (% of publishes that required retries):**
+
 ```promql
 sum(rate(hermes_client_publish_retry_attempt_total{topic="com_group.topic"}[5m]))
 /
@@ -209,6 +211,7 @@ sum(rate(hermes_client_publish_attempt_total{topic="com_group.topic"}[5m]))
 ```
 
 **Average number of retries per message:**
+
 ```promql
 sum(rate(hermes_client_retries_attempts_sum{topic="com_group.topic"}[5m]))
 /
@@ -216,6 +219,7 @@ sum(rate(hermes_client_retries_attempts_count{topic="com_group.topic"}[5m]))
 ```
 
 **Retries exhausted rate:**
+
 ```promql
 sum(rate(hermes_client_retries_exhausted_total{topic="com_group.topic"}[5m]))
 ```

--- a/docs/docs/user/java-client.md
+++ b/docs/docs/user/java-client.md
@@ -54,7 +54,7 @@ Once created, you can start publishing messages. Hermes Client API is asynchrono
 JSON sender sets `application/json` content type.
 
 ```java
-hermesClient.publishJSON("com.group.json","{hello: 1}");
+hermesClient.publishJSON("com.group.json", "{hello: 1}");
 ```
 
 Avro sender sets `avro/binary` content type. It also requires to pass Avro schema version of this message, which is

--- a/docs/docs/user/java-client.md
+++ b/docs/docs/user/java-client.md
@@ -114,18 +114,110 @@ client.closeAsync(50).get(1, TimeUnit.SECONDS);
 
 ## Metrics
 
-**Requirement**: dependency `io.dropwizard.metrics:metrics-core` must be provided at runtime.
+Hermes Client reports publishing metrics under the `hermes-client.` prefix. All metrics are tagged with `topic`.
 
-After providing `MetricRegistry`, Hermes Client metrics will be reported to `hermes-client` branch. They include
-measured latency, meters for each status code received and meter for failures.
+### Setup
+
+#### Micrometer (recommended)
 
 ```java
-MetricRegistry registry = myMetricRegistryFactory.createMetricRegistry();
+MeterRegistry meterRegistry = ... // your MeterRegistry (e.g. PrometheusMeterRegistry)
+MetricsProvider metricsProvider = new MicrometerTaggedMetricsProvider(meterRegistry);
+
+HermesClient client = HermesClientBuilder.hermesClient(sender)
+    .withURI(URI.create("http://localhost:8080"))
+    .withMetrics(metricsProvider)
+    .build();
+```
+
+#### Dropwizard
+
+**Requirement**: dependency `io.dropwizard.metrics:metrics-core` must be provided at runtime.
+
+```java
+MetricRegistry registry = new MetricRegistry();
 
 HermesClient client = HermesClientBuilder.hermesClient(sender)
     .withURI(URI.create("http://localhost:8080"))
     .withMetrics(registry)
     .build();
+```
+
+### Metrics reference
+
+The table below lists all metrics reported by the Hermes Client. The **Prometheus name** column shows
+the metric name as it appears in Prometheus after standard Micrometer naming conversion (dots and hyphens
+become underscores, counters get the `_total` suffix, timers get `_seconds` suffix).
+
+#### Counters
+
+| Micrometer name | Prometheus name | Tags | Description |
+|---|---|---|---|
+| `hermes-client.status` | `hermes_client_status_total` | `topic`, `code` | Total number of HTTP responses received from Hermes, partitioned by HTTP status code. |
+| `hermes-client.publish.attempt` | `hermes_client_publish_attempt_total` | `topic` | Total number of messages for which the publish process has completed (either successfully or after exhausting all retries). |
+| `hermes-client.publish.failure` | `hermes_client_publish_failure_total` | `topic` | Total number of individual publish attempts that received a failure (non-2xx) HTTP response. |
+| `hermes-client.publish.finally.success` | `hermes_client_publish_finally_success_total` | `topic` | Total number of messages that were ultimately published successfully (with or without retries). |
+| `hermes-client.publish.finally.failure` | `hermes_client_publish_finally_failure_total` | `topic` | Total number of messages that ultimately failed to be published (after all retries were exhausted or a non-2xx response was final). |
+| `hermes-client.publish.retry.attempt` | `hermes_client_publish_retry_attempt_total` | `topic` | Total number of messages for which at least one retry was attempted, regardless of the final outcome. |
+| `hermes-client.publish.retry.success` | `hermes_client_publish_retry_success_total` | `topic` | Total number of messages that were published successfully after at least one retry. |
+| `hermes-client.publish.retry.failure` | `hermes_client_publish_retry_failure_total` | `topic` | Total number of individual retry attempts that resulted in a failure response. |
+| `hermes-client.failure` | `hermes_client_failure_total` | `topic` | Total number of failed publish attempts (exceptions or non-2xx responses), including each failed retry. |
+| `hermes-client.retries.count` | `hermes_client_retries_count_total` | `topic` | Total number of retry attempts triggered by a failed previous attempt (exception or response matching retry condition). |
+| `hermes-client.retries.success` | `hermes_client_retries_success_total` | `topic` | Total number of messages for which the publish completed without exhausting all retries (including first-attempt successes). |
+| `hermes-client.retries.exhausted` | `hermes_client_retries_exhausted_total` | `topic` | Total number of messages for which all retry attempts were exhausted without success. |
+
+#### Timer
+
+| Micrometer name | Prometheus name | Tags | Description |
+|---|---|---|---|
+| `hermes-client.latency` | `hermes_client_latency_seconds_count` / `hermes_client_latency_seconds_sum` / `hermes_client_latency_seconds_max` | `topic` | Time spent sending a message to Hermes, recorded for every publish attempt including retries. |
+
+#### Distribution summary (histogram)
+
+| Micrometer name | Prometheus name | Tags | Description |
+|---|---|---|---|
+| `hermes-client.retries.attempts` | `hermes_client_retries_attempts_count` / `hermes_client_retries_attempts_sum` / `hermes_client_retries_attempts_max` | `topic` | Distribution of the number of retry attempts per message. Recorded when the publish completes without exhausting all retries — value is 0 when no retries were needed. Not recorded when all retries are exhausted. |
+
+### Example dashboard queries
+
+Below are example PromQL / MetricsQL queries that can be used to build a Hermes topic monitoring dashboard.
+
+**Publish success rate (%):**
+```promql
+sum(rate(hermes_client_publish_finally_success_total{topic="com_group.topic"}[5m]))
+/
+sum(rate(hermes_client_publish_attempt_total{topic="com_group.topic"}[5m]))
+* 100
+```
+
+**Publish latency (p99):**
+
+Note: `histogram_quantile` requires histogram buckets to be enabled in Micrometer configuration
+(e.g. via `publishPercentileHistogram(true)` on the Timer). Without that, use `hermes_client_latency_seconds_max`
+for an approximation, or configure percentiles on the client side.
+
+```promql
+histogram_quantile(0.99, rate(hermes_client_latency_seconds_bucket{topic="com_group.topic"}[5m]))
+```
+
+**Retry rate (% of publishes that required retries):**
+```promql
+sum(rate(hermes_client_publish_retry_attempt_total{topic="com_group.topic"}[5m]))
+/
+sum(rate(hermes_client_publish_attempt_total{topic="com_group.topic"}[5m]))
+* 100
+```
+
+**Average number of retries per message:**
+```promql
+sum(rate(hermes_client_retries_attempts_sum{topic="com_group.topic"}[5m]))
+/
+sum(rate(hermes_client_retries_attempts_count{topic="com_group.topic"}[5m]))
+```
+
+**Retries exhausted rate:**
+```promql
+sum(rate(hermes_client_retries_exhausted_total{topic="com_group.topic"}[5m]))
 ```
 
 ## Sender implementations

--- a/hermes-client/src/main/java/pl/allegro/tech/hermes/client/metrics/MicrometerTaggedMetricsProvider.java
+++ b/hermes-client/src/main/java/pl/allegro/tech/hermes/client/metrics/MicrometerTaggedMetricsProvider.java
@@ -1,14 +1,76 @@
 package pl.allegro.tech.hermes.client.metrics;
 
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.DistributionSummary;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.Timer;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 public class MicrometerTaggedMetricsProvider implements MetricsProvider {
+
+  static final Map<String, String> METRIC_DESCRIPTIONS =
+      Map.ofEntries(
+          Map.entry(
+              "latency",
+              "Time spent sending a message to Hermes, recorded for every publish attempt"
+                  + " including retries."),
+          Map.entry(
+              "status",
+              "Total number of HTTP responses received from Hermes, partitioned by HTTP status"
+                  + " code."),
+          Map.entry(
+              "publish.failure",
+              "Total number of individual publish attempts that received a failure (non-2xx) HTTP"
+                  + " response."),
+          Map.entry(
+              "failure",
+              "Total number of failed publish attempts (exceptions or non-2xx responses), including"
+                  + " each failed retry."),
+          Map.entry(
+              "retries.count",
+              "Total number of retry attempts triggered by a failed previous attempt (exception or"
+                  + " response matching retry condition)."),
+          Map.entry(
+              "publish.retry.failure",
+              "Total number of individual retry attempts that resulted in a failure response."),
+          Map.entry(
+              "retries.success",
+              "Total number of messages for which the publish completed without exhausting all"
+                  + " retries (including first-attempt successes)."),
+          Map.entry(
+              "retries.attempts",
+              "Distribution of the number of retry attempts per message. Recorded when the publish"
+                  + " completes without exhausting all retries — value is 0 when no retries were"
+                  + " needed. Not recorded when all retries are exhausted."),
+          Map.entry(
+              "publish.attempt",
+              "Total number of messages for which the publish process has completed (either"
+                  + " successfully or after exhausting all retries)."),
+          Map.entry(
+              "publish.retry.success",
+              "Total number of messages that were published successfully after at least one"
+                  + " retry."),
+          Map.entry(
+              "publish.finally.success",
+              "Total number of messages that were ultimately published successfully (with or"
+                  + " without retries)."),
+          Map.entry(
+              "publish.finally.failure",
+              "Total number of messages that ultimately failed to be published (after all retries"
+                  + " were exhausted or a non-2xx response was final)."),
+          Map.entry(
+              "publish.retry.attempt",
+              "Total number of messages for which at least one retry was attempted, regardless of"
+                  + " the final outcome."),
+          Map.entry(
+              "retries.exhausted",
+              "Total number of messages for which all retry attempts were exhausted without"
+                  + " success."));
 
   private final MeterRegistry metrics;
 
@@ -24,13 +86,10 @@ public class MicrometerTaggedMetricsProvider implements MetricsProvider {
   @Override
   public void counterIncrement(String topic, String key, Map<String, String> tags) {
     tags.put("topic", topic);
-    metrics
-        .counter(
-            buildCounterName(key),
-            Tags.of(
-                tags.entrySet().stream()
-                    .map(e -> Tag.of(e.getKey(), e.getValue()))
-                    .collect(Collectors.toSet())))
+    Counter.builder(buildMetricName(key))
+        .description(METRIC_DESCRIPTIONS.get(key))
+        .tags(toTags(tags))
+        .register(metrics)
         .increment();
   }
 
@@ -38,13 +97,10 @@ public class MicrometerTaggedMetricsProvider implements MetricsProvider {
   public void timerRecord(String topic, String key, long duration, TimeUnit unit) {
     Map<String, String> tags = new HashMap<>();
     tags.put("topic", topic);
-    metrics
-        .timer(
-            buildCounterName(key),
-            Tags.of(
-                tags.entrySet().stream()
-                    .map(e -> Tag.of(e.getKey(), e.getValue()))
-                    .collect(Collectors.toSet())))
+    Timer.builder(buildMetricName(key))
+        .description(METRIC_DESCRIPTIONS.get(key))
+        .tags(toTags(tags))
+        .register(metrics)
         .record(duration, unit);
   }
 
@@ -52,17 +108,21 @@ public class MicrometerTaggedMetricsProvider implements MetricsProvider {
   public void histogramUpdate(String topic, String key, int value) {
     Map<String, String> tags = new HashMap<>();
     tags.put("topic", topic);
-    metrics
-        .summary(
-            buildCounterName(key),
-            Tags.of(
-                tags.entrySet().stream()
-                    .map(e -> Tag.of(e.getKey(), e.getValue()))
-                    .collect(Collectors.toSet())))
+    DistributionSummary.builder(buildMetricName(key))
+        .description(METRIC_DESCRIPTIONS.get(key))
+        .tags(toTags(tags))
+        .register(metrics)
         .record(value);
   }
 
-  private String buildCounterName(String key) {
+  private String buildMetricName(String key) {
     return prefix + key;
+  }
+
+  private Tags toTags(Map<String, String> tags) {
+    return Tags.of(
+        tags.entrySet().stream()
+            .map(e -> Tag.of(e.getKey(), e.getValue()))
+            .collect(Collectors.toSet()));
   }
 }

--- a/hermes-client/src/main/java/pl/allegro/tech/hermes/client/metrics/MicrometerTaggedMetricsProvider.java
+++ b/hermes-client/src/main/java/pl/allegro/tech/hermes/client/metrics/MicrometerTaggedMetricsProvider.java
@@ -13,7 +13,7 @@ import java.util.stream.Collectors;
 
 public class MicrometerTaggedMetricsProvider implements MetricsProvider {
 
-  static final Map<String, String> METRIC_DESCRIPTIONS =
+  private static final Map<String, String> METRIC_DESCRIPTIONS =
       Map.ofEntries(
           Map.entry(
               "latency",

--- a/hermes-client/src/test/groovy/pl/allegro/tech/hermes/client/HermesClientMicrometerTaggedMetricsTest.groovy
+++ b/hermes-client/src/test/groovy/pl/allegro/tech/hermes/client/HermesClientMicrometerTaggedMetricsTest.groovy
@@ -88,11 +88,39 @@ class HermesClientMicrometerTaggedMetricsTest extends Specification {
         metrics.timer("hermes-client.latency", "topic", "com_group.topic").count() == 3
     }
 
-    private CompletableFuture<HermesResponse> successFuture(HermesMessage message) {
+    def "should set descriptions on all registered metrics"() {
+        given:
+        def retries = 3
+        HermesClient client = hermesClient(failingHermesSender(retries - 1))
+                .withRetrySleep(0)
+                .withRetries(retries)
+                .withMetrics(metricsProvider).build()
+
+        HermesClient alwaysFailingClient = hermesClient({uri, msg -> failingFuture(new RuntimeException())})
+                .withRetrySleep(0)
+                .withRetries(1)
+                .withMetrics(metricsProvider).build()
+
+        when:
+        silence({ client.publish("com.group.topic", "123").join() })
+        silence({ alwaysFailingClient.publish("com.group.topic2", "456").join() })
+
+        then:
+        def registeredMeters = metrics.getMeters()
+                .findAll { it.id.name.startsWith("hermes-client.") }
+
+        registeredMeters.size() > 0
+
+        registeredMeters.every { meter ->
+            meter.id.description != null && !meter.id.description.isEmpty()
+        }
+    }
+
+    private static CompletableFuture<HermesResponse> successFuture(HermesMessage message) {
         return completedFuture(HermesResponseBuilder.hermesResponse(message).withHttpStatus(201).build())
     }
 
-    private CompletableFuture<HermesResponse> failingFuture(Throwable throwable) {
+    private static CompletableFuture<HermesResponse> failingFuture(Throwable throwable) {
         CompletableFuture<HermesResponse> future = new CompletableFuture<>()
         future.completeExceptionally(throwable)
         return future
@@ -112,7 +140,7 @@ class HermesClientMicrometerTaggedMetricsTest extends Specification {
         }
     }
 
-    private HermesSender delayedHermesSender(Duration sendLatencyMs) {
+    private static HermesSender delayedHermesSender(Duration sendLatencyMs) {
         new HermesSender() {
             @Override
             CompletableFuture<HermesResponse> send(URI uri, HermesMessage message) {
@@ -122,10 +150,10 @@ class HermesClientMicrometerTaggedMetricsTest extends Specification {
         }
     }
 
-    private void silence(Runnable runnable) {
+    private static void silence(Runnable runnable) {
         try {
             runnable.run()
-        } catch (Exception ex) {
+        } catch (Exception ignored) {
             // do nothing
         }
     }


### PR DESCRIPTION
## Motivation

Hermes client exposes 14 metrics but none of them have descriptions.
Users have to reverse-engineer the code to understand
what each metric measures.

## Changes

### Code
- Refactored `MicrometerTaggedMetricsProvider` to use Micrometer builder
  pattern (`Counter.builder()`, `Timer.builder()`,
  `DistributionSummary.builder()`) which supports `.description()`
- Added a `METRIC_DESCRIPTIONS` map with human-readable descriptions for
  all 14 client metrics
- Descriptions are automatically exposed on the Prometheus endpoint as
  `# HELP` comments

### Documentation
- Expanded the Metrics section in `docs/docs/user/java-client.md` with:
  - Micrometer setup example (previously only Dropwizard was shown)
  - Full reference table: Micrometer name, Prometheus name, tags,
    description
  - Example PromQL queries for common dashboard panels (success rate,
    p99 latency, retry rate, average retries, exhausted retries)

### Tests
- Added test verifying all registered `hermes-client.*` meters have
  non-null descriptions (covers both success-after-retry and
  retries-exhausted paths)