### PR TITLE
Ensuring all status codes are metered in hermes-frontend

### DIFF
--- a/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/metric/CachedTopic.java
+++ b/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/metric/CachedTopic.java
@@ -86,7 +86,7 @@ public class CachedTopic {
     return kafkaTopics;
   }
 
-  public StartedTimersPair startProducerLatencyTimers() {
+  public StartedTimersPair startHermesLatencyTimers() {
     return new StartedTimersPair(
         topicProducerLatencyTimer.time(), globalProducerLatencyTimer.time());
   }

--- a/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/publishing/handlers/ExchangeMetrics.java
+++ b/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/publishing/handlers/ExchangeMetrics.java
@@ -13,12 +13,13 @@ class ExchangeMetrics implements ExchangeCompletionListener {
 
   private static final Logger logger = LoggerFactory.getLogger(ExchangeMetrics.class);
 
-  private final StartedTimersPair producerLatencyTimers;
   private final CachedTopic cachedTopic;
+  private final StartedTimersPair producerLatencyTimers;
 
-  ExchangeMetrics(CachedTopic cachedTopic) {
+  ExchangeMetrics(CachedTopic cachedTopic, boolean measureProducerLatency) {
     this.cachedTopic = cachedTopic;
-    producerLatencyTimers = cachedTopic.startProducerLatencyTimers();
+    producerLatencyTimers =
+        measureProducerLatency ? cachedTopic.startProducerLatencyTimers() : null;
   }
 
   @Override
@@ -26,7 +27,9 @@ class ExchangeMetrics implements ExchangeCompletionListener {
     try {
       cachedTopic.markRequestMeter();
       cachedTopic.markStatusCodeMeter(exchange.getStatusCode());
-      producerLatencyTimers.close();
+      if (producerLatencyTimers != null) {
+        producerLatencyTimers.close();
+      }
     } catch (RuntimeException e) {
       logger
           .atError()

--- a/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/publishing/handlers/ExchangeMetrics.java
+++ b/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/publishing/handlers/ExchangeMetrics.java
@@ -14,12 +14,11 @@ class ExchangeMetrics implements ExchangeCompletionListener {
   private static final Logger logger = LoggerFactory.getLogger(ExchangeMetrics.class);
 
   private final CachedTopic cachedTopic;
-  private final StartedTimersPair producerLatencyTimers;
+  private final StartedTimersPair hermesLatencyTimers;
 
-  ExchangeMetrics(CachedTopic cachedTopic, boolean measureProducerLatency) {
+  ExchangeMetrics(CachedTopic cachedTopic) {
     this.cachedTopic = cachedTopic;
-    producerLatencyTimers =
-        measureProducerLatency ? cachedTopic.startProducerLatencyTimers() : null;
+    hermesLatencyTimers = cachedTopic.startHermesLatencyTimers();
   }
 
   @Override
@@ -27,9 +26,7 @@ class ExchangeMetrics implements ExchangeCompletionListener {
     try {
       cachedTopic.markRequestMeter();
       cachedTopic.markStatusCodeMeter(exchange.getStatusCode());
-      if (producerLatencyTimers != null) {
-        producerLatencyTimers.close();
-      }
+      hermesLatencyTimers.close();
     } catch (RuntimeException e) {
       logger
           .atError()

--- a/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/publishing/handlers/TopicHandler.java
+++ b/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/publishing/handlers/TopicHandler.java
@@ -71,10 +71,11 @@ class TopicHandler implements HttpHandler {
     }
 
     CachedTopic cachedTopic = maybeTopic.get();
-    exchange.addExchangeCompleteListener(new ExchangeMetrics(cachedTopic));
-
     Topic topic = cachedTopic.getTopic();
-    if (topic.isAuthEnabled() && !hasPermission(exchange, topic)) {
+    boolean requestAllowed = !topic.isAuthEnabled() || hasPermission(exchange, topic);
+    exchange.addExchangeCompleteListener(new ExchangeMetrics(cachedTopic, requestAllowed));
+
+    if (!requestAllowed) {
       requestForbidden(exchange, messageId, topicName);
       return;
     }

--- a/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/publishing/handlers/TopicHandler.java
+++ b/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/publishing/handlers/TopicHandler.java
@@ -72,10 +72,9 @@ class TopicHandler implements HttpHandler {
 
     CachedTopic cachedTopic = maybeTopic.get();
     Topic topic = cachedTopic.getTopic();
-    boolean requestAllowed = !topic.isAuthEnabled() || hasPermission(exchange, topic);
-    exchange.addExchangeCompleteListener(new ExchangeMetrics(cachedTopic, requestAllowed));
+    exchange.addExchangeCompleteListener(new ExchangeMetrics(cachedTopic));
 
-    if (!requestAllowed) {
+    if (topic.isAuthEnabled() && !hasPermission(exchange, topic)) {
       requestForbidden(exchange, messageId, topicName);
       return;
     }

--- a/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/publishing/handlers/TopicHandler.java
+++ b/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/publishing/handlers/TopicHandler.java
@@ -48,7 +48,6 @@ class TopicHandler implements HttpHandler {
         exchange,
         messageId,
         cachedTopic -> {
-          exchange.addExchangeCompleteListener(new ExchangeMetrics(cachedTopic));
           exchange.putAttachment(
               AttachmentContent.KEY,
               new AttachmentContent(cachedTopic, new MessageState(), messageId));
@@ -72,6 +71,7 @@ class TopicHandler implements HttpHandler {
     }
 
     CachedTopic cachedTopic = maybeTopic.get();
+    exchange.addExchangeCompleteListener(new ExchangeMetrics(cachedTopic));
 
     Topic topic = cachedTopic.getTopic();
     if (topic.isAuthEnabled() && !hasPermission(exchange, topic)) {

--- a/hermes-frontend/src/test/groovy/pl/allegro/tech/hermes/frontend/publishing/handlers/ExchangeMetricsTest.groovy
+++ b/hermes-frontend/src/test/groovy/pl/allegro/tech/hermes/frontend/publishing/handlers/ExchangeMetricsTest.groovy
@@ -1,0 +1,35 @@
+package pl.allegro.tech.hermes.frontend.publishing.handlers
+
+import io.undertow.server.ExchangeCompletionListener
+import io.undertow.server.HttpServerExchange
+import pl.allegro.tech.hermes.common.metric.timer.StartedTimersPair
+import pl.allegro.tech.hermes.frontend.metric.CachedTopic
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class ExchangeMetricsTest extends Specification {
+
+    @Unroll
+    def "should meter status #statusCode and measure Hermes latency"() {
+        given:
+        CachedTopic cachedTopic = Mock()
+        StartedTimersPair timers = Mock()
+        ExchangeCompletionListener.NextListener nextListener = Mock()
+        HttpServerExchange exchange = new HttpServerExchange(null).setStatusCode(statusCode)
+
+        when:
+        ExchangeMetrics metrics = new ExchangeMetrics(cachedTopic)
+        metrics.exchangeEvent(exchange, nextListener)
+
+        then:
+        1 * cachedTopic.startHermesLatencyTimers() >> timers
+        1 * cachedTopic.markRequestMeter()
+        1 * cachedTopic.markStatusCodeMeter(statusCode)
+        1 * timers.close()
+        1 * nextListener.proceed()
+        0 * _
+
+        where:
+        statusCode << [201, 202, 400, 403, 408, 429, 500, 503]
+    }
+}

--- a/hermes-frontend/src/test/groovy/pl/allegro/tech/hermes/frontend/publishing/handlers/TopicHandlerTest.groovy
+++ b/hermes-frontend/src/test/groovy/pl/allegro/tech/hermes/frontend/publishing/handlers/TopicHandlerTest.groovy
@@ -1,0 +1,48 @@
+package pl.allegro.tech.hermes.frontend.publishing.handlers
+
+import io.undertow.server.HttpHandler
+import io.undertow.server.HttpServerExchange
+import pl.allegro.tech.hermes.api.ErrorCode
+import pl.allegro.tech.hermes.api.Topic
+import pl.allegro.tech.hermes.common.metric.timer.StartedTimersPair
+import pl.allegro.tech.hermes.frontend.cache.topic.TopicsCache
+import pl.allegro.tech.hermes.frontend.metric.CachedTopic
+import pl.allegro.tech.hermes.frontend.publishing.handlers.end.MessageErrorProcessor
+import pl.allegro.tech.hermes.test.helper.builder.TopicBuilder
+import spock.lang.Specification
+
+class TopicHandlerTest extends Specification {
+
+    def "should report status and Hermes latency metrics before rejecting unauthorized publisher"() {
+        given:
+        Topic topic = TopicBuilder.topicWithRandomName()
+                .withAuthEnabled()
+                .withUnauthenticatedAccessDisabled()
+                .build()
+        CachedTopic cachedTopic = Mock()
+        StartedTimersPair timers = Mock()
+        TopicsCache topicsCache = Mock()
+        MessageErrorProcessor errorProcessor = Mock()
+        HttpHandler next = Mock()
+        HttpServerExchange exchange = Mock()
+        TopicHandler handler = new TopicHandler(next, topicsCache, errorProcessor)
+
+        when:
+        handler.handleRequest(exchange)
+
+        then:
+        1 * exchange.isInIoThread() >> false
+        1 * exchange.getQueryParameters() >> [qualifiedTopicName: new ArrayDeque([topic.qualifiedName])]
+        1 * topicsCache.getTopic(topic.qualifiedName) >> Optional.of(cachedTopic)
+        1 * cachedTopic.getTopic() >> topic
+        1 * cachedTopic.startHermesLatencyTimers() >> timers
+        1 * exchange.addExchangeCompleteListener(_ as ExchangeMetrics)
+        1 * exchange.getSecurityContext() >> null
+        1 * errorProcessor.sendQuietly(
+                exchange,
+                { it.code == ErrorCode.AUTH_ERROR },
+                _ as String,
+                topic.qualifiedName)
+        0 * next.handleRequest(_)
+    }
+}

--- a/integration-tests/src/common/java/pl/allegro/tech/hermes/integrationtests/assertions/PrometheusMetricsAssertion.java
+++ b/integration-tests/src/common/java/pl/allegro/tech/hermes/integrationtests/assertions/PrometheusMetricsAssertion.java
@@ -9,7 +9,7 @@ import java.util.regex.Pattern;
 public class PrometheusMetricsAssertion {
 
   private static final Pattern METRIC_LINE_PATTERN =
-      Pattern.compile("^[a-z_]+\\{(.*)\\} (\\d+(\\.\\d+)?)$");
+      Pattern.compile("^[a-z_]+\\{(.*)} (\\d+(\\.\\d+)?)$");
 
   private final String actualBody;
 
@@ -32,6 +32,10 @@ public class PrometheusMetricsAssertion {
 
     PrometheusMetricWithNameAssertion(List<String> actualMetrics) {
       this.actualMetrics = actualMetrics;
+    }
+
+    public PrometheusMetricAssertion withLabels(String label0, String value0) {
+      return withLabels(new String[] {label0}, new String[] {value0});
     }
 
     public PrometheusMetricAssertion withLabels(
@@ -81,7 +85,7 @@ public class PrometheusMetricsAssertion {
       assertThat(matchedLines)
           .overridingErrorMessage("Found more than one metric with provided labels")
           .hasSize(1);
-      return new PrometheusMetricAssertion(matchedLines.get(0));
+      return new PrometheusMetricAssertion(matchedLines.getFirst());
     }
 
     private void withoutLabels(String[] names, String[] values) {

--- a/integration-tests/src/integrationTest/java/pl/allegro/tech/hermes/integrationtests/TopicAuthorizationTest.java
+++ b/integration-tests/src/integrationTest/java/pl/allegro/tech/hermes/integrationtests/TopicAuthorizationTest.java
@@ -1,12 +1,12 @@
 package pl.allegro.tech.hermes.integrationtests;
 
 import static org.awaitility.Awaitility.waitAtMost;
-import static pl.allegro.tech.hermes.integrationtests.assertions.HermesAssertions.assertThatMetrics;
 import static pl.allegro.tech.hermes.frontend.FrontendConfigurationProperties.AUTH_PASSWORD;
 import static pl.allegro.tech.hermes.frontend.FrontendConfigurationProperties.AUTH_USERNAME;
 import static pl.allegro.tech.hermes.frontend.FrontendConfigurationProperties.FRONTEND_AUTHENTICATION_ENABLED;
 import static pl.allegro.tech.hermes.frontend.FrontendConfigurationProperties.FRONTEND_AUTHENTICATION_MODE;
 import static pl.allegro.tech.hermes.frontend.FrontendConfigurationProperties.FRONTEND_SSL_ENABLED;
+import static pl.allegro.tech.hermes.integrationtests.assertions.HermesAssertions.assertThatMetrics;
 
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
@@ -210,7 +210,7 @@ public class TopicAuthorizationTest {
                       "group", topic.getName().getGroupName(),
                       "topic", topic.getName().getName(),
                       "status_code", "403")
-                  .withValueGreaterThan(0);
+                  .withValue(1);
               assertThatMetrics(metrics)
                   .contains("hermes_frontend_topic_global_http_status_codes_total")
                   .withLabels("status_code", "403")

--- a/integration-tests/src/integrationTest/java/pl/allegro/tech/hermes/integrationtests/TopicAuthorizationTest.java
+++ b/integration-tests/src/integrationTest/java/pl/allegro/tech/hermes/integrationtests/TopicAuthorizationTest.java
@@ -1,6 +1,7 @@
 package pl.allegro.tech.hermes.integrationtests;
 
 import static org.awaitility.Awaitility.waitAtMost;
+import static pl.allegro.tech.hermes.integrationtests.assertions.HermesAssertions.assertThatMetrics;
 import static pl.allegro.tech.hermes.frontend.FrontendConfigurationProperties.AUTH_PASSWORD;
 import static pl.allegro.tech.hermes.frontend.FrontendConfigurationProperties.AUTH_USERNAME;
 import static pl.allegro.tech.hermes.frontend.FrontendConfigurationProperties.FRONTEND_AUTHENTICATION_ENABLED;
@@ -177,6 +178,55 @@ public class TopicAuthorizationTest {
             .withAuthEnabled()
             .withUnauthenticatedAccessDisabled()
             .build());
+  }
+
+  @ParameterizedTest
+  @MethodSource("notPublishWithoutPermissionWhenAuthenticatedTopics")
+  public void shouldMeterForbiddenPublishingAttempt(Topic topic) {
+    // given
+    hermes.initHelper().createTopic(topic);
+
+    // when
+    waitAtMost(Duration.ofSeconds(10))
+        .untilAsserted(
+            () ->
+                hermes
+                    .api()
+                    .publish(
+                        topic.getQualifiedName(),
+                        MESSAGE,
+                        createAuthorizationHeader(USERNAME, PASSWORD))
+                    .expectStatus()
+                    .isForbidden());
+
+    // then
+    waitAtMost(Duration.ofSeconds(10))
+        .untilAsserted(
+            () -> {
+              String metrics = frontendMetrics();
+              assertThatMetrics(metrics)
+                  .contains("hermes_frontend_topic_http_status_codes_total")
+                  .withLabels(
+                      "group", topic.getName().getGroupName(),
+                      "topic", topic.getName().getName(),
+                      "status_code", "403")
+                  .withValueGreaterThan(0);
+              assertThatMetrics(metrics)
+                  .contains("hermes_frontend_topic_global_http_status_codes_total")
+                  .withLabels("status_code", "403")
+                  .withValueGreaterThan(0);
+            });
+  }
+
+  private String frontendMetrics() {
+    return hermes
+        .api()
+        .getFrontendMetrics()
+        .expectStatus()
+        .isOk()
+        .expectBody(String.class)
+        .returnResult()
+        .getResponseBody();
   }
 
   private static HttpHeaders createAuthorizationHeader(String username, String password) {


### PR DESCRIPTION
Meter 403 publishing attempts for known topics by registering exchange metrics before authorization completes.

This makes forbidden requests visible in topic/global status metrics while preserving Hermes latency measurement. Added coverage for representative success and error status codes, plus the unauthorized publisher path.