### PR TITLE
Fix create constraints form label

### DIFF
--- a/hermes-console/src/views/admin/constraints/create-constraint-form/CreateConstraintFormView.spec.ts
+++ b/hermes-console/src/views/admin/constraints/create-constraint-form/CreateConstraintFormView.spec.ts
@@ -4,6 +4,20 @@ import { waitFor } from '@testing-library/vue';
 import CreateConstraintFormView from '@/views/admin/constraints/create-constraint-form/CreateConstraintFormView.vue';
 
 describe('CreateConstraintForm', () => {
+  it('should render the create label on the submit button', () => {
+    // when
+    const { getByTestId } = render(CreateConstraintFormView, {
+      props: {
+        isSubscription: false,
+      },
+    });
+
+    // then
+    expect(getByTestId('createConstraintSave')).toHaveTextContent(
+      'constraints.createForm.create',
+    );
+  });
+
   it('should emit a cancel event when user clicks cancel button', async () => {
     // given
     const wrapper = renderWithEmits(CreateConstraintFormView, {

--- a/hermes-console/src/views/admin/constraints/create-constraint-form/CreateConstraintFormView.vue
+++ b/hermes-console/src/views/admin/constraints/create-constraint-form/CreateConstraintFormView.vue
@@ -85,7 +85,7 @@
           @click="onCreated"
           data-testid="createConstraintSave"
         >
-          {{ $t('constraints.createForm.save') }}
+          {{ $t('constraints.createForm.create') }}
         </v-btn>
         <v-btn
           color="orange"


### PR DESCRIPTION
Before
<img width="435" height="282" alt="Create constraints for subscription" src="https://github.com/user-attachments/assets/13d501cf-0e32-4f63-9f76-685d32122c19" />

After
<img width="435" height="282" alt="Screenshot 2026-07-21 at 14 36 44" src="https://github.com/user-attachments/assets/f61ace7c-3cd9-4889-ba8b-151f40883aca" />
