### PR TITLE
Add broker latency label indicating broker datacenter

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,34 @@ You can also run the following command to fix formatting for the whole project:
 ./.github/scripts/check-google-java-format.sh --fix
 ```
 
+### Running integration tests with Podman (macOS)
+
+Integration and slow integration tests use [Testcontainers](https://testcontainers.com/) and require a
+Docker-compatible runtime. On macOS with [Podman](https://podman.io/), export the following variables
+before running any test that requires containers:
+
+```shell
+export DOCKER_HOST="unix://$(podman machine inspect --format '{{.ConnectionInfo.PodmanSocket.Path}}')"
+export TESTCONTAINERS_RYUK_DISABLED=true
+```
+
+Then run tests as usual, e.g.:
+
+```shell
+./gradlew slowIntegrationTest
+./gradlew integrationTest
+```
+
+> **Podman VM resources**: `slowIntegrationTest` spawns many containers concurrently. Configure your
+> Podman VM with at least **8 CPUs** and **10 GB of memory** or container startup may fail
+> unexpectedly:
+>
+> ```shell
+> podman machine stop
+> podman machine set --cpus 8 --memory 10240
+> podman machine start
+> ```
+
 ## Test reports
 
 Test reports are available at https://allegro.github.io/hermes/allure, and performance test results can be found at https://allegro.github.io/hermes/performance/.

--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/common/metric/BrokerMetrics.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/common/metric/BrokerMetrics.java
@@ -12,7 +12,8 @@ public class BrokerMetrics {
     this.meterRegistry = meterRegistry;
   }
 
-  public void recordBrokerLatency(String broker, String brokerDc, Topic.Ack ack, Duration duration) {
+  public void recordBrokerLatency(
+      String broker, String brokerDc, Topic.Ack ack, Duration duration) {
     Timer.builder("broker.latency")
         .tag("broker", broker)
         .tag("broker_dc", brokerDc)

--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/common/metric/BrokerMetrics.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/common/metric/BrokerMetrics.java
@@ -12,9 +12,10 @@ public class BrokerMetrics {
     this.meterRegistry = meterRegistry;
   }
 
-  public void recordBrokerLatency(String broker, Topic.Ack ack, Duration duration) {
+  public void recordBrokerLatency(String broker, String brokerDc, Topic.Ack ack, Duration duration) {
     Timer.builder("broker.latency")
         .tag("broker", broker)
+        .tag("broker_dc", brokerDc)
         .tag("ack", ack.name())
         .publishPercentileHistogram()
         .maximumExpectedValue(Duration.ofSeconds(5))

--- a/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/producer/BrokerLatencyReporter.java
+++ b/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/producer/BrokerLatencyReporter.java
@@ -55,7 +55,9 @@ public class BrokerLatencyReporter {
       String messageId,
       Topic.Ack ack,
       Supplier<ProduceMetadata> produceMetadata) {
-    String broker = produceMetadata.get().getBroker().orElse("unknown");
+    ProduceMetadata metadata = produceMetadata.get();
+    String broker = metadata.getBroker().orElse("unknown");
+    String brokerDc = metadata.getDatacenter().orElse("unknown");
 
     if (duration.compareTo(slowResponseThreshold) > 0) {
       logger.debug(
@@ -66,6 +68,6 @@ public class BrokerLatencyReporter {
           broker);
     }
 
-    metricsFacade.broker().recordBrokerLatency(broker, ack, duration);
+    metricsFacade.broker().recordBrokerLatency(broker, brokerDc, ack, duration);
   }
 }

--- a/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/producer/kafka/KafkaMessageSender.java
+++ b/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/producer/kafka/KafkaMessageSender.java
@@ -124,7 +124,7 @@ public class KafkaMessageSender<K, V> {
         return partitionInfo
             .flatMap(partition -> Optional.ofNullable(partition.leader()))
             .map(Node::host)
-            .map(ProduceMetadata::new)
+            .map(host -> new ProduceMetadata(host, datacenter))
             .orElse(ProduceMetadata.empty());
       } catch (InterruptException e) {
         Thread.currentThread().interrupt();

--- a/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/publishing/metadata/ProduceMetadata.java
+++ b/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/publishing/metadata/ProduceMetadata.java
@@ -5,16 +5,26 @@ import java.util.Optional;
 
 public class ProduceMetadata {
   @Nullable private final String broker;
+  @Nullable private final String datacenter;
+
+  public ProduceMetadata(@Nullable String broker, @Nullable String datacenter) {
+    this.broker = broker;
+    this.datacenter = datacenter;
+  }
 
   public ProduceMetadata(@Nullable String broker) {
-    this.broker = broker;
+    this(broker, null);
   }
 
   public Optional<String> getBroker() {
     return Optional.ofNullable(broker);
   }
 
+  public Optional<String> getDatacenter() {
+    return Optional.ofNullable(datacenter);
+  }
+
   public static ProduceMetadata empty() {
-    return new ProduceMetadata(null);
+    return new ProduceMetadata(null, null);
   }
 }

--- a/integration-tests/src/slowIntegrationTest/java/pl/allegro/tech/hermes/integrationtests/BrokerLatencyReportingTest.java
+++ b/integration-tests/src/slowIntegrationTest/java/pl/allegro/tech/hermes/integrationtests/BrokerLatencyReportingTest.java
@@ -71,7 +71,8 @@ public class BrokerLatencyReportingTest {
                               .contains("hermes_frontend_broker_latency_seconds_count")
                               .withLabels(
                                   "ack", "LEADER",
-                                  "broker", "localhost")
+                                  "broker", "localhost",
+                                  "broker_dc", "dc")
                               .withValueGreaterThan(0.0d));
             });
   }

--- a/integration-tests/src/slowIntegrationTest/java/pl/allegro/tech/hermes/integrationtests/RemoteDatacenterProduceFallbackTest.java
+++ b/integration-tests/src/slowIntegrationTest/java/pl/allegro/tech/hermes/integrationtests/RemoteDatacenterProduceFallbackTest.java
@@ -266,14 +266,19 @@ public class RemoteDatacenterProduceFallbackTest {
         .isOk()
         .expectBody(String.class)
         .value(
-            (body) ->
-                assertThatMetrics(body)
-                    .contains("hermes_frontend_topic_published_total")
-                    .withLabels(
-                        "group", topic.getName().getGroupName(),
-                        "topic", topic.getName().getName(),
-                        "storageDc", REMOTE_DC2)
-                    .withValue(1.0));
+            (body) -> {
+              assertThatMetrics(body)
+                  .contains("hermes_frontend_topic_published_total")
+                  .withLabels(
+                      "group", topic.getName().getGroupName(),
+                      "topic", topic.getName().getName(),
+                      "storageDc", REMOTE_DC2)
+                  .withValue(1.0);
+              assertThatMetrics(body)
+                  .contains("hermes_frontend_broker_latency_seconds_count")
+                  .withLabels("ack", "LEADER", "broker_dc", REMOTE_DC2)
+                  .withValueGreaterThan(0.0);
+            });
   }
 
   @Test

--- a/integration-tests/src/slowIntegrationTest/java/pl/allegro/tech/hermes/integrationtests/RemoteDatacenterProduceFallbackTest.java
+++ b/integration-tests/src/slowIntegrationTest/java/pl/allegro/tech/hermes/integrationtests/RemoteDatacenterProduceFallbackTest.java
@@ -20,6 +20,7 @@ import pl.allegro.tech.hermes.api.PublishingChaosPolicy;
 import pl.allegro.tech.hermes.api.PublishingChaosPolicy.ChaosMode;
 import pl.allegro.tech.hermes.api.PublishingChaosPolicy.ChaosPolicy;
 import pl.allegro.tech.hermes.api.Topic;
+import pl.allegro.tech.hermes.frontend.FrontendConfigurationProperties;
 import pl.allegro.tech.hermes.integrationtests.assertions.PrometheusMetricsAssertion;
 import pl.allegro.tech.hermes.integrationtests.setup.HermesConsumersTestApp;
 import pl.allegro.tech.hermes.integrationtests.setup.HermesFrontendTestApp;
@@ -84,6 +85,7 @@ public class RemoteDatacenterProduceFallbackTest {
     management.start();
     frontendDC1 =
         new HermesFrontendTestApp(dc1.hermesZookeeper, kafkaConfiguration, schemaRegistry);
+    frontendDC1.withProperty(FrontendConfigurationProperties.BROKER_LATENCY_REPORTER_ENABLED, true);
     frontendDC1.start();
 
     frontendDC2 =
@@ -274,11 +276,23 @@ public class RemoteDatacenterProduceFallbackTest {
                       "topic", topic.getName().getName(),
                       "storageDc", REMOTE_DC2)
                   .withValue(1.0);
-              assertThatMetrics(body)
-                  .contains("hermes_frontend_broker_latency_seconds_count")
-                  .withLabels("ack", "LEADER", "broker_dc", REMOTE_DC2)
-                  .withValueGreaterThan(0.0);
             });
+
+    // and broker latency metric is eventually emitted by the async reporter
+    await()
+        .atMost(Duration.ofSeconds(5))
+        .untilAsserted(
+            () ->
+                DC1.getFrontendMetrics()
+                    .expectStatus()
+                    .isOk()
+                    .expectBody(String.class)
+                    .value(
+                        (body) ->
+                            assertThatMetrics(body)
+                                .contains("hermes_frontend_broker_latency_seconds_count")
+                                .withLabels("ack", "LEADER", "broker_dc", REMOTE_DC2)
+                                .withValueGreaterThan(0.0)));
   }
 
   @Test


### PR DESCRIPTION
This pull request enhances broker latency metrics by adding support for tracking the datacenter ("broker_dc") associated with each broker. This allows for more granular monitoring and analysis of broker performance across different datacenters. The changes affect metric recording, metadata propagation, and related tests.

**Broker latency metrics improvements:**

* Updated `BrokerMetrics.recordBrokerLatency` to accept and record a new `brokerDc` (datacenter) parameter as a metric tag.
* Modified `BrokerLatencyReporter` to extract the datacenter from `ProduceMetadata` and pass it to the metrics recorder. 

**Produce metadata propagation:**

* Extended `ProduceMetadata` to include a `datacenter` field, updated its constructors, and added a getter. Adjusted `empty()` to include the new field.
* Updated `KafkaMessageSender` to populate the `datacenter` field in `ProduceMetadata` when available.

**Test updates:**

* Adjusted integration tests to expect and validate the new `broker_dc` label in broker latency metrics. 