### PR TITLE
Add readiness gate for frontend publishing endpoint

### DIFF
--- a/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/server/HermesServer.java
+++ b/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/server/HermesServer.java
@@ -132,10 +132,12 @@ public class HermesServer {
     HttpHandler healthCheckHandler = new HealthCheckHandler(healthCheckService);
     HttpHandler readinessHandler = new ReadinessCheckHandler(readinessChecker, healthCheckService);
     HttpHandler prometheusHandler = new PrometheusMetricsHandler(prometheusMeterRegistry);
+    HttpHandler publishingReadinessHandler =
+        new PublishingReadinessHandler(publishingHandler, readinessChecker, healthCheckService);
 
     RoutingHandler routingHandler =
         new RoutingHandler()
-            .post("/topics/{qualifiedTopicName}", publishingHandler)
+            .post("/topics/{qualifiedTopicName}", publishingReadinessHandler)
             .get("/status/ping", healthCheckHandler)
             .get("/status/health", healthCheckHandler)
             .get("/status/ready", readinessHandler)

--- a/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/server/PublishingReadinessHandler.java
+++ b/hermes-frontend/src/main/java/pl/allegro/tech/hermes/frontend/server/PublishingReadinessHandler.java
@@ -1,0 +1,32 @@
+package pl.allegro.tech.hermes.frontend.server;
+
+import static io.undertow.util.StatusCodes.SERVICE_UNAVAILABLE;
+
+import io.undertow.server.HttpHandler;
+import io.undertow.server.HttpServerExchange;
+import pl.allegro.tech.hermes.frontend.readiness.HealthCheckService;
+import pl.allegro.tech.hermes.frontend.readiness.ReadinessChecker;
+
+public class PublishingReadinessHandler implements HttpHandler {
+
+  private final HttpHandler next;
+  private final ReadinessChecker readinessChecker;
+  private final HealthCheckService healthCheckService;
+
+  public PublishingReadinessHandler(
+      HttpHandler next, ReadinessChecker readinessChecker, HealthCheckService healthCheckService) {
+    this.next = next;
+    this.readinessChecker = readinessChecker;
+    this.healthCheckService = healthCheckService;
+  }
+
+  @Override
+  public void handleRequest(HttpServerExchange exchange) throws Exception {
+    if (!healthCheckService.isShutdown() && readinessChecker.isReady()) {
+      next.handleRequest(exchange);
+    } else {
+      exchange.setStatusCode(SERVICE_UNAVAILABLE);
+      exchange.getResponseSender().send("NOT_READY");
+    }
+  }
+}

--- a/hermes-frontend/src/test/groovy/pl/allegro/tech/hermes/frontend/server/PublishingReadinessHandlerTest.groovy
+++ b/hermes-frontend/src/test/groovy/pl/allegro/tech/hermes/frontend/server/PublishingReadinessHandlerTest.groovy
@@ -1,0 +1,73 @@
+package pl.allegro.tech.hermes.frontend.server
+
+import io.undertow.io.Sender
+import io.undertow.server.HttpHandler
+import io.undertow.server.HttpServerExchange
+import io.undertow.util.StatusCodes
+import pl.allegro.tech.hermes.frontend.readiness.HealthCheckService
+import pl.allegro.tech.hermes.frontend.readiness.ReadinessChecker
+import spock.lang.Specification
+
+class PublishingReadinessHandlerTest extends Specification {
+
+    def "should pass request to next handler when frontend is ready"() {
+        given:
+        HttpHandler next = Mock()
+        ReadinessChecker readinessChecker = Mock()
+        HealthCheckService healthCheckService = Mock()
+        HttpServerExchange exchange = Mock()
+        PublishingReadinessHandler handler = new PublishingReadinessHandler(next, readinessChecker, healthCheckService)
+
+        when:
+        handler.handleRequest(exchange)
+
+        then:
+        1 * healthCheckService.isShutdown() >> false
+        1 * readinessChecker.isReady() >> true
+        1 * next.handleRequest(exchange)
+        0 * exchange.setStatusCode(_)
+        0 * exchange.getResponseSender()
+    }
+
+    def "should reject request when readiness checker is not ready"() {
+        given:
+        HttpHandler next = Mock()
+        ReadinessChecker readinessChecker = Mock()
+        HealthCheckService healthCheckService = Mock()
+        HttpServerExchange exchange = Mock()
+        Sender sender = Mock()
+        PublishingReadinessHandler handler = new PublishingReadinessHandler(next, readinessChecker, healthCheckService)
+
+        when:
+        handler.handleRequest(exchange)
+
+        then:
+        1 * healthCheckService.isShutdown() >> false
+        1 * readinessChecker.isReady() >> false
+        1 * exchange.setStatusCode(StatusCodes.SERVICE_UNAVAILABLE)
+        1 * exchange.getResponseSender() >> sender
+        1 * sender.send("NOT_READY")
+        0 * next.handleRequest(_)
+    }
+
+    def "should reject request when frontend is in shutdown mode"() {
+        given:
+        HttpHandler next = Mock()
+        ReadinessChecker readinessChecker = Mock()
+        HealthCheckService healthCheckService = Mock()
+        HttpServerExchange exchange = Mock()
+        Sender sender = Mock()
+        PublishingReadinessHandler handler = new PublishingReadinessHandler(next, readinessChecker, healthCheckService)
+
+        when:
+        handler.handleRequest(exchange)
+
+        then:
+        1 * healthCheckService.isShutdown() >> true
+        0 * readinessChecker.isReady()
+        1 * exchange.setStatusCode(StatusCodes.SERVICE_UNAVAILABLE)
+        1 * exchange.getResponseSender() >> sender
+        1 * sender.send("NOT_READY")
+        0 * next.handleRequest(_)
+    }
+}

--- a/integration-tests/src/integrationTest/java/pl/allegro/tech/hermes/integrationtests/ReadinessCheckTest.java
+++ b/integration-tests/src/integrationTest/java/pl/allegro/tech/hermes/integrationtests/ReadinessCheckTest.java
@@ -52,23 +52,31 @@ public class ReadinessCheckTest {
   public void shouldRejectPublishingWhenFrontendIsNotReady() {
     Topic topic = hermes.initHelper().createTopic(topicWithRandomName().build());
 
-    hermes.api().setReadiness(DEFAULT_DC_NAME, false).expectStatus().isAccepted();
+    try {
+      hermes.api().setReadiness(DEFAULT_DC_NAME, false).expectStatus().isAccepted();
 
-    waitAtMost(Duration.ofSeconds(5))
-        .untilAsserted(
-            () ->
-                hermes
-                    .api()
-                    .getFrontendReadiness()
-                    .expectStatus()
-                    .isEqualTo(SERVICE_UNAVAILABLE));
+      waitAtMost(Duration.ofSeconds(5))
+          .untilAsserted(
+              () ->
+                  hermes
+                      .api()
+                      .getFrontendReadiness()
+                      .expectStatus()
+                      .isEqualTo(SERVICE_UNAVAILABLE));
 
-    hermes
-        .api()
-        .publish(topic.getQualifiedName(), "message")
-        .expectStatus()
-        .isEqualTo(SERVICE_UNAVAILABLE);
+      hermes
+          .api()
+          .publish(topic.getQualifiedName(), "message")
+          .expectStatus()
+          .isEqualTo(SERVICE_UNAVAILABLE)
+          .expectBody(String.class)
+          .isEqualTo("NOT_READY");
+    } finally {
+      hermes.api().setReadiness(DEFAULT_DC_NAME, true).expectStatus().isAccepted();
 
-    hermes.api().setReadiness(DEFAULT_DC_NAME, true).expectStatus().isAccepted();
+      waitAtMost(Duration.ofSeconds(5))
+          .untilAsserted(
+              () -> hermes.api().getFrontendReadiness().expectStatus().is2xxSuccessful());
+    }
   }
 }

--- a/integration-tests/src/integrationTest/java/pl/allegro/tech/hermes/integrationtests/ReadinessCheckTest.java
+++ b/integration-tests/src/integrationTest/java/pl/allegro/tech/hermes/integrationtests/ReadinessCheckTest.java
@@ -1,11 +1,14 @@
 package pl.allegro.tech.hermes.integrationtests;
 
 import static org.awaitility.Awaitility.waitAtMost;
+import static org.springframework.http.HttpStatus.SERVICE_UNAVAILABLE;
 import static pl.allegro.tech.hermes.infrastructure.dc.DefaultDatacenterNameProvider.DEFAULT_DC_NAME;
+import static pl.allegro.tech.hermes.test.helper.builder.TopicBuilder.topicWithRandomName;
 
 import java.time.Duration;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import pl.allegro.tech.hermes.api.Topic;
 import pl.allegro.tech.hermes.integrationtests.setup.HermesExtension;
 
 public class ReadinessCheckTest {
@@ -43,5 +46,29 @@ public class ReadinessCheckTest {
                     .isOk()
                     .expectBody(String.class)
                     .isEqualTo("READY"));
+  }
+
+  @Test
+  public void shouldRejectPublishingWhenFrontendIsNotReady() {
+    Topic topic = hermes.initHelper().createTopic(topicWithRandomName().build());
+
+    hermes.api().setReadiness(DEFAULT_DC_NAME, false).expectStatus().isAccepted();
+
+    waitAtMost(Duration.ofSeconds(5))
+        .untilAsserted(
+            () ->
+                hermes
+                    .api()
+                    .getFrontendReadiness()
+                    .expectStatus()
+                    .isEqualTo(SERVICE_UNAVAILABLE));
+
+    hermes
+        .api()
+        .publish(topic.getQualifiedName(), "message")
+        .expectStatus()
+        .isEqualTo(SERVICE_UNAVAILABLE);
+
+    hermes.api().setReadiness(DEFAULT_DC_NAME, true).expectStatus().isAccepted();
   }
 }


### PR DESCRIPTION
This pull request introduces a new readiness check for publishing requests to ensure that the frontend only accepts publish operations when it is fully ready and not in shutdown mode. The main changes include adding a `PublishingReadinessHandler` that wraps the publishing endpoint, updating the routing to use this handler, and adding unit and integration tests to verify the new behavior.

**Publishing readiness enforcement:**

* Added a new `PublishingReadinessHandler` that checks both readiness and shutdown status before allowing publishing requests to proceed. If the frontend is not ready or is shutting down, it responds with `503 SERVICE_UNAVAILABLE` and a "NOT_READY" message. 
* Updated the routing in `HermesServer` to wrap the `/topics/{qualifiedTopicName}` publishing endpoint with the new `PublishingReadinessHandler`, ensuring all publish requests are subject to readiness checks.

**Testing:**

* Added unit tests for `PublishingReadinessHandler` to verify correct behavior when the frontend is ready, not ready, or shutting down. 
* Extended integration tests to ensure publishing requests are rejected with `503` when the frontend is not ready, and allowed again when readiness is restored. 

