### PR TITLE
Convert broker latency to non-histogram timer

### DIFF
--- a/docs/docs/deployment/metrics.md
+++ b/docs/docs/deployment/metrics.md
@@ -2,7 +2,7 @@
 
 Hermes gathers a big number of different metrics which are useful when trying to observe the current state of the system.
 
-Latencies are measured as: 50, 75, 95, 99 and 99.9 percentiles.
+Latencies are measured as: 50, 99 and 99.9 percentiles.
 Rates are measured and averaged in a time window. There are 3 time windows measured: 1, 5 and 15 minutes.
 
 ## Frontend

--- a/hermes-common/src/main/java/pl/allegro/tech/hermes/common/metric/BrokerMetrics.java
+++ b/hermes-common/src/main/java/pl/allegro/tech/hermes/common/metric/BrokerMetrics.java
@@ -18,8 +18,6 @@ public class BrokerMetrics {
         .tag("broker", broker)
         .tag("broker_dc", brokerDc)
         .tag("ack", ack.name())
-        .publishPercentileHistogram()
-        .maximumExpectedValue(Duration.ofSeconds(5))
         .register(meterRegistry)
         .record(duration);
   }


### PR DESCRIPTION
This pull request makes a minor adjustment to the way broker latency metrics are recorded. Specifically, it removes the configuration for publishing percentile histograms and the maximum expected value from the metric registration.
This change was introduced due to the huge number of metrics produced for histogram purposes. This will reduce the number of produced broker latency metrics by a factor of ~50x.